### PR TITLE
SOLIDOS-250 - Display profile on authorizations

### DIFF
--- a/components/containerTableRow/index.tsx
+++ b/components/containerTableRow/index.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable camelcase */
 import { ReactElement, useContext } from "react";
-import { unstable_fetchLitDatasetWithAcl } from "lit-solid";
 import { makeStyles } from "@material-ui/core/styles";
 import { CircularProgress, TableCell, TableRow } from "@material-ui/core";
 import Link from "next/link";

--- a/components/resourceDetails/__snapshots__/index.test.tsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.tsx.snap
@@ -35,75 +35,20 @@ exports[`Container details renders container details 1`] = `
         className="listItem"
         key="owner"
       >
+        <WithStyles(ForwardRef(Avatar))
+          alt="Test Person"
+          className="makeStyles-avatar-1"
+          src="http://example.com/avatar.png"
+        />
         <WithStyles(ForwardRef(Typography))
           className="detailText"
         >
-          owner
+          Test Person
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))
           className="typeValue detailText"
         >
           Full Control
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-read"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          read
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-write"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          write
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-append"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          append
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-details"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          control
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(ListItem))>
     </WithStyles(ForwardRef(List))>
@@ -121,75 +66,19 @@ exports[`Container details renders container details 1`] = `
         className="listItem"
         key="collaborator"
       >
+        <WithStyles(ForwardRef(Avatar))
+          alt="Test Collaborator"
+          className="makeStyles-avatar-1"
+        />
         <WithStyles(ForwardRef(Typography))
           className="detailText"
         >
-          collaborator
+          Test Collaborator
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))
           className="typeValue detailText"
         >
           Can View
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="collaborator-read"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          read
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="collaborator-write"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          write
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          false
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="collaborator-append"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          append
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          false
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="collaborator-details"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          control
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          false
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(ListItem))>
     </WithStyles(ForwardRef(List))>
@@ -253,75 +142,20 @@ exports[`Container details renders no 3rd party access message 1`] = `
         className="listItem"
         key="owner"
       >
+        <WithStyles(ForwardRef(Avatar))
+          alt="Test Person"
+          className="makeStyles-avatar-1"
+          src="http://example.com/avatar.png"
+        />
         <WithStyles(ForwardRef(Typography))
           className="detailText"
         >
-          owner
+          Test Person
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))
           className="typeValue detailText"
         >
           Full Control
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-read"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          read
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-write"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          write
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-append"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          append
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner-details"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          control
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          true
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(ListItem))>
     </WithStyles(ForwardRef(List))>

--- a/components/resourceDetails/index.test.tsx
+++ b/components/resourceDetails/index.test.tsx
@@ -20,6 +20,11 @@ describe("Container details", () => {
           read: true,
           write: true,
         },
+        profile: {
+          avatar: "http://example.com/avatar.png",
+          nickname: "owner",
+          name: "Test Person",
+        },
       },
       {
         webId: "collaborator",
@@ -29,6 +34,11 @@ describe("Container details", () => {
           control: false,
           read: true,
           write: false,
+        },
+        profile: {
+          avatar: null,
+          nickname: "collaborator",
+          name: "Test Collaborator",
         },
       },
     ];
@@ -67,6 +77,11 @@ describe("Container details", () => {
           control: true,
           read: true,
           write: true,
+        },
+        profile: {
+          avatar: "http://example.com/avatar.png",
+          nickname: "owner",
+          name: "Test Person",
         },
       },
     ];

--- a/components/resourceDetails/index.tsx
+++ b/components/resourceDetails/index.tsx
@@ -1,16 +1,23 @@
-/* eslint-disable camelcase */
 import { ReactElement, useContext } from "react";
-import { Typography, List, ListItem, Divider } from "@material-ui/core";
+import { Typography, List, ListItem, Divider, Avatar } from "@material-ui/core";
 import { ILoggedInSolidSession } from "@inrupt/solid-auth-fetcher/dist/solidSession/ISolidSession";
+import { makeStyles } from "@material-ui/core/styles";
 import UserContext from "../../src/contexts/UserContext";
+import styles from "./styles";
 import {
-  NormalizedPermission,
-  getUserPermissions,
   getThirdPartyPermissions,
+  getUserPermissions,
+  NormalizedPermission,
+  Profile,
 } from "../../src/lit-solid-helpers";
 
-function displayBoolean(bool: boolean): string {
-  return bool ? "true" : "false";
+export function displayName(
+  { nickname, name }: Profile,
+  webId: string
+): string {
+  if (name) return name;
+  if (nickname) return nickname;
+  return webId;
 }
 
 export function displayPermission(
@@ -18,41 +25,24 @@ export function displayPermission(
   classes: Record<string, string>
 ): ReactElement | null {
   if (!permission) return null;
-  const { webId, alias, acl } = permission;
+  const { webId, alias, profile } = permission;
+  const { avatar } = profile;
+  const avatarSrc = avatar || undefined;
 
   return (
-    <>
-      <ListItem key={webId} className={classes.listItem}>
-        <Typography className={classes.detailText}>{webId}</Typography>
-        <Typography className={`${classes.typeValue} ${classes.detailText}`}>
-          {alias}
-        </Typography>
-      </ListItem>
-      <ListItem key={`${webId}-read`} className={classes.listItem}>
-        <Typography className={classes.detailText}>read</Typography>
-        <Typography className={`${classes.typeValue} ${classes.detailText}`}>
-          {displayBoolean(acl.read)}
-        </Typography>
-      </ListItem>
-      <ListItem key={`${webId}-write`} className={classes.listItem}>
-        <Typography className={classes.detailText}>write</Typography>
-        <Typography className={`${classes.typeValue} ${classes.detailText}`}>
-          {displayBoolean(acl.write)}
-        </Typography>
-      </ListItem>
-      <ListItem key={`${webId}-append`} className={classes.listItem}>
-        <Typography className={classes.detailText}>append</Typography>
-        <Typography className={`${classes.typeValue} ${classes.detailText}`}>
-          {displayBoolean(acl.append)}
-        </Typography>
-      </ListItem>
-      <ListItem key={`${webId}-details`} className={classes.listItem}>
-        <Typography className={classes.detailText}>control</Typography>
-        <Typography className={`${classes.typeValue} ${classes.detailText}`}>
-          {displayBoolean(acl.control)}
-        </Typography>
-      </ListItem>
-    </>
+    <ListItem key={webId} className={classes.listItem}>
+      <Avatar
+        className={classes.avatar}
+        alt={displayName(profile, webId)}
+        src={avatarSrc}
+      />
+      <Typography className={classes.detailText}>
+        {displayName(profile, webId)}
+      </Typography>
+      <Typography className={`${classes.typeValue} ${classes.detailText}`}>
+        {alias}
+      </Typography>
+    </ListItem>
   );
 }
 
@@ -89,6 +79,8 @@ function displayThirdPartyPermissions(
   );
 }
 
+const useStyles = makeStyles(styles);
+
 export interface Props {
   iri: string;
   name?: string;
@@ -103,6 +95,10 @@ export default function ResourceDetails({
   permissions,
   classes,
 }: Props): ReactElement {
+  const resourceClasses: Record<string, string> = {
+    ...classes,
+    ...useStyles(),
+  };
   const { session } = useContext(UserContext);
   const { webId } = session as ILoggedInSolidSession;
   const userPermissions = getUserPermissions(webId, permissions);
@@ -110,33 +106,35 @@ export default function ResourceDetails({
 
   return (
     <>
-      <section className={classes.centeredSection}>
+      <section className={resourceClasses.centeredSection}>
         <Typography variant="h3" title={iri}>
           {name}
         </Typography>
       </section>
 
-      <section className={classes.centeredSection}>
+      <section className={resourceClasses.centeredSection}>
         <Typography variant="h5">Details</Typography>
       </section>
 
       <Divider />
 
-      <section className={classes.centeredSection}>
+      <section className={resourceClasses.centeredSection}>
         <Typography variant="h5">My Access</Typography>
-        <List>{displayPermission(userPermissions, classes)}</List>
+        <List>{displayPermission(userPermissions, resourceClasses)}</List>
       </section>
 
-      {displayThirdPartyPermissions(thirdPartyPermissions, classes)}
+      {displayThirdPartyPermissions(thirdPartyPermissions, resourceClasses)}
 
       <Divider />
 
-      <section className={classes.centeredSection}>
+      <section className={resourceClasses.centeredSection}>
         <List>
-          <ListItem className={classes.listItem}>
-            <Typography className={classes.detailText}>Thing Type:</Typography>
+          <ListItem className={resourceClasses.listItem}>
+            <Typography className={resourceClasses.detailText}>
+              Thing Type:
+            </Typography>
             <Typography
-              className={`${classes.typeValue} ${classes.detailText}`}
+              className={`${resourceClasses.typeValue} ${resourceClasses.detailText}`}
             >
               Resource
             </Typography>

--- a/components/resourceDetails/styles.ts
+++ b/components/resourceDetails/styles.ts
@@ -1,0 +1,9 @@
+import { StyleRules } from "@material-ui/core";
+
+const styles: StyleRules = {
+  avatar: {
+    marginRight: "1rem",
+  },
+};
+
+export default styles;

--- a/src/lit-solid-helpers/index.test.ts
+++ b/src/lit-solid-helpers/index.test.ts
@@ -205,7 +205,7 @@ describe("displayPermissions", () => {
 });
 
 describe("normalizePermissions", () => {
-  test("it returns the webId and the human-friendly permission name", () => {
+  test("it returns the webId and the human-friendly permission name", async () => {
     const acl = {
       acl1: { read: true, write: false, control: false, append: false },
       acl2: { read: true, write: true, control: true, append: true },
@@ -213,23 +213,44 @@ describe("normalizePermissions", () => {
       acl4: { read: false, write: false, control: false, append: false },
     };
 
-    const [perms1, perms2, perms3, perms4] = normalizePermissions(acl);
+    const expectedProfile = {
+      avatar: "http://example.com/avatar.png",
+      name: "string",
+      nickname: "string",
+    };
+
+    jest
+      .spyOn(litSolidFns, "fetchLitDataset")
+      .mockImplementation(async () => Promise.resolve());
+    jest.spyOn(litSolidFns, "getThingOne").mockImplementation(() => {});
+    jest
+      .spyOn(litSolidFns, "getStringUnlocalizedOne")
+      .mockImplementation(() => expectedProfile.name);
+    jest
+      .spyOn(litSolidFns, "getIriOne")
+      .mockImplementation(() => expectedProfile.avatar);
+
+    const [perms1, perms2, perms3, perms4] = await normalizePermissions(acl);
 
     expect(perms1.webId).toEqual("acl1");
     expect(perms1.alias).toEqual("Can View");
     expect(perms1.acl).toMatchObject(acl.acl1);
+    expect(perms1.profile).toMatchObject(expectedProfile);
 
     expect(perms2.webId).toEqual("acl2");
     expect(perms2.alias).toEqual("Full Control");
     expect(perms2.acl).toMatchObject(acl.acl2);
+    expect(perms2.profile).toMatchObject(expectedProfile);
 
     expect(perms3.webId).toEqual("acl3");
     expect(perms3.alias).toEqual("Can Edit");
     expect(perms3.acl).toMatchObject(acl.acl3);
+    expect(perms3.profile).toMatchObject(expectedProfile);
 
     expect(perms4.webId).toEqual("acl4");
     expect(perms4.alias).toEqual("No Access");
     expect(perms4.acl).toMatchObject(acl.acl4);
+    expect(perms4.profile).toMatchObject(expectedProfile);
   });
 });
 
@@ -348,7 +369,7 @@ describe("fetchResourceWithAcl", () => {
 });
 
 describe("getUserPermissions", () => {
-  test("it returns the permissions for the given webId", () => {
+  test("it returns the permissions for the given webId", async () => {
     const acl = {
       acl1: { read: true, write: false, control: false, append: false },
       acl2: { read: true, write: true, control: true, append: true },
@@ -356,7 +377,7 @@ describe("getUserPermissions", () => {
       acl4: { read: false, write: false, control: false, append: false },
     };
 
-    const normalizedPermissions = normalizePermissions(acl);
+    const normalizedPermissions = await normalizePermissions(acl);
     const permissions = getUserPermissions("acl1", normalizedPermissions);
 
     expect(permissions.webId).toEqual("acl1");
@@ -366,7 +387,7 @@ describe("getUserPermissions", () => {
 });
 
 describe("getThirdPartyPermissions", () => {
-  test("it returns the permissions that don't belong to the given webId", () => {
+  test("it returns the permissions that don't belong to the given webId", async () => {
     const acl = {
       acl1: { read: true, write: false, control: false, append: false },
       acl2: { read: true, write: true, control: true, append: true },
@@ -374,7 +395,7 @@ describe("getThirdPartyPermissions", () => {
       acl4: { read: false, write: false, control: false, append: false },
     };
 
-    const normalizedPermissions = normalizePermissions(acl);
+    const normalizedPermissions = await normalizePermissions(acl);
     const thirdPartyPermissions = getThirdPartyPermissions(
       "acl1",
       normalizedPermissions


### PR DESCRIPTION
# Display user profile info on permissions
This PR displays the user profile information (avatar, username or name) on the permission details context menu.

![Peek 2020-06-15 16-49](https://user-images.githubusercontent.com/35955/84709795-7c77cc80-af28-11ea-96fd-77e718926d06.gif)


# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
