### PR TITLE
Fix inconsistent padding between details/loading

### DIFF
--- a/components/resourceDetails/detailsLoading/styles.ts
+++ b/components/resourceDetails/detailsLoading/styles.ts
@@ -27,7 +27,8 @@ const rules = {
     justifyContent: "center",
   },
   centeredSection: {
-    padding: "1rem",
+    paddingLeft: "1rem",
+    paddingRight: "1rem",
   },
   raw: {
     height: "100%",


### PR DESCRIPTION
This PR fixes a bug with inconsistent padding between the details and loading states of the context menu.