### PR TITLE
Feat/overwrite confirmation

### DIFF
--- a/components/addFileButton/__snapshots__/index.test.jsx.snap
+++ b/components/addFileButton/__snapshots__/index.test.jsx.snap
@@ -100,6 +100,7 @@ exports[`AddFileButton Renders an add file button 1`] = `
                 Upload File
                 <input
                   onChange={[Function]}
+                  onClick={[Function]}
                   style={
                     Object {
                       "display": "none",

--- a/components/addFileButton/__snapshots__/index.test.jsx.snap
+++ b/components/addFileButton/__snapshots__/index.test.jsx.snap
@@ -2,10 +2,10 @@
 
 exports[`AddFileButton Renders an add file button 1`] = `
 <PodLocationProvider
-  currentUri="https://www.mypodbrowser.com"
+  currentUri="https://www.mypodbrowser.com/"
 >
   <AddFileButton
-    onSave={[Function]}
+    onSave={[MockFunction]}
   >
     <WithStyles(ForwardRef(Button))
       color="primary"

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -19,48 +19,174 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { useContext, useState } from "react";
+import { useContext, useState, useEffect } from "react";
 import T from "prop-types";
-import { saveFileInContainer } from "@inrupt/solid-client";
+import { overwriteFile, fetchResourceInfoWithAcl } from "@inrupt/solid-client";
 import { Button } from "@material-ui/core";
-import PodLocationContext from "../../src/contexts/podLocationContext";
 import SessionContext from "../../src/contexts/sessionContext";
+import PodLocationContext from "../../src/contexts/podLocationContext";
 import AlertContext from "../../src/contexts/alertContext";
+import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
 
-export default function AddFileButton({ onSave }) {
-  const { currentUri } = useContext(PodLocationContext);
-  const { session } = useContext(SessionContext);
-  const [isUploading, setIsUploading] = useState(false);
-  const { setMessage, setSeverity, setAlertOpen } = useContext(AlertContext);
+export function handleSaveResource({
+  fetch,
+  currentUri,
+  onSave,
+  setIsUploading,
+  setAlertOpen,
+  setMessage,
+  setSeverity,
+}) {
+  return async (uploadedFile) => {
+    try {
+      const response = await overwriteFile(
+        `${currentUri + uploadedFile.name}`,
+        uploadedFile,
+        { type: uploadedFile.type, fetch }
+      );
 
-  const onFileSelect = async (e) => {
-    if (e.target.files.length) {
-      setIsUploading(true);
+      onSave();
 
-      const [file] = e.target.files;
-
-      try {
-        const response = await saveFileInContainer(currentUri, file, {
-          fetch: session.fetch,
-          slug: file.name,
-        });
-
-        onSave();
-
-        setSeverity("success");
-        setMessage(
-          `Your file has been saved to ${response.internal_resourceInfo.sourceIri}`
-        );
-        setAlertOpen(true);
-      } catch (error) {
-        setSeverity("error");
-        setMessage(error.toString());
-        setAlertOpen(true);
-      } finally {
-        setIsUploading(false);
-      }
+      setSeverity("success");
+      setMessage(
+        `Your file has been saved to ${response.internal_resourceInfo.sourceIri}`
+      );
+      setAlertOpen(true);
+    } catch (error) {
+      setSeverity("error");
+      setMessage(error.toString());
+      setAlertOpen(true);
+    } finally {
+      setIsUploading(false);
     }
   };
+}
+
+export async function findExistingFile(path, filename) {
+  try {
+    const existingFile = await fetchResourceInfoWithAcl(`${path}/${filename}`);
+    return existingFile;
+  } catch (err) {
+    return null;
+  }
+}
+
+export function handleUploadedFile({
+  setOpen,
+  setTitle,
+  setContent,
+  setConfirmationSetup,
+  setIsUploading,
+  saveResource,
+}) {
+  return (uploadedFile, existingFile) => {
+    if (existingFile) {
+      setOpen(true);
+      setTitle(`File ${uploadedFile.name} already exists`);
+      setContent(<p>Do you want to replace it?</p>);
+      setConfirmationSetup(true);
+      setIsUploading(false);
+    } else {
+      saveResource(uploadedFile);
+      setIsUploading(false);
+    }
+  };
+}
+
+export function handleFileSelect({
+  currentUri,
+  setIsUploading,
+  setFile,
+  findFile,
+  saveUploadedFile,
+  setSeverity,
+  setMessage,
+  setAlertOpen,
+}) {
+  return async (e) => {
+    try {
+      if (e.target.files.length) {
+        setIsUploading(true);
+        const [uploadedFile] = e.target.files;
+        setFile(uploadedFile);
+        const existingFile = await findFile(currentUri, uploadedFile.name);
+        saveUploadedFile(uploadedFile, existingFile);
+      }
+    } catch (error) {
+      setSeverity("error");
+      setMessage(error.toString());
+      setAlertOpen(true);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+}
+
+export function handleConfirmation({ setOpen, setConfirmed, saveResource }) {
+  return (confirmationSetup, confirmed, file) => {
+    if (confirmationSetup && !confirmed) return;
+
+    if (confirmed) {
+      setOpen(false);
+      setConfirmed(false);
+      saveResource(file);
+    }
+  };
+}
+
+export default function AddFileButton({ onSave }) {
+  const { session } = useContext(SessionContext);
+  const { fetch } = session;
+  const { currentUri } = useContext(PodLocationContext);
+  const [isUploading, setIsUploading] = useState(false);
+  const { setMessage, setSeverity, setAlertOpen } = useContext(AlertContext);
+  const { confirmed, setConfirmed, setContent, setOpen, setTitle } = useContext(
+    ConfirmationDialogContext
+  );
+  const [confirmationSetup, setConfirmationSetup] = useState(false);
+  const [file, setFile] = useState(null);
+  const findFile = findExistingFile;
+
+  const saveResource = handleSaveResource({
+    fetch,
+    currentUri,
+    onSave,
+    setIsUploading,
+    setAlertOpen,
+    setMessage,
+    setSeverity,
+  });
+
+  const saveUploadedFile = handleUploadedFile({
+    setOpen,
+    setTitle,
+    setContent,
+    setConfirmationSetup,
+    setIsUploading,
+    saveResource,
+  });
+
+  const onFileSelect = handleFileSelect({
+    currentUri,
+    setIsUploading,
+    setFile,
+    findFile,
+    saveUploadedFile,
+    saveResource,
+    setSeverity,
+    setMessage,
+    setAlertOpen,
+  });
+
+  const onConfirmation = handleConfirmation({
+    setOpen,
+    setConfirmed,
+    saveResource,
+  });
+
+  useEffect(() => {
+    onConfirmation(confirmationSetup, confirmed, file);
+  }, [confirmationSetup, confirmed, onConfirmation, file]);
 
   return (
     <Button
@@ -71,7 +197,14 @@ export default function AddFileButton({ onSave }) {
       disabled={isUploading}
     >
       {isUploading ? "Uploading..." : "Upload File"}
-      <input type="file" style={{ display: "none" }} onChange={onFileSelect} />
+      <input
+        type="file"
+        style={{ display: "none" }}
+        onClick={(e) => {
+          e.target.value = null;
+        }}
+        onChange={onFileSelect}
+      />
     </Button>
   );
 }

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -72,7 +72,7 @@ export function handleFetchError({ setSeverity, setMessage, setAlertOpen }) {
 
 export async function findExistingFile(path, filename, onFetchError) {
   try {
-    return await fetchResourceInfoWithAcl(`${path}/${filename}`);
+    return await fetchResourceInfoWithAcl(path + filename);
   } catch (error) {
     // The error object should include a status code, in the meantime we are extracting the error type from the message string
     if (error.message.includes("404")) {

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -38,11 +38,15 @@ export function handleSaveResource({
   setSeverity,
 }) {
   return async (uploadedFile) => {
+    const fileName = encodeURIComponent(uploadedFile.name);
     try {
       const response = await overwriteFile(
-        currentUri + uploadedFile.name,
+        currentUri + fileName,
         uploadedFile,
-        { type: uploadedFile.type, fetch }
+        {
+          type: uploadedFile.type,
+          fetch,
+        }
       );
 
       onSave();

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -38,10 +38,9 @@ export function handleSaveResource({
   setSeverity,
 }) {
   return async (uploadedFile) => {
-    const fileName = encodeURIComponent(uploadedFile.name);
     try {
       const response = await overwriteFile(
-        currentUri + fileName,
+        currentUri + encodeURIComponent(uploadedFile.name),
         uploadedFile,
         {
           type: uploadedFile.type,
@@ -53,7 +52,9 @@ export function handleSaveResource({
 
       setSeverity("success");
       setMessage(
-        `Your file has been saved to ${response.internal_resourceInfo.sourceIri}`
+        `Your file has been saved to ${decodeURIComponent(
+          response.internal_resourceInfo.sourceIri
+        )}`
       );
       setAlertOpen(true);
     } catch (error) {
@@ -142,13 +143,19 @@ export function handleFileSelect({
   };
 }
 
-export function handleConfirmation({ setOpen, setConfirmed, saveResource }) {
+export function handleConfirmation({
+  setOpen,
+  setConfirmed,
+  saveResource,
+  setConfirmationSetup,
+}) {
   return (confirmationSetup, confirmed, file) => {
     if (confirmationSetup && !confirmed) return;
 
-    if (confirmed) {
+    if (confirmationSetup && confirmed) {
       setOpen(false);
       setConfirmed(false);
+      setConfirmationSetup(false);
       saveResource(file);
     }
   };
@@ -209,6 +216,7 @@ export default function AddFileButton({ onSave }) {
     setOpen,
     setConfirmed,
     saveResource,
+    setConfirmationSetup,
   });
 
   useEffect(() => {

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -67,9 +67,9 @@ export function handleSaveResource({
   };
 }
 
-export async function findExistingFile(path, filename) {
+export async function findExistingFile(path, filename, options) {
   try {
-    return await fetchResourceInfoWithAcl(path + filename);
+    return await fetchResourceInfoWithAcl(path + filename, options);
   } catch (error) {
     // The error object should include a status code, in the meantime we are extracting the error type from the message string
     if (error.message.includes("404")) {
@@ -102,6 +102,7 @@ export function handleUploadedFile({
 }
 
 export function handleFileSelect({
+  fetch,
   currentUri,
   setIsUploading,
   setFile,
@@ -118,7 +119,9 @@ export function handleFileSelect({
         const [uploadedFile] = e.target.files;
         setFile(uploadedFile);
         try {
-          const existingFile = await findFile(currentUri, uploadedFile.name);
+          const existingFile = await findFile(currentUri, uploadedFile.name, {
+            fetch,
+          });
           saveUploadedFile(uploadedFile, existingFile);
         } catch (error) {
           setSeverity("error");
@@ -187,6 +190,7 @@ export default function AddFileButton({ onSave }) {
   });
 
   const onFileSelect = handleFileSelect({
+    fetch,
     currentUri,
     setIsUploading,
     setFile,

--- a/components/addFileButton/index.test.jsx
+++ b/components/addFileButton/index.test.jsx
@@ -269,4 +269,3 @@ describe("handleConfirmation", () => {
     expect(setConfirmed).not.toHaveBeenCalled();
   });
 });
-

--- a/components/addFileButton/index.test.jsx
+++ b/components/addFileButton/index.test.jsx
@@ -33,7 +33,6 @@ import AddFileButton, {
   findExistingFile,
   handleUploadedFile,
   handleConfirmation,
-  handleFetchError,
 } from "./index";
 
 jest.mock("@inrupt/solid-client");
@@ -152,7 +151,6 @@ describe("handleFileSelect", () => {
   const setSeverity = jest.fn();
   const setMessage = jest.fn();
   const setAlertOpen = jest.fn();
-  const onFetchError = jest.fn();
 
   const handler = handleFileSelect({
     currentUri,
@@ -163,7 +161,6 @@ describe("handleFileSelect", () => {
     setSeverity,
     setMessage,
     setAlertOpen,
-    onFetchError,
   });
   test("it returns a handler that uploads a file", async () => {
     await handler({ target: { files: [file] } });
@@ -231,13 +228,9 @@ describe("findExistingFile", () => {
 
     const currentUri = "https://www.mypodbrowser.com/";
 
-    const onFetchError = jest.fn();
-
-    return findExistingFile(currentUri, file.name, onFetchError).catch(
-      (error) => {
-        expect(error).toMatch("error");
-      }
-    );
+    return findExistingFile(currentUri, file.name).catch((error) => {
+      expect(error).toMatch("error");
+    });
   });
 });
 
@@ -277,22 +270,3 @@ describe("handleConfirmation", () => {
   });
 });
 
-describe("handleFetchError", () => {
-  test("it returns a handler that sets the severity, message and alert of error", async () => {
-    const setSeverity = jest.fn();
-    const setMessage = jest.fn();
-    const setAlertOpen = jest.fn();
-
-    const handler = handleFetchError({
-      setSeverity,
-      setMessage,
-      setAlertOpen,
-    });
-
-    await handler("error");
-
-    expect(setSeverity).toHaveBeenCalled();
-    expect(setMessage).toHaveBeenCalled();
-    expect(setAlertOpen).toHaveBeenCalled();
-  });
-});

--- a/components/addFileButton/index.test.jsx
+++ b/components/addFileButton/index.test.jsx
@@ -252,11 +252,13 @@ describe("handleConfirmation", () => {
   const setOpen = jest.fn();
   const saveResource = jest.fn();
   const setConfirmed = jest.fn();
+  const setConfirmationSetup = jest.fn();
 
   const handler = handleConfirmation({
     setOpen,
     setConfirmed,
     saveResource,
+    setConfirmationSetup,
   });
 
   test("it returns a handler that saves the file when user confirms dialog", async () => {
@@ -265,6 +267,7 @@ describe("handleConfirmation", () => {
     expect(setOpen).toHaveBeenCalled();
     expect(saveResource).toHaveBeenCalled();
     expect(setConfirmed).toHaveBeenCalled();
+    expect(setConfirmationSetup).toHaveBeenCalled();
   });
   test("it returns a handler that exits when user cancels the operation", async () => {
     await handler(true, false, file);

--- a/components/container/__snapshots__/index.test.tsx.snap
+++ b/components/container/__snapshots__/index.test.tsx.snap
@@ -2355,6 +2355,7 @@ font-display: block;",
                                       Upload File
                                       <input
                                         onChange={[Function]}
+                                        onClick={[Function]}
                                         style={
                                           Object {
                                             "display": "none",
@@ -4832,6 +4833,7 @@ font-display: block;",
                                       Upload File
                                       <input
                                         onChange={[Function]}
+                                        onClick={[Function]}
                                         style={
                                           Object {
                                             "display": "none",

--- a/components/containerToolbar/__snapshots__/index.test.tsx.snap
+++ b/components/containerToolbar/__snapshots__/index.test.tsx.snap
@@ -1355,6 +1355,7 @@ font-display: block;",
                                 Upload File
                                 <input
                                   onChange={[Function]}
+                                  onClick={[Function]}
                                   style={
                                     Object {
                                       "display": "none",

--- a/components/resourceDetails/deleteLink/index.jsx
+++ b/components/resourceDetails/deleteLink/index.jsx
@@ -37,10 +37,12 @@ export function handleConfirmation({
     if (confirmationSetup && !confirmed) return;
 
     setTitle("Confirm Delete");
-    setContent(<p>{`Are you sure you wish to delete ${name}?`}</p>);
+    setContent(
+      <p>{`Are you sure you wish to delete ${decodeURIComponent(name)}?`}</p>
+    );
     setConfirmationSetup(true);
 
-    if (confirmed) {
+    if (confirmationSetup && confirmed) {
       setOpen(false);
       setConfirmed(false);
       deleteResource();
@@ -63,7 +65,7 @@ export function handleDeleteResource({
       await deleteFile(resourceIri, { fetch });
       onDelete();
       setSeverity("success");
-      setMessage(`${name} was successfully deleted.`);
+      setMessage(`${decodeURIComponent(name)} was successfully deleted.`);
       setAlertOpen(true);
     } catch (err) {
       onDeleteError(err);

--- a/components/resourceDetails/deleteLink/index.jsx
+++ b/components/resourceDetails/deleteLink/index.jsx
@@ -25,6 +25,29 @@ import SessionContext from "../../../src/contexts/sessionContext";
 import AlertContext from "../../../src/contexts/alertContext";
 import ConfirmationDialogContext from "../../../src/contexts/confirmationDialogContext";
 
+export function handleConfirmation({
+  setOpen,
+  setConfirmed,
+  deleteResource,
+  setTitle,
+  setContent,
+  setConfirmationSetup,
+}) {
+  return (confirmationSetup, confirmed, name) => {
+    if (confirmationSetup && !confirmed) return;
+
+    setTitle("Confirm Delete");
+    setContent(<p>{`Are you sure you wish to delete ${name}?`}</p>);
+    setConfirmationSetup(true);
+
+    if (confirmed) {
+      setOpen(false);
+      setConfirmed(false);
+      deleteResource();
+    }
+  };
+}
+
 export function handleDeleteResource({
   fetch,
   name,
@@ -75,29 +98,18 @@ export default React.forwardRef(
       setSeverity,
     });
 
-    useEffect(() => {
-      if (confirmationSetup && !confirmed) return;
-
-      setTitle("Confirm Delete");
-      setContent(<p>{`Are you sure you wish to delete ${name}?`}</p>);
-      setConfirmationSetup(true);
-
-      if (confirmed) {
-        setOpen(false);
-        setConfirmed(false);
-        deleteResource();
-      }
-    }, [
-      confirmationSetup,
-      confirmed,
-      deleteResource,
-      name,
-      setConfirmationSetup,
-      setConfirmed,
-      setContent,
+    const onConfirmation = handleConfirmation({
       setOpen,
+      setConfirmed,
+      deleteResource,
       setTitle,
-    ]);
+      setContent,
+      setConfirmationSetup,
+    });
+
+    useEffect(() => {
+      onConfirmation(confirmationSetup, confirmed, name);
+    }, [confirmationSetup, confirmed, onConfirmation, name]);
 
     /* eslint jsx-a11y/anchor-has-content: 0 */
     return (

--- a/components/resourceDetails/deleteLink/index.test.jsx
+++ b/components/resourceDetails/deleteLink/index.test.jsx
@@ -23,7 +23,7 @@ import { shallow } from "enzyme";
 import { shallowToJson } from "enzyme-to-json";
 import { deleteFile } from "@inrupt/solid-client";
 
-import DeleteLink, { handleDeleteResource } from "./index";
+import DeleteLink, { handleDeleteResource, handleConfirmation } from "./index";
 
 jest.mock("@inrupt/solid-client");
 
@@ -149,5 +149,40 @@ describe("handleDeleteResource", () => {
     await handler();
 
     expect(onDeleteError).toHaveBeenCalledWith(error);
+  });
+});
+describe("handleConfirmation", () => {
+  const name = "someFile.txt";
+  const setOpen = jest.fn();
+  const deleteResource = jest.fn();
+  const setConfirmed = jest.fn();
+  const setTitle = jest.fn();
+  const setContent = jest.fn();
+  const setConfirmationSetup = jest.fn();
+
+  const handler = handleConfirmation({
+    setOpen,
+    setConfirmed,
+    deleteResource,
+    setTitle,
+    setContent,
+    setConfirmationSetup,
+  });
+
+  test("it returns a handler that deletes the file when user confirms dialog", async () => {
+    await handler(true, true, name);
+
+    expect(setOpen).toHaveBeenCalled();
+    expect(deleteResource).toHaveBeenCalled();
+    expect(setConfirmed).toHaveBeenCalled();
+    expect(setTitle).toHaveBeenCalled();
+    expect(setContent).toHaveBeenCalled();
+    expect(setConfirmationSetup).toHaveBeenCalled();
+  });
+  test("it returns a handler that exits when user cancels the operation", async () => {
+    await handler(true, false, name);
+
+    expect(deleteResource).not.toHaveBeenCalled();
+    expect(setConfirmed).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# Display confirmation dialog when trying to overwrite a file
- Reused the `confirmationDialog` component
- Upon uploading a file, the `addFileButton` component now checks that the file already exists by trying to fetch its info (`fetchResourceInfoWithAcl` - TODO: change to `fetchResourceInfo`)

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

Note: this PR is a work in progress. Due to authentication errors I can throughly test it works and would like to get feedback and help with the authentication errors before attempting to merge this.