### PR TITLE
Fix/decode resource names

### DIFF
--- a/src/solidClientHelpers/index.test.ts
+++ b/src/solidClientHelpers/index.test.ts
@@ -423,6 +423,12 @@ describe("getResourceName", () => {
 
     expect(resourceName).toEqual("tictactoe");
   });
+
+  test("it returns the decoded resource name when spaces have been URI encoded", () => {
+    const resourceName = getResourceName("public/notes/Hello%20World.txt");
+
+    expect(resourceName).toEqual("Hello World.txt");
+  });
 });
 
 describe("fetchResourceWithAcl", () => {

--- a/src/solidClientHelpers/index.ts
+++ b/src/solidClientHelpers/index.ts
@@ -149,7 +149,9 @@ export function getResourceName(iri: string): string | undefined {
   if (isContainerIri(pathname)) {
     pathname = pathname.substring(0, pathname.length - 1);
   }
-  return pathname.match(/(?!\/)(?:.(?!\/))+$/)?.toString();
+  const encodedURISegment: string =
+    pathname.match(/(?!\/)(?:.(?!\/))+$/)?.toString() || "";
+  return decodeURI(encodedURISegment);
 }
 
 export function getTypeName(rawType: string): string {


### PR DESCRIPTION
This PR fixes:
- Resource names where being extracted from the URI without decoding, which meant they retained encoded characters ("Hello%20World").
- This PR fixes that by decoding the URI segment before returning the resource name for display (see screenshot below).

![image](https://user-images.githubusercontent.com/28412960/90116443-c973f580-dd55-11ea-860c-132056742719.png)


- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
