### PR TITLE
Fix/encode new folder uri

### DIFF
--- a/components/addFolderFlyout/index.jsx
+++ b/components/addFolderFlyout/index.jsx
@@ -65,7 +65,7 @@ export function determineFinalUrl(folders, currentUri, name) {
     }
   }
   determineFinalName();
-  return currentUri + encodeURIComponent(currentName);
+  return encodeURI(currentUri) + encodeURIComponent(currentName);
 }
 
 export function handleFolderSubmit({

--- a/components/addFolderFlyout/index.test.jsx
+++ b/components/addFolderFlyout/index.test.jsx
@@ -141,6 +141,40 @@ describe("handleFolderSubmit", () => {
     expect(setMessage).toHaveBeenCalled();
     expect(setAlertOpen).toHaveBeenCalledWith(true);
   });
+  test("it returns a handler that creates a new folder within a folder which has spaces in its name", async () => {
+    const fetch = jest.fn();
+    const options = { fetch };
+    const onSave = jest.fn();
+    const currentUri = "https://www.mypodbrowser.com/First Folder/";
+    const folders = [];
+    const name = "Second Folder";
+    const setSeverity = jest.fn();
+    const setMessage = jest.fn();
+    const setAlertOpen = jest.fn();
+
+    const handler = handleFolderSubmit({
+      options,
+      onSave,
+      currentUri,
+      folders,
+      name,
+      setSeverity,
+      setMessage,
+      setAlertOpen,
+    });
+
+    await handler();
+
+    expect(createContainerAt).toHaveBeenCalledWith(
+      "https://www.mypodbrowser.com/First%20Folder/Second%20Folder",
+      options
+    );
+
+    expect(onSave).toHaveBeenCalled();
+    expect(setSeverity).toHaveBeenCalledWith("success");
+    expect(setMessage).toHaveBeenCalled();
+    expect(setAlertOpen).toHaveBeenCalledWith(true);
+  });
 });
 describe("handleCreateFolderClick", () => {
   test("it returns a handler that submits the current folder and calls a function to clear the current folder name from state", () => {


### PR DESCRIPTION
This PR fixes the auth errors thrown when creating folders inside folders with spaces.

This is accomplished by encoding the current URI before creating the container.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
