### PR TITLE
Fix/decode special characters

### DIFF
--- a/components/detailsContextMenu/__snapshots__/index.test.jsx.snap
+++ b/components/detailsContextMenu/__snapshots__/index.test.jsx.snap
@@ -2540,7 +2540,7 @@ font-display: block;",
         <DetailsError
           iri="/iri/"
           message="There was an error fetching the details."
-          name="/iri/"
+          name="iri"
         >
           <section
             className="PodBrowser-centeredSection"
@@ -2549,7 +2549,7 @@ font-display: block;",
               className="PodBrowser-content-h3"
               title="/iri/"
             >
-              /iri/
+              iri
             </h3>
           </section>
           <WithStyles(ForwardRef(Divider))>
@@ -3437,7 +3437,7 @@ font-display: block;",
       >
         <DetailsLoading
           iri="/iri/"
-          name="/iri/"
+          name="iri"
           onDelete={[Function]}
           onDeleteError={[Function]}
         >
@@ -3448,7 +3448,7 @@ font-display: block;",
               className="PodBrowser-content-h3"
               title="/iri/"
             >
-              /iri/
+              iri
             </h3>
           </section>
           <WithStyles(ForwardRef(Divider))>
@@ -5121,7 +5121,7 @@ font-display: block;",
           resource={
             Object {
               "iri": "/iri/",
-              "name": "/iri/",
+              "name": "iri",
               "permissions": Array [
                 Object {
                   "acl": Object {
@@ -5502,7 +5502,7 @@ font-display: block;",
                         "render": [Function],
                       }
                     }
-                    name="/iri/"
+                    name="iri"
                     onDelete={[Function]}
                     onDeleteError={[Function]}
                     resourceIri="/iri/"
@@ -5530,7 +5530,7 @@ font-display: block;",
                           "render": [Function],
                         }
                       }
-                      name="/iri/"
+                      name="iri"
                       onDelete={[Function]}
                       onDeleteError={[Function]}
                       resourceIri="/iri/"
@@ -5545,7 +5545,7 @@ font-display: block;",
                         }
                         disabled={false}
                         focusVisibleClassName="PodBrowser-focusVisible"
-                        name="/iri/"
+                        name="iri"
                         onDelete={[Function]}
                         onDeleteError={[Function]}
                         resourceIri="/iri/"
@@ -5567,7 +5567,7 @@ font-display: block;",
                           }
                           disabled={false}
                           focusVisibleClassName="PodBrowser-focusVisible"
-                          name="/iri/"
+                          name="iri"
                           onDelete={[Function]}
                           onDeleteError={[Function]}
                           resourceIri="/iri/"
@@ -5575,7 +5575,7 @@ font-display: block;",
                           <ForwardRef
                             aria-disabled={false}
                             className="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
-                            name="/iri/"
+                            name="iri"
                             onBlur={[Function]}
                             onDelete={[Function]}
                             onDeleteError={[Function]}
@@ -6849,7 +6849,7 @@ font-display: block;",
           dataset={Object {}}
           defaultPermissions={Array []}
           iri="/iri/"
-          name="/iri/"
+          name="iri"
           permissions={
             Array [
               Object {
@@ -7067,7 +7067,7 @@ font-display: block;",
               className="PodBrowser-content-h3"
               title="/iri/"
             >
-              /iri/
+              iri
             </h3>
           </section>
           <WithStyles(ForwardRef(Divider))>
@@ -13161,7 +13161,7 @@ font-display: block;",
       >
         <ResourceSharingLoading
           iri="/iri/"
-          name="/iri/"
+          name="iri"
         >
           <section
             className="PodBrowser-headerSection"
@@ -13326,7 +13326,7 @@ font-display: block;",
               className="PodBrowser-content-h3"
               title="/iri/"
             >
-              /iri/
+              iri
             </h3>
           </section>
           <WithStyles(ForwardRef(Divider))>

--- a/components/detailsContextMenu/index.jsx
+++ b/components/detailsContextMenu/index.jsx
@@ -23,6 +23,7 @@ import React, { useContext, useEffect } from "react";
 import T from "prop-types";
 import { useRouter } from "next/router";
 import { Drawer } from "@inrupt/prism-react-components";
+import { getResourceName } from "../../src/solidClientHelpers";
 import DetailsMenuContext, {
   DETAILS_CONTEXT_ACTIONS,
 } from "../../src/contexts/detailsMenuContext";
@@ -33,11 +34,11 @@ import DetailsError from "../resourceDetails/detailsError";
 import ResourceDetails from "../resourceDetails";
 import ResourceSharing from "../resourceDetails/resourceSharing";
 import { useFetchResourceDetails } from "../../src/hooks/solidClient";
-import { parseUrl, stripQueryParams } from "../../src/stringHelpers";
+import { stripQueryParams } from "../../src/stringHelpers";
 
 function Contents({ action, iri, onUpdate }) {
-  const { pathname } = parseUrl(iri);
   const { data, error } = useFetchResourceDetails(iri);
+  const displayName = getResourceName(iri);
 
   const { setAlertOpen, setMessage, setSeverity } = useContext(AlertContext);
   const errorMessage = "There was an error fetching the details.";
@@ -51,13 +52,13 @@ function Contents({ action, iri, onUpdate }) {
   const loadingComponent =
     action === "details" ? (
       <DetailsLoading
-        name={pathname}
+        name={displayName}
         iri={iri}
         onDelete={onUpdate}
         onDeleteError={onDeleteError}
       />
     ) : (
-      <ResourceSharingLoading name={pathname} iri={iri} />
+      <ResourceSharingLoading name={displayName} iri={iri} />
     );
 
   useEffect(() => {
@@ -69,7 +70,7 @@ function Contents({ action, iri, onUpdate }) {
   });
 
   if (error) {
-    return <DetailsError message={errorMessage} name={pathname} iri={iri} />;
+    return <DetailsError message={errorMessage} name={displayName} iri={iri} />;
   }
 
   if (!data) return loadingComponent;
@@ -81,7 +82,7 @@ function Contents({ action, iri, onUpdate }) {
       return (
         <ResourceSharing
           iri={iri}
-          name={pathname}
+          name={displayName}
           permissions={permissions}
           defaultPermissions={defaultPermissions}
           dataset={dataset}
@@ -91,7 +92,7 @@ function Contents({ action, iri, onUpdate }) {
     default:
       return (
         <ResourceDetails
-          resource={{ ...data, name: pathname }}
+          resource={{ ...data, name: displayName }}
           onDelete={onUpdate}
           onDeleteError={onDeleteError}
         />

--- a/components/resourceDetails/__snapshots__/index.test.tsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.tsx.snap
@@ -869,7 +869,7 @@ font-display: block;",
             className="PodBrowser-content-h3"
             title="/Some%20container/"
           >
-            Some container
+            Name
           </h3>
         </section>
         <WithStyles(ForwardRef(Divider))>
@@ -2569,7 +2569,7 @@ font-display: block;",
             className="PodBrowser-content-h3"
             title="/Some%20Resource"
           >
-            Some Resource
+            Name
           </h3>
         </section>
         <WithStyles(ForwardRef(Divider))>
@@ -4394,7 +4394,7 @@ font-display: block;",
             className="PodBrowser-content-h3"
             title="/container/"
           >
-            container
+            Name
           </h3>
         </section>
         <WithStyles(ForwardRef(Divider))>
@@ -6094,7 +6094,7 @@ font-display: block;",
             className="PodBrowser-content-h3"
             title="/resource"
           >
-            resource
+            Name
           </h3>
         </section>
         <WithStyles(ForwardRef(Divider))>

--- a/components/resourceDetails/index.tsx
+++ b/components/resourceDetails/index.tsx
@@ -39,10 +39,7 @@ import { makeStyles } from "@material-ui/styles";
 import { PrismTheme } from "@solid/lit-prism-patterns";
 import ResourceLink from "../resourceLink";
 import styles from "./styles";
-import {
-  getResourceName,
-  IResourceDetails,
-} from "../../src/solidClientHelpers";
+import { IResourceDetails } from "../../src/solidClientHelpers";
 import { parseUrl } from "../../src/stringHelpers";
 import SessionContext from "../../src/contexts/sessionContext";
 import { DETAILS_CONTEXT_ACTIONS } from "../../src/contexts/detailsMenuContext";
@@ -130,13 +127,12 @@ export default function ResourceDetails({
   const classes = useStyles();
   const { iri, name, types } = resource;
   const type = displayType(types);
-  const displayName = getResourceName(iri);
 
   return (
     <>
       <section className={classes.headerSection}>
         <h3 className={classes["content-h3"]} title={iri}>
-          {displayName}
+          {name}
         </h3>
       </section>
 

--- a/src/solidClientHelpers/index.test.ts
+++ b/src/solidClientHelpers/index.test.ts
@@ -424,10 +424,11 @@ describe("getResourceName", () => {
     expect(resourceName).toEqual("tictactoe");
   });
 
-  test("it returns the decoded resource name when spaces have been URI encoded", () => {
-    const resourceName = getResourceName("public/notes/Hello%20World.txt");
-
-    expect(resourceName).toEqual("Hello World.txt");
+  test("it returns the decoded resource name when spaces and special characters have been URI encoded", () => {
+    const resourceName = getResourceName(
+      "public/notes/Hello%20World%3AHello%40World%3BHello.txt"
+    );
+    expect(resourceName).toEqual("Hello World:Hello@World;Hello.txt");
   });
 });
 

--- a/src/solidClientHelpers/index.ts
+++ b/src/solidClientHelpers/index.ts
@@ -151,7 +151,7 @@ export function getResourceName(iri: string): string | undefined {
   }
   const encodedURISegment: string =
     pathname.match(/(?!\/)(?:.(?!\/))+$/)?.toString() || "";
-  return decodeURI(encodedURISegment);
+  return decodeURIComponent(encodedURISegment);
 }
 
 export function getTypeName(rawType: string): string {


### PR DESCRIPTION
This PR fixes:
 - missing some special characters when decoding resource names
 - names not being decoded everywhere in Details drawer (sharing, loading, etc).

For this I have switched from using `encodeURI` to `encodeURIComponent`which includes the characters I was missing (`:`, `:` and `@`).

In addition I moved the call to `getResourceName` to a parent component to include some other children component that also display the resource name in the Details drawer.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
