### PR TITLE
Fix: authentication errors 

### DIFF
--- a/components/addFileButton/__snapshots__/index.test.jsx.snap
+++ b/components/addFileButton/__snapshots__/index.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`AddFileButton Renders an add file button 1`] = `
   <AddFileButton
     className={[Function]}
     onSave={[MockFunction]}
+    resourceList={Array []}
   >
     <label
       className={[Function]}

--- a/components/addFileButton/index.test.jsx
+++ b/components/addFileButton/index.test.jsx
@@ -30,7 +30,6 @@ import AlertContext from "../../src/contexts/alertContext";
 import AddFileButton, {
   handleSaveResource,
   handleFileSelect,
-  findExistingFile,
   handleUploadedFile,
   handleConfirmation,
 } from "./index";
@@ -146,28 +145,30 @@ describe("handleFileSelect", () => {
 
   const setIsUploading = jest.fn();
   const setFile = jest.fn();
-  const findFile = jest.fn();
   const saveUploadedFile = jest.fn();
   const setSeverity = jest.fn();
   const setMessage = jest.fn();
   const setAlertOpen = jest.fn();
+  const resourceList = [
+    { iri: "https://www.mypodbrowser.com/", name: "somefile.pdf" },
+  ];
 
   const handler = handleFileSelect({
     currentUri,
     setIsUploading,
     setFile,
-    findFile,
     saveUploadedFile,
     setSeverity,
     setMessage,
     setAlertOpen,
+    resourceList,
   });
+
   test("it returns a handler that uploads a file", async () => {
     await handler({ target: { files: [file] } });
 
     expect(setIsUploading).toHaveBeenCalled();
     expect(setFile).toHaveBeenCalled();
-    expect(findFile).toHaveBeenCalled();
     expect(saveUploadedFile).toHaveBeenCalled();
   });
 
@@ -181,7 +182,7 @@ describe("handleFileSelect", () => {
 });
 
 describe("handleUploadedFile", () => {
-  test("it returns a handler that triggers the confirmation logic in case the file already exists", async () => {
+  test("it returns a handler that triggers the confirmation logic in case the file already exists", () => {
     const fileContents = "file contents";
 
     const file = new Blob([fileContents], {
@@ -207,30 +208,13 @@ describe("handleUploadedFile", () => {
       saveResource,
     });
 
-    await handler(file, existingFile);
+    handler(file, existingFile);
 
     expect(setIsUploading).toHaveBeenCalled();
     expect(setOpen).toHaveBeenCalled();
     expect(setContent).toHaveBeenCalled();
     expect(setTitle).toHaveBeenCalled();
     expect(setConfirmationSetup).toHaveBeenCalled();
-  });
-});
-
-describe("findExistingFile", () => {
-  test("it tries to find a file and returns the file or throws an error and returns null if the file does not exist", async () => {
-    const fileContents = "file contents";
-
-    const file = new Blob([fileContents], {
-      type: "text/plain",
-      name: "myfile.txt",
-    });
-
-    const currentUri = "https://www.mypodbrowser.com/";
-
-    return findExistingFile(currentUri, file.name).catch((error) => {
-      expect(error).toMatch("error");
-    });
   });
 });
 
@@ -254,16 +238,16 @@ describe("handleConfirmation", () => {
     setConfirmationSetup,
   });
 
-  test("it returns a handler that saves the file when user confirms dialog", async () => {
-    await handler(true, true, file);
+  test("it returns a handler that saves the file when user confirms dialog", () => {
+    handler(true, true, file);
 
     expect(setOpen).toHaveBeenCalled();
     expect(saveResource).toHaveBeenCalled();
     expect(setConfirmed).toHaveBeenCalled();
     expect(setConfirmationSetup).toHaveBeenCalled();
   });
-  test("it returns a handler that exits when user cancels the operation", async () => {
-    await handler(true, false, file);
+  test("it returns a handler that exits when user cancels the operation", () => {
+    handler(true, false, file);
 
     expect(saveResource).not.toHaveBeenCalled();
     expect(setConfirmed).not.toHaveBeenCalled();

--- a/components/container/__snapshots__/index.test.tsx.snap
+++ b/components/container/__snapshots__/index.test.tsx.snap
@@ -1781,6 +1781,7 @@ font-display: block;",
                 <AddFileButton
                   className="PodBrowser-page-header__action"
                   onSave={[Function]}
+                  resourceList={Array []}
                 />,
               ]
             }
@@ -1908,6 +1909,7 @@ font-display: block;",
                 <AddFileButton
                   className="PodBrowser-page-header__action"
                   onSave={[Function]}
+                  resourceList={Array []}
                 >
                   <label
                     className="PodBrowser-page-header__action"
@@ -3914,6 +3916,28 @@ font-display: block;",
                 <AddFileButton
                   className="PodBrowser-page-header__action"
                   onSave={[Function]}
+                  resourceList={
+                    Array [
+                      Object {
+                        "filename": "inbox",
+                        "iri": "https://myaccount.mypodserver.com/inbox",
+                        "name": "inbox",
+                        "type": "Resource",
+                      },
+                      Object {
+                        "filename": "private",
+                        "iri": "https://myaccount.mypodserver.com/private",
+                        "name": "private",
+                        "type": "Resource",
+                      },
+                      Object {
+                        "filename": "note.txt",
+                        "iri": "https://myaccount.mypodserver.com/note.txt",
+                        "name": "note.txt",
+                        "type": "Resource",
+                      },
+                    ]
+                  }
                 />,
               ]
             }
@@ -4062,6 +4086,28 @@ font-display: block;",
                 <AddFileButton
                   className="PodBrowser-page-header__action"
                   onSave={[Function]}
+                  resourceList={
+                    Array [
+                      Object {
+                        "filename": "inbox",
+                        "iri": "https://myaccount.mypodserver.com/inbox",
+                        "name": "inbox",
+                        "type": "Resource",
+                      },
+                      Object {
+                        "filename": "private",
+                        "iri": "https://myaccount.mypodserver.com/private",
+                        "name": "private",
+                        "type": "Resource",
+                      },
+                      Object {
+                        "filename": "note.txt",
+                        "iri": "https://myaccount.mypodserver.com/note.txt",
+                        "name": "note.txt",
+                        "type": "Resource",
+                      },
+                    ]
+                  }
                 >
                   <label
                     className="PodBrowser-page-header__action"

--- a/components/container/index.tsx
+++ b/components/container/index.tsx
@@ -54,8 +54,11 @@ interface IPodList {
 
 export default function Container({ iri }: IPodList): ReactElement {
   useRedirectIfLoggedOut();
+  const encodedIri = encodeURI(iri);
 
-  const { data: resourceIris, mutate } = useFetchContainerResourceIris(iri);
+  const { data: resourceIris, mutate } = useFetchContainerResourceIris(
+    encodedIri
+  );
   const loading = typeof resourceIris === "undefined";
 
   const bem = useBem(useStyles());

--- a/components/containerPageHeader/__snapshots__/index.test.tsx.snap
+++ b/components/containerPageHeader/__snapshots__/index.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`ContainerPageHeader Renders view 1`] = `
         <AddFileButton
           className="makeStyles-page-header__action-5"
           onSave={[Function]}
+          resourceList={Array []}
         />,
       ]
     }
@@ -145,6 +146,7 @@ exports[`ContainerPageHeader Renders view 1`] = `
         <AddFileButton
           className="makeStyles-page-header__action-5"
           onSave={[Function]}
+          resourceList={Array []}
         >
           <label
             className="makeStyles-page-header__action-5"

--- a/components/containerPageHeader/index.tsx
+++ b/components/containerPageHeader/index.tsx
@@ -45,7 +45,11 @@ export default function PageHeader({
     />
   );
   const addFileButton = (
-    <AddFileButton onSave={mutate} className={pageHeaderAction} />
+    <AddFileButton
+      onSave={mutate}
+      className={pageHeaderAction}
+      resourceList={resourceList}
+    />
   );
   return (
     <PrismPageHeader


### PR DESCRIPTION
This PR fixes authentication errors when navigating into a container created in Data Browser.

These errors where mainly caused by passing URI-decoded resource names/URIs in different places.
Once one error was thrown, there were auth errors on all subsequent requests.

Also in this PR: 
- Slightly refactored AddFileButton to eliminate an unnecessary fetch (which was also throwing auth errors).
- Updated tests and snapshots

<!-- When fixing a bug: -->

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
