### PR TITLE
Fix/change display last crumb

### DIFF
--- a/components/breadcrumbs/__snapshots__/index.test.jsx.snap
+++ b/components/breadcrumbs/__snapshots__/index.test.jsx.snap
@@ -854,35 +854,19 @@ font-display: block;",
                   "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F",
                 }
               }
+              isLink={false}
               key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
             >
               <li
-                className="makeStyles-breadcrumb__crumb-1541"
+                className="makeStyles-breadcrumb__crumb-3085"
                 key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
               >
                 <i
-                  className="makeStyles-icon-caret-left-1486 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--small-1539"
+                  className="makeStyles-icon-caret-left-3030 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--small-3083"
                 />
-                <Link
-                  as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
-                  href="/resource/[iri]"
-                >
-                  <a
-                    className="makeStyles-breadcrumb__link-1542"
-                    href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    <span
-                      className="makeStyles-breadcrumb__prefix-1543"
-                    >
-                      Back to 
-                    </span>
-                    All files
-                  </a>
-                </Link>
+                All files
                 <i
-                  className="makeStyles-icon-caret-right-1487 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--large-1540"
+                  className="makeStyles-icon-caret-right-3031 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--large-3084"
                 />
               </li>
             </Crumb>
@@ -1748,27 +1732,28 @@ font-display: block;",
                   "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F",
                 }
               }
+              isLink={true}
               key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
             >
               <li
-                className="makeStyles-breadcrumb__crumb-1541"
+                className="makeStyles-breadcrumb__crumb-3085"
                 key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
               >
                 <i
-                  className="makeStyles-icon-caret-left-1486 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--small-1539"
+                  className="makeStyles-icon-caret-left-3030 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--small-3083"
                 />
                 <Link
                   as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
                   href="/resource/[iri]"
                 >
                   <a
-                    className="makeStyles-breadcrumb__link-1542"
+                    className="makeStyles-breadcrumb__link-3086"
                     href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2F"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
                     <span
-                      className="makeStyles-breadcrumb__prefix-1543"
+                      className="makeStyles-breadcrumb__prefix-3087"
                     >
                       Back to 
                     </span>
@@ -1776,7 +1761,7 @@ font-display: block;",
                   </a>
                 </Link>
                 <i
-                  className="makeStyles-icon-caret-right-1487 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--large-1540"
+                  className="makeStyles-icon-caret-right-3031 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--large-3084"
                 />
               </li>
             </Crumb>
@@ -1787,27 +1772,28 @@ font-display: block;",
                   "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome",
                 }
               }
+              isLink={true}
               key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
             >
               <li
-                className="makeStyles-breadcrumb__crumb-1541"
+                className="makeStyles-breadcrumb__crumb-3085"
                 key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
               >
                 <i
-                  className="makeStyles-icon-caret-left-1486 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--small-1539"
+                  className="makeStyles-icon-caret-left-3030 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--small-3083"
                 />
                 <Link
                   as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
                   href="/resource/[iri]"
                 >
                   <a
-                    className="makeStyles-breadcrumb__link-1542"
+                    className="makeStyles-breadcrumb__link-3086"
                     href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
                     onClick={[Function]}
                     onMouseEnter={[Function]}
                   >
                     <span
-                      className="makeStyles-breadcrumb__prefix-1543"
+                      className="makeStyles-breadcrumb__prefix-3087"
                     >
                       Back to 
                     </span>
@@ -1815,7 +1801,7 @@ font-display: block;",
                   </a>
                 </Link>
                 <i
-                  className="makeStyles-icon-caret-right-1487 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--large-1540"
+                  className="makeStyles-icon-caret-right-3031 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--large-3084"
                 />
               </li>
             </Crumb>
@@ -1826,35 +1812,19 @@ font-display: block;",
                   "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation",
                 }
               }
+              isLink={false}
               key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
             >
               <li
-                className="makeStyles-breadcrumb__crumb-1541"
+                className="makeStyles-breadcrumb__crumb-3085"
                 key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
               >
                 <i
-                  className="makeStyles-icon-caret-left-1486 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--small-1539"
+                  className="makeStyles-icon-caret-left-3030 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--small-3083"
                 />
-                <Link
-                  as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
-                  href="/resource/[iri]"
-                >
-                  <a
-                    className="makeStyles-breadcrumb__link-1542"
-                    href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
-                    onClick={[Function]}
-                    onMouseEnter={[Function]}
-                  >
-                    <span
-                      className="makeStyles-breadcrumb__prefix-1543"
-                    >
-                      Back to 
-                    </span>
-                    location
-                  </a>
-                </Link>
+                location
                 <i
-                  className="makeStyles-icon-caret-right-1487 makeStyles-breadcrumb__caret-1538 makeStyles-breadcrumb__caret--large-1540"
+                  className="makeStyles-icon-caret-right-3031 makeStyles-breadcrumb__caret-3082 makeStyles-breadcrumb__caret--large-3084"
                 />
               </li>
             </Crumb>

--- a/components/breadcrumbs/crumb/index.jsx
+++ b/components/breadcrumbs/crumb/index.jsx
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { createStyles, makeStyles } from "@material-ui/styles";
+import PropTypes from "prop-types";
+import { useBem } from "@solid/lit-prism-patterns";
+import Link from "next/link";
+import clsx from "clsx";
+import styles from "../styles";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function Crumb({ crumb, isLink }) {
+  const bem = useBem(useStyles());
+  return (
+    <li key={crumb.uri} className={bem("breadcrumb__crumb")}>
+      <i
+        className={clsx(
+          bem("icon-caret-left"),
+          bem("breadcrumb__caret", "small")
+        )}
+      />
+      {isLink ? (
+        <Link href="/resource/[iri]" as={crumb.uri}>
+          <a className={bem("breadcrumb__link")}>
+            <span className={bem("breadcrumb__prefix")}>Back to </span>
+            {crumb.label}
+          </a>
+        </Link>
+      ) : (
+        crumb.label
+      )}
+      <i
+        className={clsx(
+          bem("icon-caret-right"),
+          bem("breadcrumb__caret", "large")
+        )}
+      />
+    </li>
+  );
+}
+
+Crumb.defaultProps = {
+  crumb: {},
+};
+
+Crumb.propTypes = {
+  crumb: PropTypes.shape({ uri: PropTypes.string, label: PropTypes.string }),
+  isLink: PropTypes.bool.isRequired,
+};

--- a/components/breadcrumbs/crumb/index.test.jsx
+++ b/components/breadcrumbs/crumb/index.test.jsx
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { mount } from "enzyme";
+import { WithTheme } from "../../../__testUtils/mountWithTheme";
+import defaultTheme from "../../../src/theme";
+import Crumb from "./index";
+
+describe("Breadcrumbs crumb component", () => {
+  test("Renders last breadcrumb as plain text", () => {
+    const crumbProps = {
+      crumb: {
+        uri: "https://www.mypodbrowser.com/some/location",
+        label: "location",
+      },
+      isLink: false,
+    };
+    const crumb = mount(
+      <WithTheme theme={defaultTheme}>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <Crumb {...crumbProps} />
+      </WithTheme>
+    );
+    expect(crumb.html()).not.toContain("href");
+  });
+
+  test("Renders all crumbs except last one as links", () => {
+    const crumbProps = {
+      crumb: {
+        uri: "https://www.mypodbrowser.com/some",
+        label: "some",
+      },
+      isLink: true,
+    };
+    const crumb = mount(
+      <WithTheme theme={defaultTheme}>
+        {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+        <Crumb {...crumbProps} />
+      </WithTheme>
+    );
+    expect(crumb.html()).toContain("href");
+  });
+});

--- a/components/breadcrumbs/index.jsx
+++ b/components/breadcrumbs/index.jsx
@@ -48,7 +48,7 @@ export default function Breadcrumbs() {
     .substr(baseUri.length)
     .split("/")
     .filter((crumb) => !!crumb);
-  const resourceHref = (index = -1) => {
+  const resourceHref = (index) => {
     return `/resource/${encodeURIComponent(
       baseUri + uriParts.slice(0, index + 1).join("/")
     )}`;

--- a/components/breadcrumbs/index.jsx
+++ b/components/breadcrumbs/index.jsx
@@ -19,33 +19,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { createRef, ReactElement, useContext, useLayoutEffect } from "react";
-import { StyleRules, createStyles, makeStyles } from "@material-ui/styles";
-import { PrismTheme, useBem } from "@solid/lit-prism-patterns";
-import Link from "next/link";
-import clsx from "clsx";
+import { createRef, useContext, useLayoutEffect } from "react";
+import { createStyles, makeStyles } from "@material-ui/styles";
+import { useBem } from "@solid/lit-prism-patterns";
 import PodLocationContext from "../../src/contexts/podLocationContext";
 import Spinner from "../spinner";
 import styles from "./styles";
+import Crumb from "./crumb";
 
-const useStyles = makeStyles<PrismTheme>((theme) =>
-  createStyles(styles(theme) as StyleRules)
-);
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
-interface Crumb {
-  uri: string;
-  label: string;
-}
-
-interface CrumbProps {
-  crumb: Crumb;
-  isLink: boolean;
-}
-
-export default function Breadcrumbs(): ReactElement {
+export default function Breadcrumbs() {
   const bem = useBem(useStyles());
   const podLocation = useContext(PodLocationContext);
-  const breadcrumbsList = createRef<HTMLUListElement>();
+  const breadcrumbsList = createRef();
 
   useLayoutEffect(() => {
     if (!breadcrumbsList.current) {
@@ -57,45 +44,19 @@ export default function Breadcrumbs(): ReactElement {
   if (!podLocation.baseUri) return <Spinner />;
 
   const { baseUri, currentUri } = podLocation;
-  const uriParts: string[] = currentUri
+  const uriParts = currentUri
     .substr(baseUri.length)
     .split("/")
     .filter((crumb) => !!crumb);
-  const resourceHref = (index = -1): string => {
+  const resourceHref = (index = -1) => {
     return `/resource/${encodeURIComponent(
       baseUri + uriParts.slice(0, index + 1).join("/")
     )}`;
   };
-  const crumbs: Array<Crumb> = [
+  const crumbs = [
     { uri: `/resource/${encodeURIComponent(baseUri)}`, label: "All files" },
   ].concat(
     uriParts.map((part, index) => ({ uri: resourceHref(index), label: part }))
-  );
-  const Crumb = ({ crumb, isLink }: CrumbProps): ReactElement => (
-    <li key={crumb.uri} className={bem("breadcrumb__crumb")}>
-      <i
-        className={clsx(
-          bem("icon-caret-left"),
-          bem("breadcrumb__caret", "small")
-        )}
-      />
-      {isLink ? (
-        <Link href="/resource/[iri]" as={crumb.uri}>
-          <a className={bem("breadcrumb__link")}>
-            <span className={bem("breadcrumb__prefix")}>Back to </span>
-            {crumb.label}
-          </a>
-        </Link>
-      ) : (
-        crumb.label
-      )}
-      <i
-        className={clsx(
-          bem("icon-caret-right"),
-          bem("breadcrumb__caret", "large")
-        )}
-      />
-    </li>
   );
 
   return (

--- a/components/breadcrumbs/index.test.jsx
+++ b/components/breadcrumbs/index.test.jsx
@@ -20,7 +20,9 @@
  */
 
 import * as ReactUtils from "react";
-import { mountToJson } from "../../__testUtils/mountWithTheme";
+import { mount } from "enzyme";
+import { mountToJson, WithTheme } from "../../__testUtils/mountWithTheme";
+import defaultTheme from "../../src/theme";
 import { PodLocationProvider } from "../../src/contexts/podLocationContext";
 import Breadcrumbs from "./index";
 
@@ -45,5 +47,36 @@ describe("Breadcrumbs view", () => {
       </PodLocationProvider>
     );
     expect(tree).toMatchSnapshot();
+  });
+
+  test("Renders last breadcrumb as plain text", () => {
+    jest.spyOn(ReactUtils, "useLayoutEffect").mockImplementation(() => {});
+
+    const tree = mount(
+      <WithTheme theme={defaultTheme}>
+        <PodLocationProvider currentUri="https://www.mypodbrowser.com/some/location">
+          <Breadcrumbs />
+        </PodLocationProvider>
+      </WithTheme>
+    );
+    expect(tree.html()).toContain(
+      'href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome'
+    );
+    expect(tree.html()).not.toContain(
+      'href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation'
+    );
+  });
+
+  test("Displays current folder as crumb in breadcrumbs", () => {
+    jest.spyOn(ReactUtils, "useLayoutEffect").mockImplementation(() => {});
+
+    const tree = mount(
+      <WithTheme theme={defaultTheme}>
+        <PodLocationProvider currentUri="https://www.mypodbrowser.com/some/location">
+          <Breadcrumbs />
+        </PodLocationProvider>
+      </WithTheme>
+    );
+    expect(tree.html()).toContain("location");
   });
 });

--- a/components/breadcrumbs/index.tsx
+++ b/components/breadcrumbs/index.tsx
@@ -39,6 +39,7 @@ interface Crumb {
 
 interface CrumbProps {
   crumb: Crumb;
+  isLink: boolean;
 }
 
 export default function Breadcrumbs(): ReactElement {
@@ -50,7 +51,6 @@ export default function Breadcrumbs(): ReactElement {
     if (!breadcrumbsList.current) {
       return;
     }
-
     breadcrumbsList.current.scrollTo(breadcrumbsList.current.scrollWidth, 0);
   });
 
@@ -71,7 +71,7 @@ export default function Breadcrumbs(): ReactElement {
   ].concat(
     uriParts.map((part, index) => ({ uri: resourceHref(index), label: part }))
   );
-  const Crumb = ({ crumb }: CrumbProps): ReactElement => (
+  const Crumb = ({ crumb, isLink }: CrumbProps): ReactElement => (
     <li key={crumb.uri} className={bem("breadcrumb__crumb")}>
       <i
         className={clsx(
@@ -79,12 +79,16 @@ export default function Breadcrumbs(): ReactElement {
           bem("breadcrumb__caret", "small")
         )}
       />
-      <Link href="/resource/[iri]" as={crumb.uri}>
-        <a className={bem("breadcrumb__link")}>
-          <span className={bem("breadcrumb__prefix")}>Back to </span>
-          {crumb.label}
-        </a>
-      </Link>
+      {isLink ? (
+        <Link href="/resource/[iri]" as={crumb.uri}>
+          <a className={bem("breadcrumb__link")}>
+            <span className={bem("breadcrumb__prefix")}>Back to </span>
+            {crumb.label}
+          </a>
+        </Link>
+      ) : (
+        crumb.label
+      )}
       <i
         className={clsx(
           bem("icon-caret-right"),
@@ -97,8 +101,12 @@ export default function Breadcrumbs(): ReactElement {
   return (
     <nav aria-label="Breadcrumbs">
       <ul className={bem("breadcrumb")} ref={breadcrumbsList}>
-        {crumbs.map((crumb) => (
-          <Crumb crumb={crumb} key={crumb.uri} />
+        {crumbs.map((crumb, index) => (
+          <Crumb
+            crumb={crumb}
+            key={crumb.uri}
+            isLink={index !== crumbs.length - 1}
+          />
         ))}
       </ul>
     </nav>


### PR DESCRIPTION
This PR fixes:
  Last breadcrumb (current folder name) is now displayed as plain txt rather than a link
   - Refactored Breadcrumbs component to `.jsx`
   - Added tests to Breadcrumbs and new Crumb component file
   - Removed unnecessary untested default value for an index 

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).