### PR TITLE
Move mouse enter event to button to prevent infinite toggling

### DIFF
--- a/components/header/__snapshots__/index.test.tsx.snap
+++ b/components/header/__snapshots__/index.test.tsx.snap
@@ -867,7 +867,6 @@ font-display: block;",
           <UserMenu>
             <div
               className="PodBrowser-header-banner__aside-menu PodBrowser-header-banner__aside-menu--popup"
-              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <button
@@ -876,6 +875,7 @@ font-display: block;",
                 aria-haspopup="true"
                 className="PodBrowser-header-banner__aside-menu-trigger"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
                 type="button"
               >
                 <i
@@ -1796,7 +1796,6 @@ font-display: block;",
           <UserMenu>
             <div
               className="PodBrowser-header-banner__aside-menu PodBrowser-header-banner__aside-menu--popup"
-              onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
               <button
@@ -1805,6 +1804,7 @@ font-display: block;",
                 aria-haspopup="true"
                 className="PodBrowser-header-banner__aside-menu-trigger"
                 onClick={[Function]}
+                onMouseEnter={[Function]}
                 type="button"
               >
                 <i

--- a/components/header/userMenu/__snapshots__/index.test.tsx.snap
+++ b/components/header/userMenu/__snapshots__/index.test.tsx.snap
@@ -843,7 +843,6 @@ font-display: block;",
       <UserMenu>
         <div
           className="PodBrowser-header-banner__aside-menu PodBrowser-header-banner__aside-menu--popup"
-          onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
           <button
@@ -852,6 +851,7 @@ font-display: block;",
             aria-haspopup="true"
             className="PodBrowser-header-banner__aside-menu-trigger"
             onClick={[Function]}
+            onMouseEnter={[Function]}
             type="button"
           >
             <i

--- a/components/header/userMenu/index.tsx
+++ b/components/header/userMenu/index.tsx
@@ -39,7 +39,6 @@ export default function UserMenu(): ReactElement {
   return (
     <div
       className={bem("header-banner__aside-menu", "popup")}
-      onMouseEnter={toggleMenu}
       onMouseLeave={toggleMenu}
     >
       <button
@@ -49,6 +48,7 @@ export default function UserMenu(): ReactElement {
         aria-controls="UserMenu"
         aria-expanded={!userMenuOpen}
         onClick={toggleMenu}
+        onMouseEnter={toggleMenu}
       >
         <i
           className={clsx(


### PR DESCRIPTION
When clicking the user menu button and then hovering over "Log out", the toggle function was triggered causing back and forth toggling, which resulted in the "Log out" menu item being displayed intermittently.

Moving the mouse enter event to the button instead of the "Log out" menu item fixes this.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
