### PR TITLE
Fix/show full path in breadcrumbs

### DIFF
--- a/components/breadcrumbs/__snapshots__/index.test.tsx.snap
+++ b/components/breadcrumbs/__snapshots__/index.test.tsx.snap
@@ -846,7 +846,47 @@ font-display: block;",
         >
           <ul
             className="makeStyles-breadcrumb-1537"
-          />
+          >
+            <Crumb
+              crumb={
+                Object {
+                  "label": "All files",
+                  "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F",
+                }
+              }
+              key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
+            >
+              <li
+                className="makeStyles-breadcrumb__crumb-1541"
+                key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
+              >
+                <i
+                  className="makeStyles-icon-caret-left-1486 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--small-1539"
+                />
+                <Link
+                  as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
+                  href="/resource/[iri]"
+                >
+                  <a
+                    className="makeStyles-breadcrumb__link-1542"
+                    href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    <span
+                      className="makeStyles-breadcrumb__prefix-1543"
+                    >
+                      Back to 
+                    </span>
+                    All files
+                  </a>
+                </Link>
+                <i
+                  className="makeStyles-icon-caret-right-1487 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--large-1540"
+                />
+              </li>
+            </Crumb>
+          </ul>
         </nav>
       </Breadcrumbs>
     </PodLocationProvider>
@@ -1772,6 +1812,45 @@ font-display: block;",
                       Back to 
                     </span>
                     some
+                  </a>
+                </Link>
+                <i
+                  className="makeStyles-icon-caret-right-1487 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--large-1540"
+                />
+              </li>
+            </Crumb>
+            <Crumb
+              crumb={
+                Object {
+                  "label": "location",
+                  "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation",
+                }
+              }
+              key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
+            >
+              <li
+                className="makeStyles-breadcrumb__crumb-1541"
+                key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
+              >
+                <i
+                  className="makeStyles-icon-caret-left-1486 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--small-1539"
+                />
+                <Link
+                  as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
+                  href="/resource/[iri]"
+                >
+                  <a
+                    className="makeStyles-breadcrumb__link-1542"
+                    href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
+                    onClick={[Function]}
+                    onMouseEnter={[Function]}
+                  >
+                    <span
+                      className="makeStyles-breadcrumb__prefix-1543"
+                    >
+                      Back to 
+                    </span>
+                    location
                   </a>
                 </Link>
                 <i

--- a/components/breadcrumbs/index.tsx
+++ b/components/breadcrumbs/index.tsx
@@ -71,7 +71,6 @@ export default function Breadcrumbs(): ReactElement {
   ].concat(
     uriParts.map((part, index) => ({ uri: resourceHref(index), label: part }))
   );
-
   const Crumb = ({ crumb }: CrumbProps): ReactElement => (
     <li key={crumb.uri} className={bem("breadcrumb__crumb")}>
       <i
@@ -98,7 +97,7 @@ export default function Breadcrumbs(): ReactElement {
   return (
     <nav aria-label="Breadcrumbs">
       <ul className={bem("breadcrumb")} ref={breadcrumbsList}>
-        {crumbs.slice(0, crumbs.length - 1).map((crumb) => (
+        {crumbs.map((crumb) => (
           <Crumb crumb={crumb} key={crumb.uri} />
         ))}
       </ul>


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes bug #.

- [ ] I've added a unit test to test for potential regressions of this bug.
**Note on this point**: I believe the breadcrumbs were intentionally excluding the last folder, but I am happy to add a unit test to ensure the last folder is displayed if considered necessary.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description
This PR partially fixes the issue of the full path not being displayed in the breadcrumbs. 
While the full path is not displayed (it is still limited to the last three folders), the current folder is now displayed: 

![image](https://user-images.githubusercontent.com/28412960/90001045-3b363b80-dc91-11ea-922e-c5d84aeb1dde.png)

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
