### PR TITLE
Display decoded names in Resource Details

### DIFF
--- a/components/detailsContextMenu/__snapshots__/index.test.jsx.snap
+++ b/components/detailsContextMenu/__snapshots__/index.test.jsx.snap
@@ -5147,7 +5147,7 @@ font-display: block;",
               className="PodBrowser-content-h3"
               title="/iri/"
             >
-              /iri/
+              iri
             </h3>
           </section>
           <WithStyles(ForwardRef(Divider))>

--- a/components/resourceDetails/__snapshots__/index.test.tsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.tsx.snap
@@ -11,6 +11,3531 @@ exports[`DownloadLink returns a download button if resource is not a container 1
 
 exports[`DownloadLink returns null if resource is a container 1`] = `""`;
 
+exports[`Resource details it renders a decoded cntainer name 1`] = `
+<WithTheme
+  theme={
+    Object {
+      "breakpoints": Object {
+        "between": [Function],
+        "down": [Function],
+        "keys": Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ],
+        "only": [Function],
+        "up": [Function],
+        "values": Object {
+          "lg": 1280,
+          "md": 960,
+          "sm": 600,
+          "xl": 1920,
+          "xs": 0,
+        },
+        "width": [Function],
+      },
+      "direction": "ltr",
+      "iconSet": Object {
+        "config": Object {
+          "cssFiles": Array [
+            "css/all.css",
+          ],
+          "fonts": Array [
+            Object {
+              "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+              "fontsPath": "./webfonts",
+              "licensePath": "./LICENSE.txt",
+              "source": "fa-solid-900.eot",
+              "sources": Array [
+                Object {
+                  "format": "embedded-opentype",
+                  "path": "fa-solid-900.eot",
+                  "urlAddition": "?#iefix",
+                },
+                Object {
+                  "format": "woff2",
+                  "path": "fa-solid-900.woff2",
+                },
+                Object {
+                  "format": "woff",
+                  "path": "fa-solid-900.woff",
+                },
+                Object {
+                  "format": "truetype",
+                  "path": "fa-solid-900.ttf",
+                },
+                Object {
+                  "format": "svg",
+                  "path": "fa-solid-900.svg",
+                  "urlAddition": "#fontawesome",
+                },
+              ],
+            },
+          ],
+          "label": "Font Awesome Solid",
+          "name": "fontawesome-solid",
+          "npmModule": "@fortawesome/fontawesome-free",
+          "type": 0,
+        },
+        "iconColor": [Function],
+        "styles": [Function],
+      },
+      "icons": Object {
+        "config": Object {
+          "cssFiles": Array [
+            "css/all.css",
+          ],
+          "fonts": Array [
+            Object {
+              "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+              "fontsPath": "./webfonts",
+              "licensePath": "./LICENSE.txt",
+              "source": "fa-solid-900.eot",
+              "sources": Array [
+                Object {
+                  "format": "embedded-opentype",
+                  "path": "fa-solid-900.eot",
+                  "urlAddition": "?#iefix",
+                },
+                Object {
+                  "format": "woff2",
+                  "path": "fa-solid-900.woff2",
+                },
+                Object {
+                  "format": "woff",
+                  "path": "fa-solid-900.woff",
+                },
+                Object {
+                  "format": "truetype",
+                  "path": "fa-solid-900.ttf",
+                },
+                Object {
+                  "format": "svg",
+                  "path": "fa-solid-900.svg",
+                  "urlAddition": "#fontawesome",
+                },
+              ],
+            },
+          ],
+          "label": "Font Awesome Solid",
+          "name": "fontawesome-solid",
+          "npmModule": "@fortawesome/fontawesome-free",
+          "type": 0,
+        },
+        "iconColor": [Function],
+        "styles": [Function],
+      },
+      "label": "SDK Default",
+      "licenses": Array [
+        "fonts/Raleway/OFL.txt",
+      ],
+      "localFonts": Object {
+        "fonts/Raleway/Raleway-ExtraBold": [Function],
+        "fonts/Raleway/Raleway-Medium": [Function],
+      },
+      "mixins": Object {
+        "gutters": [Function],
+        "toolbar": Object {
+          "@media (min-width:0px) and (orientation: landscape)": Object {
+            "minHeight": 48,
+          },
+          "@media (min-width:600px)": Object {
+            "minHeight": 64,
+          },
+          "minHeight": 56,
+        },
+      },
+      "name": "sdk-default",
+      "overrides": Object {},
+      "palette": Object {
+        "action": Object {
+          "activatedOpacity": 0.12,
+          "active": "rgba(0, 0, 0, 0.54)",
+          "disabled": "rgba(0, 0, 0, 0.26)",
+          "disabledBackground": "rgba(0, 0, 0, 0.12)",
+          "disabledOpacity": 0.38,
+          "focus": "rgba(0, 0, 0, 0.12)",
+          "focusOpacity": 0.12,
+          "hover": "rgba(0, 0, 0, 0.04)",
+          "hoverOpacity": 0.04,
+          "selected": "rgba(0, 0, 0, 0.08)",
+          "selectedOpacity": 0.08,
+        },
+        "adjustAlpha": [Function],
+        "augmentColor": [Function],
+        "background": Object {
+          "default": "#FFFFFF",
+          "paper": "#fff",
+        },
+        "common": Object {
+          "black": "#000",
+          "white": "#fff",
+        },
+        "contrastThreshold": 3,
+        "divider": "rgba(0, 0, 0, 0.12)",
+        "error": Object {
+          "contrastText": "#fff",
+          "dark": "#d32f2f",
+          "light": "#e57373",
+          "main": "#f44336",
+        },
+        "getContrastText": [Function],
+        "grey": Object {
+          "100": "#f5f5f5",
+          "200": "#eeeeee",
+          "300": "#e0e0e0",
+          "400": "#bdbdbd",
+          "50": "#fafafa",
+          "500": "#9e9e9e",
+          "600": "#757575",
+          "700": "#616161",
+          "800": "#424242",
+          "900": "#212121",
+          "A100": "#d5d5d5",
+          "A200": "#aaaaaa",
+          "A400": "#303030",
+          "A700": "#616161",
+        },
+        "info": Object {
+          "contrastText": "#fff",
+          "dark": "#1976d2",
+          "light": "#64b5f6",
+          "main": "#2196f3",
+        },
+        "primary": Object {
+          "contrastText": "#fff",
+          "dark": "rgb(86, 53, 178)",
+          "light": "rgb(150, 112, 255)",
+          "main": "#7C4DFF",
+        },
+        "secondary": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#083575",
+          "light": "#01C9EA",
+          "main": "#18A9E6",
+        },
+        "success": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#388e3c",
+          "light": "#81c784",
+          "main": "#4caf50",
+        },
+        "text": Object {
+          "disabled": "rgba(0, 0, 0, 0.38)",
+          "hint": "rgba(0, 0, 0, 0.38)",
+          "primary": "#4E4E4E",
+          "secondary": "#4E4E4E",
+        },
+        "tonalOffset": 0.2,
+        "type": "light",
+        "warning": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#f57c00",
+          "light": "#ffb74d",
+          "main": "#ff9800",
+        },
+      },
+      "props": Object {},
+      "shadows": Array [
+        "none",
+        "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+        "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+        "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+        "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+        "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+        "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+        "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+        "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+        "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+        "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+        "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+        "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+        "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+        "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+        "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+        "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+      ],
+      "shape": Object {
+        "borderRadius": 4,
+      },
+      "spacing": [Function],
+      "stylesheets": Array [
+        "https://fonts.googleapis.com/css?family=Raleway:500,800&display=swap",
+      ],
+      "transitions": Object {
+        "create": [Function],
+        "duration": Object {
+          "complex": 375,
+          "enteringScreen": 225,
+          "leavingScreen": 195,
+          "short": 250,
+          "shorter": 200,
+          "shortest": 150,
+          "standard": 300,
+        },
+        "easing": Object {
+          "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+          "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+          "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+        },
+        "getAutoHeightDuration": [Function],
+      },
+      "typography": Object {
+        "body": Object {
+          "fontFamily": "\\"Raleway-Medium\\"",
+          "fontSize": "0.9375rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.43,
+        },
+        "body1": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "body2": Object {
+          "fontFamily": "\\"Raleway-Medium\\"",
+          "fontSize": "0.9375rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.43,
+        },
+        "button": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.02857em",
+          "lineHeight": 1.75,
+          "textTransform": "uppercase",
+        },
+        "caption": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.03333em",
+          "lineHeight": 1.66,
+        },
+        "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+        "fontSize": 14,
+        "fontWeightBold": 800,
+        "fontWeightLight": 500,
+        "fontWeightMedium": 500,
+        "fontWeightRegular": 400,
+        "h1": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.375rem",
+          "fontWeight": 800,
+          "letterSpacing": "-0.01562em",
+          "lineHeight": 1.45,
+        },
+        "h2": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.125rem",
+          "fontWeight": 800,
+          "letterSpacing": "-0.00833em",
+          "lineHeight": 1.27,
+        },
+        "h3": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.05rem",
+          "fontWeight": 800,
+          "letterSpacing": "0em",
+          "lineHeight": 1.2,
+        },
+        "h4": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00735em",
+          "lineHeight": 1.1,
+        },
+        "h5": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0em",
+          "lineHeight": 1,
+        },
+        "h6": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "0.625rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.0075em",
+          "lineHeight": 1,
+        },
+        "heading": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "htmlFontSize": 16,
+        "overline": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.08333em",
+          "lineHeight": 2.66,
+          "textTransform": "uppercase",
+        },
+        "pxToRem": [Function],
+        "round": [Function],
+        "subtitle1": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.75,
+        },
+        "subtitle2": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.00714em",
+          "lineHeight": 1.57,
+        },
+      },
+      "zIndex": Object {
+        "appBar": 1100,
+        "drawer": 1200,
+        "mobileStepper": 1000,
+        "modal": 1300,
+        "snackbar": 1400,
+        "speedDial": 1050,
+        "tooltip": 1500,
+      },
+      Symbol(mui.nested): false,
+    }
+  }
+>
+  <StylesProvider
+    generateClassName={[Function]}
+  >
+    <ThemeProvider
+      theme={
+        Object {
+          "breakpoints": Object {
+            "between": [Function],
+            "down": [Function],
+            "keys": Array [
+              "xs",
+              "sm",
+              "md",
+              "lg",
+              "xl",
+            ],
+            "only": [Function],
+            "up": [Function],
+            "values": Object {
+              "lg": 1280,
+              "md": 960,
+              "sm": 600,
+              "xl": 1920,
+              "xs": 0,
+            },
+            "width": [Function],
+          },
+          "direction": "ltr",
+          "iconSet": Object {
+            "config": Object {
+              "cssFiles": Array [
+                "css/all.css",
+              ],
+              "fonts": Array [
+                Object {
+                  "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+                  "fontsPath": "./webfonts",
+                  "licensePath": "./LICENSE.txt",
+                  "source": "fa-solid-900.eot",
+                  "sources": Array [
+                    Object {
+                      "format": "embedded-opentype",
+                      "path": "fa-solid-900.eot",
+                      "urlAddition": "?#iefix",
+                    },
+                    Object {
+                      "format": "woff2",
+                      "path": "fa-solid-900.woff2",
+                    },
+                    Object {
+                      "format": "woff",
+                      "path": "fa-solid-900.woff",
+                    },
+                    Object {
+                      "format": "truetype",
+                      "path": "fa-solid-900.ttf",
+                    },
+                    Object {
+                      "format": "svg",
+                      "path": "fa-solid-900.svg",
+                      "urlAddition": "#fontawesome",
+                    },
+                  ],
+                },
+              ],
+              "label": "Font Awesome Solid",
+              "name": "fontawesome-solid",
+              "npmModule": "@fortawesome/fontawesome-free",
+              "type": 0,
+            },
+            "iconColor": [Function],
+            "styles": [Function],
+          },
+          "icons": Object {
+            "config": Object {
+              "cssFiles": Array [
+                "css/all.css",
+              ],
+              "fonts": Array [
+                Object {
+                  "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+                  "fontsPath": "./webfonts",
+                  "licensePath": "./LICENSE.txt",
+                  "source": "fa-solid-900.eot",
+                  "sources": Array [
+                    Object {
+                      "format": "embedded-opentype",
+                      "path": "fa-solid-900.eot",
+                      "urlAddition": "?#iefix",
+                    },
+                    Object {
+                      "format": "woff2",
+                      "path": "fa-solid-900.woff2",
+                    },
+                    Object {
+                      "format": "woff",
+                      "path": "fa-solid-900.woff",
+                    },
+                    Object {
+                      "format": "truetype",
+                      "path": "fa-solid-900.ttf",
+                    },
+                    Object {
+                      "format": "svg",
+                      "path": "fa-solid-900.svg",
+                      "urlAddition": "#fontawesome",
+                    },
+                  ],
+                },
+              ],
+              "label": "Font Awesome Solid",
+              "name": "fontawesome-solid",
+              "npmModule": "@fortawesome/fontawesome-free",
+              "type": 0,
+            },
+            "iconColor": [Function],
+            "styles": [Function],
+          },
+          "label": "SDK Default",
+          "licenses": Array [
+            "fonts/Raleway/OFL.txt",
+          ],
+          "localFonts": Object {
+            "fonts/Raleway/Raleway-ExtraBold": [Function],
+            "fonts/Raleway/Raleway-Medium": [Function],
+          },
+          "mixins": Object {
+            "gutters": [Function],
+            "toolbar": Object {
+              "@media (min-width:0px) and (orientation: landscape)": Object {
+                "minHeight": 48,
+              },
+              "@media (min-width:600px)": Object {
+                "minHeight": 64,
+              },
+              "minHeight": 56,
+            },
+          },
+          "name": "sdk-default",
+          "overrides": Object {},
+          "palette": Object {
+            "action": Object {
+              "activatedOpacity": 0.12,
+              "active": "rgba(0, 0, 0, 0.54)",
+              "disabled": "rgba(0, 0, 0, 0.26)",
+              "disabledBackground": "rgba(0, 0, 0, 0.12)",
+              "disabledOpacity": 0.38,
+              "focus": "rgba(0, 0, 0, 0.12)",
+              "focusOpacity": 0.12,
+              "hover": "rgba(0, 0, 0, 0.04)",
+              "hoverOpacity": 0.04,
+              "selected": "rgba(0, 0, 0, 0.08)",
+              "selectedOpacity": 0.08,
+            },
+            "adjustAlpha": [Function],
+            "augmentColor": [Function],
+            "background": Object {
+              "default": "#FFFFFF",
+              "paper": "#fff",
+            },
+            "common": Object {
+              "black": "#000",
+              "white": "#fff",
+            },
+            "contrastThreshold": 3,
+            "divider": "rgba(0, 0, 0, 0.12)",
+            "error": Object {
+              "contrastText": "#fff",
+              "dark": "#d32f2f",
+              "light": "#e57373",
+              "main": "#f44336",
+            },
+            "getContrastText": [Function],
+            "grey": Object {
+              "100": "#f5f5f5",
+              "200": "#eeeeee",
+              "300": "#e0e0e0",
+              "400": "#bdbdbd",
+              "50": "#fafafa",
+              "500": "#9e9e9e",
+              "600": "#757575",
+              "700": "#616161",
+              "800": "#424242",
+              "900": "#212121",
+              "A100": "#d5d5d5",
+              "A200": "#aaaaaa",
+              "A400": "#303030",
+              "A700": "#616161",
+            },
+            "info": Object {
+              "contrastText": "#fff",
+              "dark": "#1976d2",
+              "light": "#64b5f6",
+              "main": "#2196f3",
+            },
+            "primary": Object {
+              "contrastText": "#fff",
+              "dark": "rgb(86, 53, 178)",
+              "light": "rgb(150, 112, 255)",
+              "main": "#7C4DFF",
+            },
+            "secondary": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#083575",
+              "light": "#01C9EA",
+              "main": "#18A9E6",
+            },
+            "success": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#388e3c",
+              "light": "#81c784",
+              "main": "#4caf50",
+            },
+            "text": Object {
+              "disabled": "rgba(0, 0, 0, 0.38)",
+              "hint": "rgba(0, 0, 0, 0.38)",
+              "primary": "#4E4E4E",
+              "secondary": "#4E4E4E",
+            },
+            "tonalOffset": 0.2,
+            "type": "light",
+            "warning": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#f57c00",
+              "light": "#ffb74d",
+              "main": "#ff9800",
+            },
+          },
+          "props": Object {},
+          "shadows": Array [
+            "none",
+            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+          ],
+          "shape": Object {
+            "borderRadius": 4,
+          },
+          "spacing": [Function],
+          "stylesheets": Array [
+            "https://fonts.googleapis.com/css?family=Raleway:500,800&display=swap",
+          ],
+          "transitions": Object {
+            "create": [Function],
+            "duration": Object {
+              "complex": 375,
+              "enteringScreen": 225,
+              "leavingScreen": 195,
+              "short": 250,
+              "shorter": 200,
+              "shortest": 150,
+              "standard": 300,
+            },
+            "easing": Object {
+              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+            },
+            "getAutoHeightDuration": [Function],
+          },
+          "typography": Object {
+            "body": Object {
+              "fontFamily": "\\"Raleway-Medium\\"",
+              "fontSize": "0.9375rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.01071em",
+              "lineHeight": 1.43,
+            },
+            "body1": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.5,
+            },
+            "body2": Object {
+              "fontFamily": "\\"Raleway-Medium\\"",
+              "fontSize": "0.9375rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.01071em",
+              "lineHeight": 1.43,
+            },
+            "button": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.875rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.02857em",
+              "lineHeight": 1.75,
+              "textTransform": "uppercase",
+            },
+            "caption": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.03333em",
+              "lineHeight": 1.66,
+            },
+            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+            "fontSize": 14,
+            "fontWeightBold": 800,
+            "fontWeightLight": 500,
+            "fontWeightMedium": 500,
+            "fontWeightRegular": 400,
+            "h1": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.375rem",
+              "fontWeight": 800,
+              "letterSpacing": "-0.01562em",
+              "lineHeight": 1.45,
+            },
+            "h2": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.125rem",
+              "fontWeight": 800,
+              "letterSpacing": "-0.00833em",
+              "lineHeight": 1.27,
+            },
+            "h3": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.05rem",
+              "fontWeight": 800,
+              "letterSpacing": "0em",
+              "lineHeight": 1.2,
+            },
+            "h4": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00735em",
+              "lineHeight": 1.1,
+            },
+            "h5": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0em",
+              "lineHeight": 1,
+            },
+            "h6": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "0.625rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.0075em",
+              "lineHeight": 1,
+            },
+            "heading": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.5,
+            },
+            "htmlFontSize": 16,
+            "overline": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.08333em",
+              "lineHeight": 2.66,
+              "textTransform": "uppercase",
+            },
+            "pxToRem": [Function],
+            "round": [Function],
+            "subtitle1": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.75,
+            },
+            "subtitle2": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.875rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.00714em",
+              "lineHeight": 1.57,
+            },
+          },
+          "zIndex": Object {
+            "appBar": 1100,
+            "drawer": 1200,
+            "mobileStepper": 1000,
+            "modal": 1300,
+            "snackbar": 1400,
+            "speedDial": 1050,
+            "tooltip": 1500,
+          },
+          Symbol(mui.nested): false,
+        }
+      }
+    >
+      <ResourceDetails
+        resource={
+          Object {
+            "iri": "/Some%20container/",
+            "name": "Name",
+            "types": Array [
+              "Container",
+            ],
+          }
+        }
+      >
+        <section
+          className="PodBrowser-headerSection"
+        >
+          <h3
+            className="PodBrowser-content-h3"
+            title="/Some%20container/"
+          >
+            Some container
+          </h3>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <h5
+            className="PodBrowser-content-h5"
+          >
+            Actions
+          </h5>
+          <WithStyles(ForwardRef(List))>
+            <ForwardRef(List)
+              classes={
+                Object {
+                  "dense": "PodBrowser-dense",
+                  "padding": "PodBrowser-padding",
+                  "root": "PodBrowser-root",
+                  "subheader": "PodBrowser-subheader",
+                }
+              }
+            >
+              <ul
+                className="PodBrowser-root PodBrowser-padding"
+              >
+                <WithStyles(ForwardRef(ListItem))
+                  button={true}
+                  component={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "render": [Function],
+                    }
+                  }
+                  resourceIri="/Some%20container/"
+                >
+                  <ForwardRef(ListItem)
+                    button={true}
+                    classes={
+                      Object {
+                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                        "button": "PodBrowser-button",
+                        "container": "PodBrowser-container",
+                        "dense": "PodBrowser-dense",
+                        "disabled": "PodBrowser-disabled",
+                        "divider": "PodBrowser-divider",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "gutters": "PodBrowser-gutters",
+                        "root": "PodBrowser-root",
+                        "secondaryAction": "PodBrowser-secondaryAction",
+                        "selected": "PodBrowser-selected",
+                      }
+                    }
+                    component={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      }
+                    }
+                    resourceIri="/Some%20container/"
+                  >
+                    <WithStyles(ForwardRef(ButtonBase))
+                      className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                      component={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      focusVisibleClassName="PodBrowser-focusVisible"
+                      resourceIri="/Some%20container/"
+                    >
+                      <ForwardRef(ButtonBase)
+                        className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                        classes={
+                          Object {
+                            "disabled": "PodBrowser-disabled",
+                            "focusVisible": "PodBrowser-focusVisible",
+                            "root": "PodBrowser-root",
+                          }
+                        }
+                        component={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "render": [Function],
+                          }
+                        }
+                        disabled={false}
+                        focusVisibleClassName="PodBrowser-focusVisible"
+                        resourceIri="/Some%20container/"
+                      >
+                        <ForwardRef
+                          aria-disabled={false}
+                          className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                          onBlur={[Function]}
+                          onDragLeave={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          resourceIri="/Some%20container/"
+                          role="button"
+                          tabIndex={0}
+                        >
+                          <ResourceLink
+                            action="sharing"
+                            aria-disabled={false}
+                            className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                            onBlur={[Function]}
+                            onDragLeave={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            resourceIri="/Some%20container/"
+                            role="button"
+                            tabIndex={0}
+                          >
+                            <Link
+                              as={
+                                Object {
+                                  "pathname": "/resource/[iri]",
+                                  "query": Object {
+                                    "action": "sharing",
+                                    "resourceIri": "/Some%20container/",
+                                  },
+                                }
+                              }
+                              href={
+                                Object {
+                                  "pathname": "/resource/[iri]",
+                                  "query": Object {
+                                    "action": "sharing",
+                                    "resourceIri": "/Some%20container/",
+                                  },
+                                }
+                              }
+                              replace={true}
+                            >
+                              <a
+                                aria-disabled={false}
+                                className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                                href="/resource/[iri]?action=sharing&resourceIri=%2FSome%2520container%2F"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragLeave={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="button"
+                                tabIndex={0}
+                              >
+                                <WithStyles(ForwardRef(ListItemIcon))
+                                  key=".0"
+                                >
+                                  <ForwardRef(ListItemIcon)
+                                    classes={
+                                      Object {
+                                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <div
+                                      className="PodBrowser-root"
+                                    >
+                                      <ForwardRef>
+                                        <WithStyles(ForwardRef(SvgIcon))>
+                                          <ForwardRef(SvgIcon)
+                                            classes={
+                                              Object {
+                                                "colorAction": "PodBrowser-colorAction",
+                                                "colorDisabled": "PodBrowser-colorDisabled",
+                                                "colorError": "PodBrowser-colorError",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                                "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                                "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                "root": "PodBrowser-root",
+                                              }
+                                            }
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="PodBrowser-root"
+                                              focusable="false"
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <path
+                                                d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+                                              />
+                                            </svg>
+                                          </ForwardRef(SvgIcon)>
+                                        </WithStyles(ForwardRef(SvgIcon))>
+                                      </ForwardRef>
+                                    </div>
+                                  </ForwardRef(ListItemIcon)>
+                                </WithStyles(ForwardRef(ListItemIcon))>
+                                <WithStyles(ForwardRef(ListItemText))
+                                  key=".1"
+                                  primary="Sharing & App Permissions"
+                                >
+                                  <ForwardRef(ListItemText)
+                                    classes={
+                                      Object {
+                                        "dense": "PodBrowser-dense",
+                                        "inset": "PodBrowser-inset",
+                                        "multiline": "PodBrowser-multiline",
+                                        "primary": "PodBrowser-primary",
+                                        "root": "PodBrowser-root",
+                                        "secondary": "PodBrowser-secondary",
+                                      }
+                                    }
+                                    primary="Sharing & App Permissions"
+                                  >
+                                    <div
+                                      className="PodBrowser-root"
+                                    >
+                                      <WithStyles(ForwardRef(Typography))
+                                        className="PodBrowser-primary"
+                                        component="span"
+                                        display="block"
+                                        variant="body1"
+                                      >
+                                        <ForwardRef(Typography)
+                                          className="PodBrowser-primary"
+                                          classes={
+                                            Object {
+                                              "alignCenter": "PodBrowser-alignCenter",
+                                              "alignJustify": "PodBrowser-alignJustify",
+                                              "alignLeft": "PodBrowser-alignLeft",
+                                              "alignRight": "PodBrowser-alignRight",
+                                              "body1": "PodBrowser-body1",
+                                              "body2": "PodBrowser-body2",
+                                              "button": "PodBrowser-button",
+                                              "caption": "PodBrowser-caption",
+                                              "colorError": "PodBrowser-colorError",
+                                              "colorInherit": "PodBrowser-colorInherit",
+                                              "colorPrimary": "PodBrowser-colorPrimary",
+                                              "colorSecondary": "PodBrowser-colorSecondary",
+                                              "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                              "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                              "displayBlock": "PodBrowser-displayBlock",
+                                              "displayInline": "PodBrowser-displayInline",
+                                              "gutterBottom": "PodBrowser-gutterBottom",
+                                              "h1": "PodBrowser-h1",
+                                              "h2": "PodBrowser-h2",
+                                              "h3": "PodBrowser-h3",
+                                              "h4": "PodBrowser-h4",
+                                              "h5": "PodBrowser-h5",
+                                              "h6": "PodBrowser-h6",
+                                              "noWrap": "PodBrowser-noWrap",
+                                              "overline": "PodBrowser-overline",
+                                              "paragraph": "PodBrowser-paragraph",
+                                              "root": "PodBrowser-root",
+                                              "srOnly": "PodBrowser-srOnly",
+                                              "subtitle1": "PodBrowser-subtitle1",
+                                              "subtitle2": "PodBrowser-subtitle2",
+                                            }
+                                          }
+                                          component="span"
+                                          display="block"
+                                          variant="body1"
+                                        >
+                                          <span
+                                            className="PodBrowser-root PodBrowser-primary PodBrowser-body1 PodBrowser-displayBlock"
+                                          >
+                                            Sharing & App Permissions
+                                          </span>
+                                        </ForwardRef(Typography)>
+                                      </WithStyles(ForwardRef(Typography))>
+                                    </div>
+                                  </ForwardRef(ListItemText)>
+                                </WithStyles(ForwardRef(ListItemText))>
+                                <WithStyles(memo)
+                                  center={false}
+                                >
+                                  <ForwardRef(TouchRipple)
+                                    center={false}
+                                    classes={
+                                      Object {
+                                        "child": "PodBrowser-child",
+                                        "childLeaving": "PodBrowser-childLeaving",
+                                        "childPulsate": "PodBrowser-childPulsate",
+                                        "ripple": "PodBrowser-ripple",
+                                        "ripplePulsate": "PodBrowser-ripplePulsate",
+                                        "rippleVisible": "PodBrowser-rippleVisible",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="PodBrowser-root"
+                                    >
+                                      <TransitionGroup
+                                        childFactory={[Function]}
+                                        component={null}
+                                        exit={true}
+                                      />
+                                    </span>
+                                  </ForwardRef(TouchRipple)>
+                                </WithStyles(memo)>
+                              </a>
+                            </Link>
+                          </ResourceLink>
+                        </ForwardRef>
+                      </ForwardRef(ButtonBase)>
+                    </WithStyles(ForwardRef(ButtonBase))>
+                  </ForwardRef(ListItem)>
+                </WithStyles(ForwardRef(ListItem))>
+                <WithStyles(ForwardRef(ListItem))
+                  button={true}
+                  component={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "render": [Function],
+                    }
+                  }
+                  name="Name"
+                  resourceIri="/Some%20container/"
+                >
+                  <ForwardRef(ListItem)
+                    button={true}
+                    classes={
+                      Object {
+                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                        "button": "PodBrowser-button",
+                        "container": "PodBrowser-container",
+                        "dense": "PodBrowser-dense",
+                        "disabled": "PodBrowser-disabled",
+                        "divider": "PodBrowser-divider",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "gutters": "PodBrowser-gutters",
+                        "root": "PodBrowser-root",
+                        "secondaryAction": "PodBrowser-secondaryAction",
+                        "selected": "PodBrowser-selected",
+                      }
+                    }
+                    component={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      }
+                    }
+                    name="Name"
+                    resourceIri="/Some%20container/"
+                  >
+                    <WithStyles(ForwardRef(ButtonBase))
+                      className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                      component={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      focusVisibleClassName="PodBrowser-focusVisible"
+                      name="Name"
+                      resourceIri="/Some%20container/"
+                    >
+                      <ForwardRef(ButtonBase)
+                        className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                        classes={
+                          Object {
+                            "disabled": "PodBrowser-disabled",
+                            "focusVisible": "PodBrowser-focusVisible",
+                            "root": "PodBrowser-root",
+                          }
+                        }
+                        component={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "render": [Function],
+                          }
+                        }
+                        disabled={false}
+                        focusVisibleClassName="PodBrowser-focusVisible"
+                        name="Name"
+                        resourceIri="/Some%20container/"
+                      >
+                        <ForwardRef
+                          aria-disabled={false}
+                          className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                          name="Name"
+                          onBlur={[Function]}
+                          onDragLeave={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          resourceIri="/Some%20container/"
+                          role="button"
+                          tabIndex={0}
+                        >
+                          <a
+                            aria-disabled={false}
+                            className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                            href="#delete"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragLeave={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            role="button"
+                            tabIndex={0}
+                          >
+                            <WithStyles(ForwardRef(ListItemIcon))
+                              key=".0"
+                            >
+                              <ForwardRef(ListItemIcon)
+                                classes={
+                                  Object {
+                                    "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                    "root": "PodBrowser-root",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="PodBrowser-root"
+                                >
+                                  <ForwardRef>
+                                    <WithStyles(ForwardRef(SvgIcon))>
+                                      <ForwardRef(SvgIcon)
+                                        classes={
+                                          Object {
+                                            "colorAction": "PodBrowser-colorAction",
+                                            "colorDisabled": "PodBrowser-colorDisabled",
+                                            "colorError": "PodBrowser-colorError",
+                                            "colorPrimary": "PodBrowser-colorPrimary",
+                                            "colorSecondary": "PodBrowser-colorSecondary",
+                                            "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                            "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                            "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                            "root": "PodBrowser-root",
+                                          }
+                                        }
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="PodBrowser-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                          />
+                                        </svg>
+                                      </ForwardRef(SvgIcon)>
+                                    </WithStyles(ForwardRef(SvgIcon))>
+                                  </ForwardRef>
+                                </div>
+                              </ForwardRef(ListItemIcon)>
+                            </WithStyles(ForwardRef(ListItemIcon))>
+                            <WithStyles(ForwardRef(ListItemText))
+                              key=".1"
+                              primary="Delete"
+                            >
+                              <ForwardRef(ListItemText)
+                                classes={
+                                  Object {
+                                    "dense": "PodBrowser-dense",
+                                    "inset": "PodBrowser-inset",
+                                    "multiline": "PodBrowser-multiline",
+                                    "primary": "PodBrowser-primary",
+                                    "root": "PodBrowser-root",
+                                    "secondary": "PodBrowser-secondary",
+                                  }
+                                }
+                                primary="Delete"
+                              >
+                                <div
+                                  className="PodBrowser-root"
+                                >
+                                  <WithStyles(ForwardRef(Typography))
+                                    className="PodBrowser-primary"
+                                    component="span"
+                                    display="block"
+                                    variant="body1"
+                                  >
+                                    <ForwardRef(Typography)
+                                      className="PodBrowser-primary"
+                                      classes={
+                                        Object {
+                                          "alignCenter": "PodBrowser-alignCenter",
+                                          "alignJustify": "PodBrowser-alignJustify",
+                                          "alignLeft": "PodBrowser-alignLeft",
+                                          "alignRight": "PodBrowser-alignRight",
+                                          "body1": "PodBrowser-body1",
+                                          "body2": "PodBrowser-body2",
+                                          "button": "PodBrowser-button",
+                                          "caption": "PodBrowser-caption",
+                                          "colorError": "PodBrowser-colorError",
+                                          "colorInherit": "PodBrowser-colorInherit",
+                                          "colorPrimary": "PodBrowser-colorPrimary",
+                                          "colorSecondary": "PodBrowser-colorSecondary",
+                                          "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                          "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                          "displayBlock": "PodBrowser-displayBlock",
+                                          "displayInline": "PodBrowser-displayInline",
+                                          "gutterBottom": "PodBrowser-gutterBottom",
+                                          "h1": "PodBrowser-h1",
+                                          "h2": "PodBrowser-h2",
+                                          "h3": "PodBrowser-h3",
+                                          "h4": "PodBrowser-h4",
+                                          "h5": "PodBrowser-h5",
+                                          "h6": "PodBrowser-h6",
+                                          "noWrap": "PodBrowser-noWrap",
+                                          "overline": "PodBrowser-overline",
+                                          "paragraph": "PodBrowser-paragraph",
+                                          "root": "PodBrowser-root",
+                                          "srOnly": "PodBrowser-srOnly",
+                                          "subtitle1": "PodBrowser-subtitle1",
+                                          "subtitle2": "PodBrowser-subtitle2",
+                                        }
+                                      }
+                                      component="span"
+                                      display="block"
+                                      variant="body1"
+                                    >
+                                      <span
+                                        className="PodBrowser-root PodBrowser-primary PodBrowser-body1 PodBrowser-displayBlock"
+                                      >
+                                        Delete
+                                      </span>
+                                    </ForwardRef(Typography)>
+                                  </WithStyles(ForwardRef(Typography))>
+                                </div>
+                              </ForwardRef(ListItemText)>
+                            </WithStyles(ForwardRef(ListItemText))>
+                            <WithStyles(memo)
+                              center={false}
+                            >
+                              <ForwardRef(TouchRipple)
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "PodBrowser-child",
+                                    "childLeaving": "PodBrowser-childLeaving",
+                                    "childPulsate": "PodBrowser-childPulsate",
+                                    "ripple": "PodBrowser-ripple",
+                                    "ripplePulsate": "PodBrowser-ripplePulsate",
+                                    "rippleVisible": "PodBrowser-rippleVisible",
+                                    "root": "PodBrowser-root",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="PodBrowser-root"
+                                >
+                                  <TransitionGroup
+                                    childFactory={[Function]}
+                                    component={null}
+                                    exit={true}
+                                  />
+                                </span>
+                              </ForwardRef(TouchRipple)>
+                            </WithStyles(memo)>
+                          </a>
+                        </ForwardRef>
+                      </ForwardRef(ButtonBase)>
+                    </WithStyles(ForwardRef(ButtonBase))>
+                  </ForwardRef(ListItem)>
+                </WithStyles(ForwardRef(ListItem))>
+              </ul>
+            </ForwardRef(List)>
+          </WithStyles(ForwardRef(List))>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <h5
+            className="PodBrowser-content-h5"
+          >
+            Details
+          </h5>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <WithStyles(ForwardRef(List))>
+            <ForwardRef(List)
+              classes={
+                Object {
+                  "dense": "PodBrowser-dense",
+                  "padding": "PodBrowser-padding",
+                  "root": "PodBrowser-root",
+                  "subheader": "PodBrowser-subheader",
+                }
+              }
+            >
+              <ul
+                className="PodBrowser-root PodBrowser-padding"
+              >
+                <WithStyles(ForwardRef(ListItem))
+                  className="PodBrowser-listItem"
+                >
+                  <ForwardRef(ListItem)
+                    className="PodBrowser-listItem"
+                    classes={
+                      Object {
+                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                        "button": "PodBrowser-button",
+                        "container": "PodBrowser-container",
+                        "dense": "PodBrowser-dense",
+                        "disabled": "PodBrowser-disabled",
+                        "divider": "PodBrowser-divider",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "gutters": "PodBrowser-gutters",
+                        "root": "PodBrowser-root",
+                        "secondaryAction": "PodBrowser-secondaryAction",
+                        "selected": "PodBrowser-selected",
+                      }
+                    }
+                  >
+                    <li
+                      className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
+                      disabled={false}
+                    >
+                      <WithStyles(ForwardRef(Typography))
+                        className="PodBrowser-detailText"
+                        key=".0"
+                      >
+                        <ForwardRef(Typography)
+                          className="PodBrowser-detailText"
+                          classes={
+                            Object {
+                              "alignCenter": "PodBrowser-alignCenter",
+                              "alignJustify": "PodBrowser-alignJustify",
+                              "alignLeft": "PodBrowser-alignLeft",
+                              "alignRight": "PodBrowser-alignRight",
+                              "body1": "PodBrowser-body1",
+                              "body2": "PodBrowser-body2",
+                              "button": "PodBrowser-button",
+                              "caption": "PodBrowser-caption",
+                              "colorError": "PodBrowser-colorError",
+                              "colorInherit": "PodBrowser-colorInherit",
+                              "colorPrimary": "PodBrowser-colorPrimary",
+                              "colorSecondary": "PodBrowser-colorSecondary",
+                              "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                              "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                              "displayBlock": "PodBrowser-displayBlock",
+                              "displayInline": "PodBrowser-displayInline",
+                              "gutterBottom": "PodBrowser-gutterBottom",
+                              "h1": "PodBrowser-h1",
+                              "h2": "PodBrowser-h2",
+                              "h3": "PodBrowser-h3",
+                              "h4": "PodBrowser-h4",
+                              "h5": "PodBrowser-h5",
+                              "h6": "PodBrowser-h6",
+                              "noWrap": "PodBrowser-noWrap",
+                              "overline": "PodBrowser-overline",
+                              "paragraph": "PodBrowser-paragraph",
+                              "root": "PodBrowser-root",
+                              "srOnly": "PodBrowser-srOnly",
+                              "subtitle1": "PodBrowser-subtitle1",
+                              "subtitle2": "PodBrowser-subtitle2",
+                            }
+                          }
+                        >
+                          <p
+                            className="PodBrowser-root PodBrowser-detailText PodBrowser-body1"
+                          >
+                            Thing Type:
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <WithStyles(ForwardRef(Typography))
+                        className="PodBrowser-typeValue PodBrowser-detailText"
+                        key=".1"
+                      >
+                        <ForwardRef(Typography)
+                          className="PodBrowser-typeValue PodBrowser-detailText"
+                          classes={
+                            Object {
+                              "alignCenter": "PodBrowser-alignCenter",
+                              "alignJustify": "PodBrowser-alignJustify",
+                              "alignLeft": "PodBrowser-alignLeft",
+                              "alignRight": "PodBrowser-alignRight",
+                              "body1": "PodBrowser-body1",
+                              "body2": "PodBrowser-body2",
+                              "button": "PodBrowser-button",
+                              "caption": "PodBrowser-caption",
+                              "colorError": "PodBrowser-colorError",
+                              "colorInherit": "PodBrowser-colorInherit",
+                              "colorPrimary": "PodBrowser-colorPrimary",
+                              "colorSecondary": "PodBrowser-colorSecondary",
+                              "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                              "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                              "displayBlock": "PodBrowser-displayBlock",
+                              "displayInline": "PodBrowser-displayInline",
+                              "gutterBottom": "PodBrowser-gutterBottom",
+                              "h1": "PodBrowser-h1",
+                              "h2": "PodBrowser-h2",
+                              "h3": "PodBrowser-h3",
+                              "h4": "PodBrowser-h4",
+                              "h5": "PodBrowser-h5",
+                              "h6": "PodBrowser-h6",
+                              "noWrap": "PodBrowser-noWrap",
+                              "overline": "PodBrowser-overline",
+                              "paragraph": "PodBrowser-paragraph",
+                              "root": "PodBrowser-root",
+                              "srOnly": "PodBrowser-srOnly",
+                              "subtitle1": "PodBrowser-subtitle1",
+                              "subtitle2": "PodBrowser-subtitle2",
+                            }
+                          }
+                        >
+                          <p
+                            className="PodBrowser-root PodBrowser-typeValue PodBrowser-detailText PodBrowser-body1"
+                          >
+                            Container
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                    </li>
+                  </ForwardRef(ListItem)>
+                </WithStyles(ForwardRef(ListItem))>
+              </ul>
+            </ForwardRef(List)>
+          </WithStyles(ForwardRef(List))>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <DownloadLink
+            className="PodBrowser-downloadButton"
+            iri="/Some%20container/"
+            type="Container"
+          />
+        </section>
+      </ResourceDetails>
+    </ThemeProvider>
+  </StylesProvider>
+</WithTheme>
+`;
+
+exports[`Resource details it renders a decoded resource name 1`] = `
+<WithTheme
+  theme={
+    Object {
+      "breakpoints": Object {
+        "between": [Function],
+        "down": [Function],
+        "keys": Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ],
+        "only": [Function],
+        "up": [Function],
+        "values": Object {
+          "lg": 1280,
+          "md": 960,
+          "sm": 600,
+          "xl": 1920,
+          "xs": 0,
+        },
+        "width": [Function],
+      },
+      "direction": "ltr",
+      "iconSet": Object {
+        "config": Object {
+          "cssFiles": Array [
+            "css/all.css",
+          ],
+          "fonts": Array [
+            Object {
+              "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+              "fontsPath": "./webfonts",
+              "licensePath": "./LICENSE.txt",
+              "source": "fa-solid-900.eot",
+              "sources": Array [
+                Object {
+                  "format": "embedded-opentype",
+                  "path": "fa-solid-900.eot",
+                  "urlAddition": "?#iefix",
+                },
+                Object {
+                  "format": "woff2",
+                  "path": "fa-solid-900.woff2",
+                },
+                Object {
+                  "format": "woff",
+                  "path": "fa-solid-900.woff",
+                },
+                Object {
+                  "format": "truetype",
+                  "path": "fa-solid-900.ttf",
+                },
+                Object {
+                  "format": "svg",
+                  "path": "fa-solid-900.svg",
+                  "urlAddition": "#fontawesome",
+                },
+              ],
+            },
+          ],
+          "label": "Font Awesome Solid",
+          "name": "fontawesome-solid",
+          "npmModule": "@fortawesome/fontawesome-free",
+          "type": 0,
+        },
+        "iconColor": [Function],
+        "styles": [Function],
+      },
+      "icons": Object {
+        "config": Object {
+          "cssFiles": Array [
+            "css/all.css",
+          ],
+          "fonts": Array [
+            Object {
+              "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+              "fontsPath": "./webfonts",
+              "licensePath": "./LICENSE.txt",
+              "source": "fa-solid-900.eot",
+              "sources": Array [
+                Object {
+                  "format": "embedded-opentype",
+                  "path": "fa-solid-900.eot",
+                  "urlAddition": "?#iefix",
+                },
+                Object {
+                  "format": "woff2",
+                  "path": "fa-solid-900.woff2",
+                },
+                Object {
+                  "format": "woff",
+                  "path": "fa-solid-900.woff",
+                },
+                Object {
+                  "format": "truetype",
+                  "path": "fa-solid-900.ttf",
+                },
+                Object {
+                  "format": "svg",
+                  "path": "fa-solid-900.svg",
+                  "urlAddition": "#fontawesome",
+                },
+              ],
+            },
+          ],
+          "label": "Font Awesome Solid",
+          "name": "fontawesome-solid",
+          "npmModule": "@fortawesome/fontawesome-free",
+          "type": 0,
+        },
+        "iconColor": [Function],
+        "styles": [Function],
+      },
+      "label": "SDK Default",
+      "licenses": Array [
+        "fonts/Raleway/OFL.txt",
+      ],
+      "localFonts": Object {
+        "fonts/Raleway/Raleway-ExtraBold": [Function],
+        "fonts/Raleway/Raleway-Medium": [Function],
+      },
+      "mixins": Object {
+        "gutters": [Function],
+        "toolbar": Object {
+          "@media (min-width:0px) and (orientation: landscape)": Object {
+            "minHeight": 48,
+          },
+          "@media (min-width:600px)": Object {
+            "minHeight": 64,
+          },
+          "minHeight": 56,
+        },
+      },
+      "name": "sdk-default",
+      "overrides": Object {},
+      "palette": Object {
+        "action": Object {
+          "activatedOpacity": 0.12,
+          "active": "rgba(0, 0, 0, 0.54)",
+          "disabled": "rgba(0, 0, 0, 0.26)",
+          "disabledBackground": "rgba(0, 0, 0, 0.12)",
+          "disabledOpacity": 0.38,
+          "focus": "rgba(0, 0, 0, 0.12)",
+          "focusOpacity": 0.12,
+          "hover": "rgba(0, 0, 0, 0.04)",
+          "hoverOpacity": 0.04,
+          "selected": "rgba(0, 0, 0, 0.08)",
+          "selectedOpacity": 0.08,
+        },
+        "adjustAlpha": [Function],
+        "augmentColor": [Function],
+        "background": Object {
+          "default": "#FFFFFF",
+          "paper": "#fff",
+        },
+        "common": Object {
+          "black": "#000",
+          "white": "#fff",
+        },
+        "contrastThreshold": 3,
+        "divider": "rgba(0, 0, 0, 0.12)",
+        "error": Object {
+          "contrastText": "#fff",
+          "dark": "#d32f2f",
+          "light": "#e57373",
+          "main": "#f44336",
+        },
+        "getContrastText": [Function],
+        "grey": Object {
+          "100": "#f5f5f5",
+          "200": "#eeeeee",
+          "300": "#e0e0e0",
+          "400": "#bdbdbd",
+          "50": "#fafafa",
+          "500": "#9e9e9e",
+          "600": "#757575",
+          "700": "#616161",
+          "800": "#424242",
+          "900": "#212121",
+          "A100": "#d5d5d5",
+          "A200": "#aaaaaa",
+          "A400": "#303030",
+          "A700": "#616161",
+        },
+        "info": Object {
+          "contrastText": "#fff",
+          "dark": "#1976d2",
+          "light": "#64b5f6",
+          "main": "#2196f3",
+        },
+        "primary": Object {
+          "contrastText": "#fff",
+          "dark": "rgb(86, 53, 178)",
+          "light": "rgb(150, 112, 255)",
+          "main": "#7C4DFF",
+        },
+        "secondary": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#083575",
+          "light": "#01C9EA",
+          "main": "#18A9E6",
+        },
+        "success": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#388e3c",
+          "light": "#81c784",
+          "main": "#4caf50",
+        },
+        "text": Object {
+          "disabled": "rgba(0, 0, 0, 0.38)",
+          "hint": "rgba(0, 0, 0, 0.38)",
+          "primary": "#4E4E4E",
+          "secondary": "#4E4E4E",
+        },
+        "tonalOffset": 0.2,
+        "type": "light",
+        "warning": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#f57c00",
+          "light": "#ffb74d",
+          "main": "#ff9800",
+        },
+      },
+      "props": Object {},
+      "shadows": Array [
+        "none",
+        "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+        "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+        "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+        "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+        "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+        "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+        "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+        "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+        "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+        "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+        "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+        "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+        "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+        "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+        "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+        "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+      ],
+      "shape": Object {
+        "borderRadius": 4,
+      },
+      "spacing": [Function],
+      "stylesheets": Array [
+        "https://fonts.googleapis.com/css?family=Raleway:500,800&display=swap",
+      ],
+      "transitions": Object {
+        "create": [Function],
+        "duration": Object {
+          "complex": 375,
+          "enteringScreen": 225,
+          "leavingScreen": 195,
+          "short": 250,
+          "shorter": 200,
+          "shortest": 150,
+          "standard": 300,
+        },
+        "easing": Object {
+          "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+          "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+          "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+        },
+        "getAutoHeightDuration": [Function],
+      },
+      "typography": Object {
+        "body": Object {
+          "fontFamily": "\\"Raleway-Medium\\"",
+          "fontSize": "0.9375rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.43,
+        },
+        "body1": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "body2": Object {
+          "fontFamily": "\\"Raleway-Medium\\"",
+          "fontSize": "0.9375rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.43,
+        },
+        "button": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.02857em",
+          "lineHeight": 1.75,
+          "textTransform": "uppercase",
+        },
+        "caption": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.03333em",
+          "lineHeight": 1.66,
+        },
+        "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+        "fontSize": 14,
+        "fontWeightBold": 800,
+        "fontWeightLight": 500,
+        "fontWeightMedium": 500,
+        "fontWeightRegular": 400,
+        "h1": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.375rem",
+          "fontWeight": 800,
+          "letterSpacing": "-0.01562em",
+          "lineHeight": 1.45,
+        },
+        "h2": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.125rem",
+          "fontWeight": 800,
+          "letterSpacing": "-0.00833em",
+          "lineHeight": 1.27,
+        },
+        "h3": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.05rem",
+          "fontWeight": 800,
+          "letterSpacing": "0em",
+          "lineHeight": 1.2,
+        },
+        "h4": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00735em",
+          "lineHeight": 1.1,
+        },
+        "h5": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0em",
+          "lineHeight": 1,
+        },
+        "h6": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "0.625rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.0075em",
+          "lineHeight": 1,
+        },
+        "heading": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "htmlFontSize": 16,
+        "overline": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.08333em",
+          "lineHeight": 2.66,
+          "textTransform": "uppercase",
+        },
+        "pxToRem": [Function],
+        "round": [Function],
+        "subtitle1": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.75,
+        },
+        "subtitle2": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.00714em",
+          "lineHeight": 1.57,
+        },
+      },
+      "zIndex": Object {
+        "appBar": 1100,
+        "drawer": 1200,
+        "mobileStepper": 1000,
+        "modal": 1300,
+        "snackbar": 1400,
+        "speedDial": 1050,
+        "tooltip": 1500,
+      },
+      Symbol(mui.nested): false,
+    }
+  }
+>
+  <StylesProvider
+    generateClassName={[Function]}
+  >
+    <ThemeProvider
+      theme={
+        Object {
+          "breakpoints": Object {
+            "between": [Function],
+            "down": [Function],
+            "keys": Array [
+              "xs",
+              "sm",
+              "md",
+              "lg",
+              "xl",
+            ],
+            "only": [Function],
+            "up": [Function],
+            "values": Object {
+              "lg": 1280,
+              "md": 960,
+              "sm": 600,
+              "xl": 1920,
+              "xs": 0,
+            },
+            "width": [Function],
+          },
+          "direction": "ltr",
+          "iconSet": Object {
+            "config": Object {
+              "cssFiles": Array [
+                "css/all.css",
+              ],
+              "fonts": Array [
+                Object {
+                  "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+                  "fontsPath": "./webfonts",
+                  "licensePath": "./LICENSE.txt",
+                  "source": "fa-solid-900.eot",
+                  "sources": Array [
+                    Object {
+                      "format": "embedded-opentype",
+                      "path": "fa-solid-900.eot",
+                      "urlAddition": "?#iefix",
+                    },
+                    Object {
+                      "format": "woff2",
+                      "path": "fa-solid-900.woff2",
+                    },
+                    Object {
+                      "format": "woff",
+                      "path": "fa-solid-900.woff",
+                    },
+                    Object {
+                      "format": "truetype",
+                      "path": "fa-solid-900.ttf",
+                    },
+                    Object {
+                      "format": "svg",
+                      "path": "fa-solid-900.svg",
+                      "urlAddition": "#fontawesome",
+                    },
+                  ],
+                },
+              ],
+              "label": "Font Awesome Solid",
+              "name": "fontawesome-solid",
+              "npmModule": "@fortawesome/fontawesome-free",
+              "type": 0,
+            },
+            "iconColor": [Function],
+            "styles": [Function],
+          },
+          "icons": Object {
+            "config": Object {
+              "cssFiles": Array [
+                "css/all.css",
+              ],
+              "fonts": Array [
+                Object {
+                  "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+                  "fontsPath": "./webfonts",
+                  "licensePath": "./LICENSE.txt",
+                  "source": "fa-solid-900.eot",
+                  "sources": Array [
+                    Object {
+                      "format": "embedded-opentype",
+                      "path": "fa-solid-900.eot",
+                      "urlAddition": "?#iefix",
+                    },
+                    Object {
+                      "format": "woff2",
+                      "path": "fa-solid-900.woff2",
+                    },
+                    Object {
+                      "format": "woff",
+                      "path": "fa-solid-900.woff",
+                    },
+                    Object {
+                      "format": "truetype",
+                      "path": "fa-solid-900.ttf",
+                    },
+                    Object {
+                      "format": "svg",
+                      "path": "fa-solid-900.svg",
+                      "urlAddition": "#fontawesome",
+                    },
+                  ],
+                },
+              ],
+              "label": "Font Awesome Solid",
+              "name": "fontawesome-solid",
+              "npmModule": "@fortawesome/fontawesome-free",
+              "type": 0,
+            },
+            "iconColor": [Function],
+            "styles": [Function],
+          },
+          "label": "SDK Default",
+          "licenses": Array [
+            "fonts/Raleway/OFL.txt",
+          ],
+          "localFonts": Object {
+            "fonts/Raleway/Raleway-ExtraBold": [Function],
+            "fonts/Raleway/Raleway-Medium": [Function],
+          },
+          "mixins": Object {
+            "gutters": [Function],
+            "toolbar": Object {
+              "@media (min-width:0px) and (orientation: landscape)": Object {
+                "minHeight": 48,
+              },
+              "@media (min-width:600px)": Object {
+                "minHeight": 64,
+              },
+              "minHeight": 56,
+            },
+          },
+          "name": "sdk-default",
+          "overrides": Object {},
+          "palette": Object {
+            "action": Object {
+              "activatedOpacity": 0.12,
+              "active": "rgba(0, 0, 0, 0.54)",
+              "disabled": "rgba(0, 0, 0, 0.26)",
+              "disabledBackground": "rgba(0, 0, 0, 0.12)",
+              "disabledOpacity": 0.38,
+              "focus": "rgba(0, 0, 0, 0.12)",
+              "focusOpacity": 0.12,
+              "hover": "rgba(0, 0, 0, 0.04)",
+              "hoverOpacity": 0.04,
+              "selected": "rgba(0, 0, 0, 0.08)",
+              "selectedOpacity": 0.08,
+            },
+            "adjustAlpha": [Function],
+            "augmentColor": [Function],
+            "background": Object {
+              "default": "#FFFFFF",
+              "paper": "#fff",
+            },
+            "common": Object {
+              "black": "#000",
+              "white": "#fff",
+            },
+            "contrastThreshold": 3,
+            "divider": "rgba(0, 0, 0, 0.12)",
+            "error": Object {
+              "contrastText": "#fff",
+              "dark": "#d32f2f",
+              "light": "#e57373",
+              "main": "#f44336",
+            },
+            "getContrastText": [Function],
+            "grey": Object {
+              "100": "#f5f5f5",
+              "200": "#eeeeee",
+              "300": "#e0e0e0",
+              "400": "#bdbdbd",
+              "50": "#fafafa",
+              "500": "#9e9e9e",
+              "600": "#757575",
+              "700": "#616161",
+              "800": "#424242",
+              "900": "#212121",
+              "A100": "#d5d5d5",
+              "A200": "#aaaaaa",
+              "A400": "#303030",
+              "A700": "#616161",
+            },
+            "info": Object {
+              "contrastText": "#fff",
+              "dark": "#1976d2",
+              "light": "#64b5f6",
+              "main": "#2196f3",
+            },
+            "primary": Object {
+              "contrastText": "#fff",
+              "dark": "rgb(86, 53, 178)",
+              "light": "rgb(150, 112, 255)",
+              "main": "#7C4DFF",
+            },
+            "secondary": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#083575",
+              "light": "#01C9EA",
+              "main": "#18A9E6",
+            },
+            "success": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#388e3c",
+              "light": "#81c784",
+              "main": "#4caf50",
+            },
+            "text": Object {
+              "disabled": "rgba(0, 0, 0, 0.38)",
+              "hint": "rgba(0, 0, 0, 0.38)",
+              "primary": "#4E4E4E",
+              "secondary": "#4E4E4E",
+            },
+            "tonalOffset": 0.2,
+            "type": "light",
+            "warning": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#f57c00",
+              "light": "#ffb74d",
+              "main": "#ff9800",
+            },
+          },
+          "props": Object {},
+          "shadows": Array [
+            "none",
+            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+          ],
+          "shape": Object {
+            "borderRadius": 4,
+          },
+          "spacing": [Function],
+          "stylesheets": Array [
+            "https://fonts.googleapis.com/css?family=Raleway:500,800&display=swap",
+          ],
+          "transitions": Object {
+            "create": [Function],
+            "duration": Object {
+              "complex": 375,
+              "enteringScreen": 225,
+              "leavingScreen": 195,
+              "short": 250,
+              "shorter": 200,
+              "shortest": 150,
+              "standard": 300,
+            },
+            "easing": Object {
+              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+            },
+            "getAutoHeightDuration": [Function],
+          },
+          "typography": Object {
+            "body": Object {
+              "fontFamily": "\\"Raleway-Medium\\"",
+              "fontSize": "0.9375rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.01071em",
+              "lineHeight": 1.43,
+            },
+            "body1": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.5,
+            },
+            "body2": Object {
+              "fontFamily": "\\"Raleway-Medium\\"",
+              "fontSize": "0.9375rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.01071em",
+              "lineHeight": 1.43,
+            },
+            "button": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.875rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.02857em",
+              "lineHeight": 1.75,
+              "textTransform": "uppercase",
+            },
+            "caption": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.03333em",
+              "lineHeight": 1.66,
+            },
+            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+            "fontSize": 14,
+            "fontWeightBold": 800,
+            "fontWeightLight": 500,
+            "fontWeightMedium": 500,
+            "fontWeightRegular": 400,
+            "h1": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.375rem",
+              "fontWeight": 800,
+              "letterSpacing": "-0.01562em",
+              "lineHeight": 1.45,
+            },
+            "h2": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.125rem",
+              "fontWeight": 800,
+              "letterSpacing": "-0.00833em",
+              "lineHeight": 1.27,
+            },
+            "h3": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.05rem",
+              "fontWeight": 800,
+              "letterSpacing": "0em",
+              "lineHeight": 1.2,
+            },
+            "h4": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00735em",
+              "lineHeight": 1.1,
+            },
+            "h5": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0em",
+              "lineHeight": 1,
+            },
+            "h6": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "0.625rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.0075em",
+              "lineHeight": 1,
+            },
+            "heading": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.5,
+            },
+            "htmlFontSize": 16,
+            "overline": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.08333em",
+              "lineHeight": 2.66,
+              "textTransform": "uppercase",
+            },
+            "pxToRem": [Function],
+            "round": [Function],
+            "subtitle1": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.75,
+            },
+            "subtitle2": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.875rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.00714em",
+              "lineHeight": 1.57,
+            },
+          },
+          "zIndex": Object {
+            "appBar": 1100,
+            "drawer": 1200,
+            "mobileStepper": 1000,
+            "modal": 1300,
+            "snackbar": 1400,
+            "speedDial": 1050,
+            "tooltip": 1500,
+          },
+          Symbol(mui.nested): false,
+        }
+      }
+    >
+      <ResourceDetails
+        resource={
+          Object {
+            "iri": "/Some%20Resource",
+            "name": "Name",
+            "types": Array [
+              "Resource",
+            ],
+          }
+        }
+      >
+        <section
+          className="PodBrowser-headerSection"
+        >
+          <h3
+            className="PodBrowser-content-h3"
+            title="/Some%20Resource"
+          >
+            Some Resource
+          </h3>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <h5
+            className="PodBrowser-content-h5"
+          >
+            Actions
+          </h5>
+          <WithStyles(ForwardRef(List))>
+            <ForwardRef(List)
+              classes={
+                Object {
+                  "dense": "PodBrowser-dense",
+                  "padding": "PodBrowser-padding",
+                  "root": "PodBrowser-root",
+                  "subheader": "PodBrowser-subheader",
+                }
+              }
+            >
+              <ul
+                className="PodBrowser-root PodBrowser-padding"
+              >
+                <WithStyles(ForwardRef(ListItem))
+                  button={true}
+                  component={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "render": [Function],
+                    }
+                  }
+                  resourceIri="/Some%20Resource"
+                >
+                  <ForwardRef(ListItem)
+                    button={true}
+                    classes={
+                      Object {
+                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                        "button": "PodBrowser-button",
+                        "container": "PodBrowser-container",
+                        "dense": "PodBrowser-dense",
+                        "disabled": "PodBrowser-disabled",
+                        "divider": "PodBrowser-divider",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "gutters": "PodBrowser-gutters",
+                        "root": "PodBrowser-root",
+                        "secondaryAction": "PodBrowser-secondaryAction",
+                        "selected": "PodBrowser-selected",
+                      }
+                    }
+                    component={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      }
+                    }
+                    resourceIri="/Some%20Resource"
+                  >
+                    <WithStyles(ForwardRef(ButtonBase))
+                      className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                      component={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      focusVisibleClassName="PodBrowser-focusVisible"
+                      resourceIri="/Some%20Resource"
+                    >
+                      <ForwardRef(ButtonBase)
+                        className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                        classes={
+                          Object {
+                            "disabled": "PodBrowser-disabled",
+                            "focusVisible": "PodBrowser-focusVisible",
+                            "root": "PodBrowser-root",
+                          }
+                        }
+                        component={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "render": [Function],
+                          }
+                        }
+                        disabled={false}
+                        focusVisibleClassName="PodBrowser-focusVisible"
+                        resourceIri="/Some%20Resource"
+                      >
+                        <ForwardRef
+                          aria-disabled={false}
+                          className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                          onBlur={[Function]}
+                          onDragLeave={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          resourceIri="/Some%20Resource"
+                          role="button"
+                          tabIndex={0}
+                        >
+                          <ResourceLink
+                            action="sharing"
+                            aria-disabled={false}
+                            className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                            onBlur={[Function]}
+                            onDragLeave={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            resourceIri="/Some%20Resource"
+                            role="button"
+                            tabIndex={0}
+                          >
+                            <Link
+                              as={
+                                Object {
+                                  "pathname": "/resource/[iri]",
+                                  "query": Object {
+                                    "action": "sharing",
+                                    "resourceIri": "/Some%20Resource",
+                                  },
+                                }
+                              }
+                              href={
+                                Object {
+                                  "pathname": "/resource/[iri]",
+                                  "query": Object {
+                                    "action": "sharing",
+                                    "resourceIri": "/Some%20Resource",
+                                  },
+                                }
+                              }
+                              replace={true}
+                            >
+                              <a
+                                aria-disabled={false}
+                                className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                                href="/resource/[iri]?action=sharing&resourceIri=%2FSome%2520Resource"
+                                onBlur={[Function]}
+                                onClick={[Function]}
+                                onDragLeave={[Function]}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onKeyUp={[Function]}
+                                onMouseDown={[Function]}
+                                onMouseEnter={[Function]}
+                                onMouseLeave={[Function]}
+                                onMouseUp={[Function]}
+                                onTouchEnd={[Function]}
+                                onTouchMove={[Function]}
+                                onTouchStart={[Function]}
+                                role="button"
+                                tabIndex={0}
+                              >
+                                <WithStyles(ForwardRef(ListItemIcon))
+                                  key=".0"
+                                >
+                                  <ForwardRef(ListItemIcon)
+                                    classes={
+                                      Object {
+                                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <div
+                                      className="PodBrowser-root"
+                                    >
+                                      <ForwardRef>
+                                        <WithStyles(ForwardRef(SvgIcon))>
+                                          <ForwardRef(SvgIcon)
+                                            classes={
+                                              Object {
+                                                "colorAction": "PodBrowser-colorAction",
+                                                "colorDisabled": "PodBrowser-colorDisabled",
+                                                "colorError": "PodBrowser-colorError",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                                "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                                "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                "root": "PodBrowser-root",
+                                              }
+                                            }
+                                          >
+                                            <svg
+                                              aria-hidden={true}
+                                              className="PodBrowser-root"
+                                              focusable="false"
+                                              viewBox="0 0 24 24"
+                                            >
+                                              <path
+                                                d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92 1.61 0 2.92-1.31 2.92-2.92s-1.31-2.92-2.92-2.92z"
+                                              />
+                                            </svg>
+                                          </ForwardRef(SvgIcon)>
+                                        </WithStyles(ForwardRef(SvgIcon))>
+                                      </ForwardRef>
+                                    </div>
+                                  </ForwardRef(ListItemIcon)>
+                                </WithStyles(ForwardRef(ListItemIcon))>
+                                <WithStyles(ForwardRef(ListItemText))
+                                  key=".1"
+                                  primary="Sharing & App Permissions"
+                                >
+                                  <ForwardRef(ListItemText)
+                                    classes={
+                                      Object {
+                                        "dense": "PodBrowser-dense",
+                                        "inset": "PodBrowser-inset",
+                                        "multiline": "PodBrowser-multiline",
+                                        "primary": "PodBrowser-primary",
+                                        "root": "PodBrowser-root",
+                                        "secondary": "PodBrowser-secondary",
+                                      }
+                                    }
+                                    primary="Sharing & App Permissions"
+                                  >
+                                    <div
+                                      className="PodBrowser-root"
+                                    >
+                                      <WithStyles(ForwardRef(Typography))
+                                        className="PodBrowser-primary"
+                                        component="span"
+                                        display="block"
+                                        variant="body1"
+                                      >
+                                        <ForwardRef(Typography)
+                                          className="PodBrowser-primary"
+                                          classes={
+                                            Object {
+                                              "alignCenter": "PodBrowser-alignCenter",
+                                              "alignJustify": "PodBrowser-alignJustify",
+                                              "alignLeft": "PodBrowser-alignLeft",
+                                              "alignRight": "PodBrowser-alignRight",
+                                              "body1": "PodBrowser-body1",
+                                              "body2": "PodBrowser-body2",
+                                              "button": "PodBrowser-button",
+                                              "caption": "PodBrowser-caption",
+                                              "colorError": "PodBrowser-colorError",
+                                              "colorInherit": "PodBrowser-colorInherit",
+                                              "colorPrimary": "PodBrowser-colorPrimary",
+                                              "colorSecondary": "PodBrowser-colorSecondary",
+                                              "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                              "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                              "displayBlock": "PodBrowser-displayBlock",
+                                              "displayInline": "PodBrowser-displayInline",
+                                              "gutterBottom": "PodBrowser-gutterBottom",
+                                              "h1": "PodBrowser-h1",
+                                              "h2": "PodBrowser-h2",
+                                              "h3": "PodBrowser-h3",
+                                              "h4": "PodBrowser-h4",
+                                              "h5": "PodBrowser-h5",
+                                              "h6": "PodBrowser-h6",
+                                              "noWrap": "PodBrowser-noWrap",
+                                              "overline": "PodBrowser-overline",
+                                              "paragraph": "PodBrowser-paragraph",
+                                              "root": "PodBrowser-root",
+                                              "srOnly": "PodBrowser-srOnly",
+                                              "subtitle1": "PodBrowser-subtitle1",
+                                              "subtitle2": "PodBrowser-subtitle2",
+                                            }
+                                          }
+                                          component="span"
+                                          display="block"
+                                          variant="body1"
+                                        >
+                                          <span
+                                            className="PodBrowser-root PodBrowser-primary PodBrowser-body1 PodBrowser-displayBlock"
+                                          >
+                                            Sharing & App Permissions
+                                          </span>
+                                        </ForwardRef(Typography)>
+                                      </WithStyles(ForwardRef(Typography))>
+                                    </div>
+                                  </ForwardRef(ListItemText)>
+                                </WithStyles(ForwardRef(ListItemText))>
+                                <WithStyles(memo)
+                                  center={false}
+                                >
+                                  <ForwardRef(TouchRipple)
+                                    center={false}
+                                    classes={
+                                      Object {
+                                        "child": "PodBrowser-child",
+                                        "childLeaving": "PodBrowser-childLeaving",
+                                        "childPulsate": "PodBrowser-childPulsate",
+                                        "ripple": "PodBrowser-ripple",
+                                        "ripplePulsate": "PodBrowser-ripplePulsate",
+                                        "rippleVisible": "PodBrowser-rippleVisible",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="PodBrowser-root"
+                                    >
+                                      <TransitionGroup
+                                        childFactory={[Function]}
+                                        component={null}
+                                        exit={true}
+                                      />
+                                    </span>
+                                  </ForwardRef(TouchRipple)>
+                                </WithStyles(memo)>
+                              </a>
+                            </Link>
+                          </ResourceLink>
+                        </ForwardRef>
+                      </ForwardRef(ButtonBase)>
+                    </WithStyles(ForwardRef(ButtonBase))>
+                  </ForwardRef(ListItem)>
+                </WithStyles(ForwardRef(ListItem))>
+                <WithStyles(ForwardRef(ListItem))
+                  button={true}
+                  component={
+                    Object {
+                      "$$typeof": Symbol(react.forward_ref),
+                      "render": [Function],
+                    }
+                  }
+                  name="Name"
+                  resourceIri="/Some%20Resource"
+                >
+                  <ForwardRef(ListItem)
+                    button={true}
+                    classes={
+                      Object {
+                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                        "button": "PodBrowser-button",
+                        "container": "PodBrowser-container",
+                        "dense": "PodBrowser-dense",
+                        "disabled": "PodBrowser-disabled",
+                        "divider": "PodBrowser-divider",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "gutters": "PodBrowser-gutters",
+                        "root": "PodBrowser-root",
+                        "secondaryAction": "PodBrowser-secondaryAction",
+                        "selected": "PodBrowser-selected",
+                      }
+                    }
+                    component={
+                      Object {
+                        "$$typeof": Symbol(react.forward_ref),
+                        "render": [Function],
+                      }
+                    }
+                    name="Name"
+                    resourceIri="/Some%20Resource"
+                  >
+                    <WithStyles(ForwardRef(ButtonBase))
+                      className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                      component={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "render": [Function],
+                        }
+                      }
+                      disabled={false}
+                      focusVisibleClassName="PodBrowser-focusVisible"
+                      name="Name"
+                      resourceIri="/Some%20Resource"
+                    >
+                      <ForwardRef(ButtonBase)
+                        className="PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                        classes={
+                          Object {
+                            "disabled": "PodBrowser-disabled",
+                            "focusVisible": "PodBrowser-focusVisible",
+                            "root": "PodBrowser-root",
+                          }
+                        }
+                        component={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "render": [Function],
+                          }
+                        }
+                        disabled={false}
+                        focusVisibleClassName="PodBrowser-focusVisible"
+                        name="Name"
+                        resourceIri="/Some%20Resource"
+                      >
+                        <ForwardRef
+                          aria-disabled={false}
+                          className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                          name="Name"
+                          onBlur={[Function]}
+                          onDragLeave={[Function]}
+                          onFocus={[Function]}
+                          onKeyDown={[Function]}
+                          onKeyUp={[Function]}
+                          onMouseDown={[Function]}
+                          onMouseLeave={[Function]}
+                          onMouseUp={[Function]}
+                          onTouchEnd={[Function]}
+                          onTouchMove={[Function]}
+                          onTouchStart={[Function]}
+                          resourceIri="/Some%20Resource"
+                          role="button"
+                          tabIndex={0}
+                        >
+                          <a
+                            aria-disabled={false}
+                            className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+                            href="#delete"
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragLeave={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            role="button"
+                            tabIndex={0}
+                          >
+                            <WithStyles(ForwardRef(ListItemIcon))
+                              key=".0"
+                            >
+                              <ForwardRef(ListItemIcon)
+                                classes={
+                                  Object {
+                                    "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                    "root": "PodBrowser-root",
+                                  }
+                                }
+                              >
+                                <div
+                                  className="PodBrowser-root"
+                                >
+                                  <ForwardRef>
+                                    <WithStyles(ForwardRef(SvgIcon))>
+                                      <ForwardRef(SvgIcon)
+                                        classes={
+                                          Object {
+                                            "colorAction": "PodBrowser-colorAction",
+                                            "colorDisabled": "PodBrowser-colorDisabled",
+                                            "colorError": "PodBrowser-colorError",
+                                            "colorPrimary": "PodBrowser-colorPrimary",
+                                            "colorSecondary": "PodBrowser-colorSecondary",
+                                            "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                            "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                            "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                            "root": "PodBrowser-root",
+                                          }
+                                        }
+                                      >
+                                        <svg
+                                          aria-hidden={true}
+                                          className="PodBrowser-root"
+                                          focusable="false"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                                          />
+                                        </svg>
+                                      </ForwardRef(SvgIcon)>
+                                    </WithStyles(ForwardRef(SvgIcon))>
+                                  </ForwardRef>
+                                </div>
+                              </ForwardRef(ListItemIcon)>
+                            </WithStyles(ForwardRef(ListItemIcon))>
+                            <WithStyles(ForwardRef(ListItemText))
+                              key=".1"
+                              primary="Delete"
+                            >
+                              <ForwardRef(ListItemText)
+                                classes={
+                                  Object {
+                                    "dense": "PodBrowser-dense",
+                                    "inset": "PodBrowser-inset",
+                                    "multiline": "PodBrowser-multiline",
+                                    "primary": "PodBrowser-primary",
+                                    "root": "PodBrowser-root",
+                                    "secondary": "PodBrowser-secondary",
+                                  }
+                                }
+                                primary="Delete"
+                              >
+                                <div
+                                  className="PodBrowser-root"
+                                >
+                                  <WithStyles(ForwardRef(Typography))
+                                    className="PodBrowser-primary"
+                                    component="span"
+                                    display="block"
+                                    variant="body1"
+                                  >
+                                    <ForwardRef(Typography)
+                                      className="PodBrowser-primary"
+                                      classes={
+                                        Object {
+                                          "alignCenter": "PodBrowser-alignCenter",
+                                          "alignJustify": "PodBrowser-alignJustify",
+                                          "alignLeft": "PodBrowser-alignLeft",
+                                          "alignRight": "PodBrowser-alignRight",
+                                          "body1": "PodBrowser-body1",
+                                          "body2": "PodBrowser-body2",
+                                          "button": "PodBrowser-button",
+                                          "caption": "PodBrowser-caption",
+                                          "colorError": "PodBrowser-colorError",
+                                          "colorInherit": "PodBrowser-colorInherit",
+                                          "colorPrimary": "PodBrowser-colorPrimary",
+                                          "colorSecondary": "PodBrowser-colorSecondary",
+                                          "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                          "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                          "displayBlock": "PodBrowser-displayBlock",
+                                          "displayInline": "PodBrowser-displayInline",
+                                          "gutterBottom": "PodBrowser-gutterBottom",
+                                          "h1": "PodBrowser-h1",
+                                          "h2": "PodBrowser-h2",
+                                          "h3": "PodBrowser-h3",
+                                          "h4": "PodBrowser-h4",
+                                          "h5": "PodBrowser-h5",
+                                          "h6": "PodBrowser-h6",
+                                          "noWrap": "PodBrowser-noWrap",
+                                          "overline": "PodBrowser-overline",
+                                          "paragraph": "PodBrowser-paragraph",
+                                          "root": "PodBrowser-root",
+                                          "srOnly": "PodBrowser-srOnly",
+                                          "subtitle1": "PodBrowser-subtitle1",
+                                          "subtitle2": "PodBrowser-subtitle2",
+                                        }
+                                      }
+                                      component="span"
+                                      display="block"
+                                      variant="body1"
+                                    >
+                                      <span
+                                        className="PodBrowser-root PodBrowser-primary PodBrowser-body1 PodBrowser-displayBlock"
+                                      >
+                                        Delete
+                                      </span>
+                                    </ForwardRef(Typography)>
+                                  </WithStyles(ForwardRef(Typography))>
+                                </div>
+                              </ForwardRef(ListItemText)>
+                            </WithStyles(ForwardRef(ListItemText))>
+                            <WithStyles(memo)
+                              center={false}
+                            >
+                              <ForwardRef(TouchRipple)
+                                center={false}
+                                classes={
+                                  Object {
+                                    "child": "PodBrowser-child",
+                                    "childLeaving": "PodBrowser-childLeaving",
+                                    "childPulsate": "PodBrowser-childPulsate",
+                                    "ripple": "PodBrowser-ripple",
+                                    "ripplePulsate": "PodBrowser-ripplePulsate",
+                                    "rippleVisible": "PodBrowser-rippleVisible",
+                                    "root": "PodBrowser-root",
+                                  }
+                                }
+                              >
+                                <span
+                                  className="PodBrowser-root"
+                                >
+                                  <TransitionGroup
+                                    childFactory={[Function]}
+                                    component={null}
+                                    exit={true}
+                                  />
+                                </span>
+                              </ForwardRef(TouchRipple)>
+                            </WithStyles(memo)>
+                          </a>
+                        </ForwardRef>
+                      </ForwardRef(ButtonBase)>
+                    </WithStyles(ForwardRef(ButtonBase))>
+                  </ForwardRef(ListItem)>
+                </WithStyles(ForwardRef(ListItem))>
+              </ul>
+            </ForwardRef(List)>
+          </WithStyles(ForwardRef(List))>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <h5
+            className="PodBrowser-content-h5"
+          >
+            Details
+          </h5>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <WithStyles(ForwardRef(List))>
+            <ForwardRef(List)
+              classes={
+                Object {
+                  "dense": "PodBrowser-dense",
+                  "padding": "PodBrowser-padding",
+                  "root": "PodBrowser-root",
+                  "subheader": "PodBrowser-subheader",
+                }
+              }
+            >
+              <ul
+                className="PodBrowser-root PodBrowser-padding"
+              >
+                <WithStyles(ForwardRef(ListItem))
+                  className="PodBrowser-listItem"
+                >
+                  <ForwardRef(ListItem)
+                    className="PodBrowser-listItem"
+                    classes={
+                      Object {
+                        "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                        "button": "PodBrowser-button",
+                        "container": "PodBrowser-container",
+                        "dense": "PodBrowser-dense",
+                        "disabled": "PodBrowser-disabled",
+                        "divider": "PodBrowser-divider",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "gutters": "PodBrowser-gutters",
+                        "root": "PodBrowser-root",
+                        "secondaryAction": "PodBrowser-secondaryAction",
+                        "selected": "PodBrowser-selected",
+                      }
+                    }
+                  >
+                    <li
+                      className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
+                      disabled={false}
+                    >
+                      <WithStyles(ForwardRef(Typography))
+                        className="PodBrowser-detailText"
+                        key=".0"
+                      >
+                        <ForwardRef(Typography)
+                          className="PodBrowser-detailText"
+                          classes={
+                            Object {
+                              "alignCenter": "PodBrowser-alignCenter",
+                              "alignJustify": "PodBrowser-alignJustify",
+                              "alignLeft": "PodBrowser-alignLeft",
+                              "alignRight": "PodBrowser-alignRight",
+                              "body1": "PodBrowser-body1",
+                              "body2": "PodBrowser-body2",
+                              "button": "PodBrowser-button",
+                              "caption": "PodBrowser-caption",
+                              "colorError": "PodBrowser-colorError",
+                              "colorInherit": "PodBrowser-colorInherit",
+                              "colorPrimary": "PodBrowser-colorPrimary",
+                              "colorSecondary": "PodBrowser-colorSecondary",
+                              "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                              "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                              "displayBlock": "PodBrowser-displayBlock",
+                              "displayInline": "PodBrowser-displayInline",
+                              "gutterBottom": "PodBrowser-gutterBottom",
+                              "h1": "PodBrowser-h1",
+                              "h2": "PodBrowser-h2",
+                              "h3": "PodBrowser-h3",
+                              "h4": "PodBrowser-h4",
+                              "h5": "PodBrowser-h5",
+                              "h6": "PodBrowser-h6",
+                              "noWrap": "PodBrowser-noWrap",
+                              "overline": "PodBrowser-overline",
+                              "paragraph": "PodBrowser-paragraph",
+                              "root": "PodBrowser-root",
+                              "srOnly": "PodBrowser-srOnly",
+                              "subtitle1": "PodBrowser-subtitle1",
+                              "subtitle2": "PodBrowser-subtitle2",
+                            }
+                          }
+                        >
+                          <p
+                            className="PodBrowser-root PodBrowser-detailText PodBrowser-body1"
+                          >
+                            Thing Type:
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                      <WithStyles(ForwardRef(Typography))
+                        className="PodBrowser-typeValue PodBrowser-detailText"
+                        key=".1"
+                      >
+                        <ForwardRef(Typography)
+                          className="PodBrowser-typeValue PodBrowser-detailText"
+                          classes={
+                            Object {
+                              "alignCenter": "PodBrowser-alignCenter",
+                              "alignJustify": "PodBrowser-alignJustify",
+                              "alignLeft": "PodBrowser-alignLeft",
+                              "alignRight": "PodBrowser-alignRight",
+                              "body1": "PodBrowser-body1",
+                              "body2": "PodBrowser-body2",
+                              "button": "PodBrowser-button",
+                              "caption": "PodBrowser-caption",
+                              "colorError": "PodBrowser-colorError",
+                              "colorInherit": "PodBrowser-colorInherit",
+                              "colorPrimary": "PodBrowser-colorPrimary",
+                              "colorSecondary": "PodBrowser-colorSecondary",
+                              "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                              "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                              "displayBlock": "PodBrowser-displayBlock",
+                              "displayInline": "PodBrowser-displayInline",
+                              "gutterBottom": "PodBrowser-gutterBottom",
+                              "h1": "PodBrowser-h1",
+                              "h2": "PodBrowser-h2",
+                              "h3": "PodBrowser-h3",
+                              "h4": "PodBrowser-h4",
+                              "h5": "PodBrowser-h5",
+                              "h6": "PodBrowser-h6",
+                              "noWrap": "PodBrowser-noWrap",
+                              "overline": "PodBrowser-overline",
+                              "paragraph": "PodBrowser-paragraph",
+                              "root": "PodBrowser-root",
+                              "srOnly": "PodBrowser-srOnly",
+                              "subtitle1": "PodBrowser-subtitle1",
+                              "subtitle2": "PodBrowser-subtitle2",
+                            }
+                          }
+                        >
+                          <p
+                            className="PodBrowser-root PodBrowser-typeValue PodBrowser-detailText PodBrowser-body1"
+                          >
+                            Resource
+                          </p>
+                        </ForwardRef(Typography)>
+                      </WithStyles(ForwardRef(Typography))>
+                    </li>
+                  </ForwardRef(ListItem)>
+                </WithStyles(ForwardRef(ListItem))>
+              </ul>
+            </ForwardRef(List)>
+          </WithStyles(ForwardRef(List))>
+        </section>
+        <WithStyles(ForwardRef(Divider))>
+          <ForwardRef(Divider)
+            classes={
+              Object {
+                "absolute": "PodBrowser-absolute",
+                "flexItem": "PodBrowser-flexItem",
+                "inset": "PodBrowser-inset",
+                "light": "PodBrowser-light",
+                "middle": "PodBrowser-middle",
+                "root": "PodBrowser-root",
+                "vertical": "PodBrowser-vertical",
+              }
+            }
+          >
+            <hr
+              className="PodBrowser-root"
+            />
+          </ForwardRef(Divider)>
+        </WithStyles(ForwardRef(Divider))>
+        <section
+          className="PodBrowser-centeredSection"
+        >
+          <DownloadLink
+            className="PodBrowser-downloadButton"
+            iri="/Some%20Resource"
+            type="Resource"
+          >
+            <WithStyles(ForwardRef(Button))
+              className="PodBrowser-downloadButton"
+              onClick={[Function]}
+              variant="contained"
+            >
+              <ForwardRef(Button)
+                className="PodBrowser-downloadButton"
+                classes={
+                  Object {
+                    "colorInherit": "PodBrowser-colorInherit",
+                    "contained": "PodBrowser-contained",
+                    "containedPrimary": "PodBrowser-containedPrimary",
+                    "containedSecondary": "PodBrowser-containedSecondary",
+                    "containedSizeLarge": "PodBrowser-containedSizeLarge",
+                    "containedSizeSmall": "PodBrowser-containedSizeSmall",
+                    "disableElevation": "PodBrowser-disableElevation",
+                    "disabled": "PodBrowser-disabled",
+                    "endIcon": "PodBrowser-endIcon",
+                    "focusVisible": "PodBrowser-focusVisible",
+                    "fullWidth": "PodBrowser-fullWidth",
+                    "iconSizeLarge": "PodBrowser-iconSizeLarge",
+                    "iconSizeMedium": "PodBrowser-iconSizeMedium",
+                    "iconSizeSmall": "PodBrowser-iconSizeSmall",
+                    "label": "PodBrowser-label",
+                    "outlined": "PodBrowser-outlined",
+                    "outlinedPrimary": "PodBrowser-outlinedPrimary",
+                    "outlinedSecondary": "PodBrowser-outlinedSecondary",
+                    "outlinedSizeLarge": "PodBrowser-outlinedSizeLarge",
+                    "outlinedSizeSmall": "PodBrowser-outlinedSizeSmall",
+                    "root": "PodBrowser-root",
+                    "sizeLarge": "PodBrowser-sizeLarge",
+                    "sizeSmall": "PodBrowser-sizeSmall",
+                    "startIcon": "PodBrowser-startIcon",
+                    "text": "PodBrowser-text",
+                    "textPrimary": "PodBrowser-textPrimary",
+                    "textSecondary": "PodBrowser-textSecondary",
+                    "textSizeLarge": "PodBrowser-textSizeLarge",
+                    "textSizeSmall": "PodBrowser-textSizeSmall",
+                  }
+                }
+                onClick={[Function]}
+                variant="contained"
+              >
+                <WithStyles(ForwardRef(ButtonBase))
+                  className="PodBrowser-root PodBrowser-contained PodBrowser-downloadButton"
+                  component="button"
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="PodBrowser-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(ButtonBase)
+                    className="PodBrowser-root PodBrowser-contained PodBrowser-downloadButton"
+                    classes={
+                      Object {
+                        "disabled": "PodBrowser-disabled",
+                        "focusVisible": "PodBrowser-focusVisible",
+                        "root": "PodBrowser-root",
+                      }
+                    }
+                    component="button"
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="PodBrowser-focusVisible"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="PodBrowser-root PodBrowser-root PodBrowser-contained PodBrowser-downloadButton"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onDragLeave={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="PodBrowser-label"
+                      >
+                        Download
+                      </span>
+                      <WithStyles(memo)
+                        center={false}
+                      >
+                        <ForwardRef(TouchRipple)
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "PodBrowser-child",
+                              "childLeaving": "PodBrowser-childLeaving",
+                              "childPulsate": "PodBrowser-childPulsate",
+                              "ripple": "PodBrowser-ripple",
+                              "ripplePulsate": "PodBrowser-ripplePulsate",
+                              "rippleVisible": "PodBrowser-rippleVisible",
+                              "root": "PodBrowser-root",
+                            }
+                          }
+                        >
+                          <span
+                            className="PodBrowser-root"
+                          >
+                            <TransitionGroup
+                              childFactory={[Function]}
+                              component={null}
+                              exit={true}
+                            />
+                          </span>
+                        </ForwardRef(TouchRipple)>
+                      </WithStyles(memo)>
+                    </button>
+                  </ForwardRef(ButtonBase)>
+                </WithStyles(ForwardRef(ButtonBase))>
+              </ForwardRef(Button)>
+            </WithStyles(ForwardRef(Button))>
+          </DownloadLink>
+        </section>
+      </ResourceDetails>
+    </ThemeProvider>
+  </StylesProvider>
+</WithTheme>
+`;
+
 exports[`Resource details it renders container details 1`] = `
 <WithTheme
   theme={

--- a/components/resourceDetails/__snapshots__/index.test.tsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.tsx.snap
@@ -869,7 +869,7 @@ font-display: block;",
             className="PodBrowser-content-h3"
             title="/container/"
           >
-            Name
+            container
           </h3>
         </section>
         <WithStyles(ForwardRef(Divider))>
@@ -2569,7 +2569,7 @@ font-display: block;",
             className="PodBrowser-content-h3"
             title="/resource"
           >
-            Name
+            resource
           </h3>
         </section>
         <WithStyles(ForwardRef(Divider))>

--- a/components/resourceDetails/index.test.tsx
+++ b/components/resourceDetails/index.test.tsx
@@ -50,10 +50,38 @@ describe("Resource details", () => {
     const tree = mountToJson(<ResourceDetails resource={resource} />);
     expect(tree).toMatchSnapshot();
   });
+  test("it renders a decoded cntainer name", () => {
+    const resource = {
+      iri: "/Some%20container/",
+      types: ["Container"],
+      name: "Name",
+    };
+
+    jest
+      .spyOn(Router, "useRouter")
+      .mockReturnValue({ asPath: "/pathname", replace: jest.fn() });
+
+    const tree = mountToJson(<ResourceDetails resource={resource} />);
+    expect(tree).toMatchSnapshot();
+  });
 
   test("it renders resource details", () => {
     const resource = {
       iri: "/resource",
+      types: ["Resource"],
+      name: "Name",
+    };
+
+    jest
+      .spyOn(Router, "useRouter")
+      .mockReturnValue({ asPath: "/pathname", replace: jest.fn() });
+
+    const tree = mountToJson(<ResourceDetails resource={resource} />);
+    expect(tree).toMatchSnapshot();
+  });
+  test("it renders a decoded resource name", () => {
+    const resource = {
+      iri: "/Some%20Resource",
       types: ["Resource"],
       name: "Name",
     };

--- a/components/resourceDetails/index.tsx
+++ b/components/resourceDetails/index.tsx
@@ -39,7 +39,10 @@ import { makeStyles } from "@material-ui/styles";
 import { PrismTheme } from "@solid/lit-prism-patterns";
 import ResourceLink from "../resourceLink";
 import styles from "./styles";
-import { IResourceDetails } from "../../src/solidClientHelpers";
+import {
+  getResourceName,
+  IResourceDetails,
+} from "../../src/solidClientHelpers";
 import { parseUrl } from "../../src/stringHelpers";
 import SessionContext from "../../src/contexts/sessionContext";
 import { DETAILS_CONTEXT_ACTIONS } from "../../src/contexts/detailsMenuContext";
@@ -127,12 +130,13 @@ export default function ResourceDetails({
   const classes = useStyles();
   const { iri, name, types } = resource;
   const type = displayType(types);
+  const displayName = getResourceName(iri);
 
   return (
     <>
       <section className={classes.headerSection}>
         <h3 className={classes["content-h3"]} title={iri}>
-          {name}
+          {displayName}
         </h3>
       </section>
 


### PR DESCRIPTION
This PR changes the display names for resources in the Resource Details from the encoded full path name to just the decoded name of the resource, matching the displayed names in the Files container/list:

![image](https://user-images.githubusercontent.com/28412960/92935861-ab2f1180-f449-11ea-9f61-6a128c08c61d.png)
 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

