### PR TITLE
Fetch public folder without acl

### DIFF
--- a/components/containerTableRow/index.tsx
+++ b/components/containerTableRow/index.tsx
@@ -6,12 +6,18 @@ import Link from "next/link";
 import Details from "../details";
 import DetailsMenuContext from "../../src/contexts/detailsMenuContext";
 import {
-  NormalizedResource,
-  getIriPath,
-  fetchResourceWithAcl,
   fetchFileWithAcl,
+  fetchResource,
+  fetchResourceWithAcl,
+  getIriPath,
+  NormalizedResource,
+  PUBLIC_PERMISSIONS,
 } from "../../src/lit-solid-helpers";
 import styles from "./styles";
+
+export function isPublic(pathname: string): boolean {
+  return !!pathname.match(/^\/public$/);
+}
 
 interface ResourceDetails extends NormalizedResource {
   name: string | undefined;
@@ -23,7 +29,15 @@ export async function fetchResourceDetails(
   const name = getIriPath(iri);
   let resource;
   try {
-    resource = await fetchResourceWithAcl(iri);
+    if (isPublic(name as string)) {
+      const response = await fetchResource(iri);
+      resource = {
+        ...response,
+        permissions: PUBLIC_PERMISSIONS,
+      };
+    } else {
+      resource = await fetchResourceWithAcl(iri);
+    }
   } catch (e) {
     resource = await fetchFileWithAcl(iri);
   }

--- a/src/lit-solid-helpers/index.ts
+++ b/src/lit-solid-helpers/index.ts
@@ -159,6 +159,20 @@ export interface NormalizedResource {
 }
 
 export const PERMISSIONS: string[] = ["read", "write", "append", "control"];
+export const PUBLIC_PERMISSIONS: NormalizedPermission[] = [
+  {
+    webId: "user",
+    alias: "Full Control",
+    acl: { read: true, write: true, append: true, control: true },
+    profile: { webId: "user" },
+  },
+  {
+    webId: "public",
+    alias: "Can Edit",
+    acl: { read: true, write: true, append: true, control: false },
+    profile: { webId: "public" },
+  },
+];
 
 export function parseStringAcl(acl: string): unstable_AccessModes {
   return PERMISSIONS.reduce((acc, key) => {
@@ -230,6 +244,14 @@ export async function fetchResourceWithAcl(
     permissions,
     ...normalizeDataset(thing, iri),
   };
+}
+
+export async function fetchResource(iri: string): Promise<NormalizedResource> {
+  const resource = await fetchLitDataset(iri);
+  const dataset = resource as LitDataset;
+  const thing = dataset as Thing;
+
+  return normalizeDataset(thing, iri);
 }
 
 export function isUserOrMatch(webId: string, id: string): boolean {


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes a bug where a public resource with no acl definition will fail when trying to fetch the resource with acl, and consequently fetch the resource as a file, which yields different results regarding its details.

This PR adds a `fetchResource` function that replicates `fetchResourceWithAcl` so it can be used conditionally.

Initially this implementation solves the problem by detecting if an iri ends with `/public` and then adding in hard-coded public permissions. This is a stop-gap solution until we find a way to solve it more holistically.

### Before
![Peek 2020-06-17 09-11](https://user-images.githubusercontent.com/35955/84908967-bfe25000-b07a-11ea-96c1-68c9cf291461.gif)
### After
![Peek 2020-06-17 09-12](https://user-images.githubusercontent.com/35955/84909012-ca044e80-b07a-11ea-9714-98de451acc94.gif)


- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
