### PR TITLE
Make sure that ACL check are done for resource, not the ACL resource

### DIFF
--- a/src/lit-solid-helpers/index.test.ts
+++ b/src/lit-solid-helpers/index.test.ts
@@ -934,7 +934,7 @@ describe("savePermissions", () => {
 
     const { error } = await savePermissions({ iri, webId, access });
 
-    expect(error).toEqual("aclDataset does not have accessible ACL");
+    expect(error).toEqual("dataset does not have accessible ACL");
   });
 
   test("it returns an error if the updated ACL is empty", async () => {

--- a/src/lit-solid-helpers/index.ts
+++ b/src/lit-solid-helpers/index.ts
@@ -186,8 +186,8 @@ export async function savePermissions({
 
   if (!aclDataset) return error("aclDataset is empty");
 
-  if (!unstable_hasAccessibleAcl(aclDataset)) {
-    return error("aclDataset does not have accessible ACL");
+  if (!unstable_hasAccessibleAcl(dataset)) {
+    return error("dataset does not have accessible ACL");
   }
 
   const updatedAcl = unstable_setAgentResourceAccess(aclDataset, webId, access);


### PR DESCRIPTION
This PR doesn't a bug issue, I found it while working on another task.

Found a bug that uncovered a divergent behavior in NSS and ESS. Response header from NSS will serve Link rel="acl" for ACL resource to another ACL resource (that shouldn't exist, according to the spec), while ESS will serve Link rel"acl self" and point to the ACL resource itself.

This divergent behavior masked the bug when testing on NSS, which is why we haven't picked it up before.

I haven't written a test that tests this bug, as it really is a NSS bug in my mind. But I've corrected the check, and adjusted the corresponding, existing test.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
