### PR TITLE
SOLIDOS-253 - Handle file nodes in resource lists

### DIFF
--- a/components/containerTableRow/index.tsx
+++ b/components/containerTableRow/index.tsx
@@ -9,6 +9,7 @@ import {
   NormalizedResource,
   getIriPath,
   fetchResourceWithAcl,
+  fetchFileWithAcl,
 } from "../../src/lit-solid-helpers";
 import styles from "./styles";
 
@@ -20,7 +21,12 @@ export async function fetchResourceDetails(
   iri: string
 ): Promise<ResourceDetails> {
   const name = getIriPath(iri);
-  const resource = await fetchResourceWithAcl(iri);
+  let resource;
+  try {
+    resource = await fetchResourceWithAcl(iri);
+  } catch (e) {
+    resource = await fetchFileWithAcl(iri);
+  }
 
   return {
     ...resource,

--- a/components/details/__snapshots__/index.test.tsx.snap
+++ b/components/details/__snapshots__/index.test.tsx.snap
@@ -13,6 +13,11 @@ exports[`Details when given a container it renders a ContainerDetails component 
   }
   iri="iri"
   name="container"
+  types={
+    Array [
+      "BasicContainer",
+    ]
+  }
 />
 `;
 
@@ -29,6 +34,11 @@ exports[`Details when given a resource it renders a ResourceDetails component 1`
   }
   iri="iri"
   name="container"
+  types={
+    Array [
+      "NotAContainer",
+    ]
+  }
 />
 `;
 

--- a/components/details/index.tsx
+++ b/components/details/index.tsx
@@ -46,6 +46,7 @@ export default function Details({
       name={name}
       permissions={permissions}
       classes={classes}
+      types={types}
     />
   );
 }

--- a/components/resourceDetails/__snapshots__/index.test.tsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Container details renders container details 1`] = `
+exports[`Resource details renders no 3rd party access message 1`] = `
 <Fragment>
   <section
     className="centeredSection"
@@ -9,7 +9,104 @@ exports[`Container details renders container details 1`] = `
       title="iri"
       variant="h3"
     >
-      Container Name
+      Resource Name
+    </WithStyles(ForwardRef(Typography))>
+  </section>
+  <section
+    className="centeredSection"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="h5"
+    >
+      Details
+    </WithStyles(ForwardRef(Typography))>
+  </section>
+  <WithStyles(ForwardRef(Divider)) />
+  <section
+    className="centeredSection"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="h5"
+    >
+      My Access
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(List))>
+      <WithStyles(ForwardRef(ListItem))
+        className="listItem"
+        key="owner"
+      >
+        <WithStyles(ForwardRef(Avatar))
+          alt="Test Person"
+          className="makeStyles-avatar-1"
+          src="http://example.com/avatar.png"
+        />
+        <WithStyles(ForwardRef(Typography))
+          className="detailText"
+        >
+          Test Person
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))
+          className="typeValue detailText"
+        >
+          Full Control
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(ListItem))>
+    </WithStyles(ForwardRef(List))>
+  </section>
+  <section
+    className="centeredSection"
+  >
+    <WithStyles(ForwardRef(Typography))
+      variant="h5"
+    >
+      Sharing
+    </WithStyles(ForwardRef(Typography))>
+    <WithStyles(ForwardRef(List))>
+      <WithStyles(ForwardRef(ListItem))
+        className="listItem"
+      >
+        <WithStyles(ForwardRef(Typography))
+          className="detailText"
+        >
+          No 3rd party access
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(ListItem))>
+    </WithStyles(ForwardRef(List))>
+  </section>
+  <WithStyles(ForwardRef(Divider)) />
+  <section
+    className="centeredSection"
+  >
+    <WithStyles(ForwardRef(List))>
+      <WithStyles(ForwardRef(ListItem))
+        className="listItem"
+      >
+        <WithStyles(ForwardRef(Typography))
+          className="detailText"
+        >
+          Thing Type:
+        </WithStyles(ForwardRef(Typography))>
+        <WithStyles(ForwardRef(Typography))
+          className="typeValue detailText"
+        >
+          Resource
+        </WithStyles(ForwardRef(Typography))>
+      </WithStyles(ForwardRef(ListItem))>
+    </WithStyles(ForwardRef(List))>
+  </section>
+</Fragment>
+`;
+
+exports[`Resource details renders resource details 1`] = `
+<Fragment>
+  <section
+    className="centeredSection"
+  >
+    <WithStyles(ForwardRef(Typography))
+      title="iri"
+      variant="h3"
+    >
+      Resource Name
     </WithStyles(ForwardRef(Typography))>
   </section>
   <section
@@ -79,103 +176,6 @@ exports[`Container details renders container details 1`] = `
           className="typeValue detailText"
         >
           Can View
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-    </WithStyles(ForwardRef(List))>
-  </section>
-  <WithStyles(ForwardRef(Divider)) />
-  <section
-    className="centeredSection"
-  >
-    <WithStyles(ForwardRef(List))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          Thing Type:
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          Resource
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-    </WithStyles(ForwardRef(List))>
-  </section>
-</Fragment>
-`;
-
-exports[`Container details renders no 3rd party access message 1`] = `
-<Fragment>
-  <section
-    className="centeredSection"
-  >
-    <WithStyles(ForwardRef(Typography))
-      title="iri"
-      variant="h3"
-    >
-      Container Name
-    </WithStyles(ForwardRef(Typography))>
-  </section>
-  <section
-    className="centeredSection"
-  >
-    <WithStyles(ForwardRef(Typography))
-      variant="h5"
-    >
-      Details
-    </WithStyles(ForwardRef(Typography))>
-  </section>
-  <WithStyles(ForwardRef(Divider)) />
-  <section
-    className="centeredSection"
-  >
-    <WithStyles(ForwardRef(Typography))
-      variant="h5"
-    >
-      My Access
-    </WithStyles(ForwardRef(Typography))>
-    <WithStyles(ForwardRef(List))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-        key="owner"
-      >
-        <WithStyles(ForwardRef(Avatar))
-          alt="Test Person"
-          className="makeStyles-avatar-1"
-          src="http://example.com/avatar.png"
-        />
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          Test Person
-        </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Typography))
-          className="typeValue detailText"
-        >
-          Full Control
-        </WithStyles(ForwardRef(Typography))>
-      </WithStyles(ForwardRef(ListItem))>
-    </WithStyles(ForwardRef(List))>
-  </section>
-  <section
-    className="centeredSection"
-  >
-    <WithStyles(ForwardRef(Typography))
-      variant="h5"
-    >
-      Sharing
-    </WithStyles(ForwardRef(Typography))>
-    <WithStyles(ForwardRef(List))>
-      <WithStyles(ForwardRef(ListItem))
-        className="listItem"
-      >
-        <WithStyles(ForwardRef(Typography))
-          className="detailText"
-        >
-          No 3rd party access
         </WithStyles(ForwardRef(Typography))>
       </WithStyles(ForwardRef(ListItem))>
     </WithStyles(ForwardRef(List))>

--- a/components/resourceDetails/index.test.tsx
+++ b/components/resourceDetails/index.test.tsx
@@ -2,10 +2,15 @@ import * as ReactFns from "react";
 import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 
-import ResourceDetails from "./index";
+import ResourceDetails, {
+  displayName,
+  displayPermission,
+  displayThirdPartyPermissions,
+  displayType,
+} from "./index";
 
-describe("Container details", () => {
-  test("renders container details", () => {
+describe("Resource details", () => {
+  test("renders resource details", () => {
     jest.spyOn(ReactFns, "useContext").mockImplementation(() => ({
       session: { webId: "owner" },
     }));
@@ -52,8 +57,8 @@ describe("Container details", () => {
 
     const tree = shallow(
       <ResourceDetails
-        name="Container Name"
-        types={["Container"]}
+        name="Resource Name"
+        types={["Resource"]}
         iri="iri"
         classes={classes}
         permissions={permissions}
@@ -95,8 +100,8 @@ describe("Container details", () => {
 
     const tree = shallow(
       <ResourceDetails
-        name="Container Name"
-        types={["Container"]}
+        name="Resource Name"
+        types={["Resource"]}
         iri="iri"
         classes={classes}
         permissions={permissions}
@@ -104,5 +109,45 @@ describe("Container details", () => {
     );
 
     expect(shallowToJson(tree)).toMatchSnapshot();
+  });
+});
+
+describe("displayName", () => {
+  const name = "Test Example";
+  const nickname = "test_example";
+  const webId = "webId";
+
+  test("it returns the webId, if no name or nickname is defined", () => {
+    expect(displayName({ webId })).toEqual("webId");
+  });
+
+  test("it returns the nickname, if no name is defined", () => {
+    expect(displayName({ nickname, webId })).toEqual("test_example");
+  });
+
+  test("it returns the name, if defined", () => {
+    expect(displayName({ name, nickname, webId })).toEqual("Test Example");
+  });
+});
+
+describe("displayPermission", () => {
+  test("it returns null if given no permission", () => {
+    let permission;
+    const classes = {};
+    expect(displayPermission(permission, classes)).toBeNull();
+  });
+});
+
+describe("displayThirdPartyPermissions", () => {
+  test("it returns null if given no permissions", () => {
+    let permissions;
+    const classes = {};
+    expect(displayThirdPartyPermissions(permissions, classes)).toBeNull();
+  });
+});
+
+describe("displayType", () => {
+  test("it returns 'Resource' if no types", () => {
+    expect(displayType([])).toEqual("Resource");
   });
 });

--- a/components/resourceDetails/index.tsx
+++ b/components/resourceDetails/index.tsx
@@ -11,10 +11,7 @@ import {
   Profile,
 } from "../../src/lit-solid-helpers";
 
-export function displayName(
-  { nickname, name }: Profile,
-  webId: string
-): string {
+export function displayName({ nickname, name, webId }: Profile): string {
   if (name) return name;
   if (nickname) return nickname;
   return webId;
@@ -33,11 +30,11 @@ export function displayPermission(
     <ListItem key={webId} className={classes.listItem}>
       <Avatar
         className={classes.avatar}
-        alt={displayName(profile, webId)}
+        alt={displayName(profile)}
         src={avatarSrc}
       />
       <Typography className={classes.detailText}>
-        {displayName(profile, webId)}
+        {displayName(profile)}
       </Typography>
       <Typography className={`${classes.typeValue} ${classes.detailText}`}>
         {alias}
@@ -46,7 +43,7 @@ export function displayPermission(
   );
 }
 
-function displayThirdPartyPermissions(
+export function displayThirdPartyPermissions(
   thirdPartyPermissions: NormalizedPermission[] | null,
   classes: Record<string, string>
 ): ReactElement | null {
@@ -79,6 +76,12 @@ function displayThirdPartyPermissions(
   );
 }
 
+export function displayType(types: string[] | undefined): string {
+  if (!types || types.length === 0) return "Resource";
+  const [type] = types;
+  return type;
+}
+
 const useStyles = makeStyles(styles);
 
 export interface Props {
@@ -94,6 +97,7 @@ export default function ResourceDetails({
   name,
   permissions,
   classes,
+  types,
 }: Props): ReactElement {
   const resourceClasses: Record<string, string> = {
     ...classes,
@@ -136,7 +140,7 @@ export default function ResourceDetails({
             <Typography
               className={`${resourceClasses.typeValue} ${resourceClasses.detailText}`}
             >
-              Resource
+              {displayType(types)}
             </Typography>
           </ListItem>
         </List>


### PR DESCRIPTION
This PR fixes bug https://inrupt.atlassian.net/browse/SOLIDOS-253?atlOrigin=eyJpIjoiMjk3OGYzODlhMTBiNDU3M2IwMjNiMzUwOWE5YmIwNDIiLCJwIjoiaiJ9.

This PR adds a file fetching function with acl to handle files that are not resources. This allows us to display details of the file the same way we do for resources.

![Peek 2020-06-16 16-40](https://user-images.githubusercontent.com/35955/84831181-7f3df480-aff0-11ea-9227-2b9c90012836.gif)

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).