### PR TITLE
fix: uri decoding names regression

### DIFF
--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -49,7 +49,7 @@ export function getResourceName(iri) {
   }
   const encodedURISegment =
     pathname.match(/(?!\/)(?:.(?!\/))+$/)?.toString() || "";
-  return decodeURI(encodedURISegment);
+  return decodeURIComponent(encodedURISegment);
 }
 
 export function normalizePermissions(permissions) {

--- a/src/solidClientHelpers/resource.test.js
+++ b/src/solidClientHelpers/resource.test.js
@@ -226,10 +226,11 @@ describe("getResourceName", () => {
     expect(resourceName).toEqual("tictactoe");
   });
 
-  test("it returns the decoded resource name when spaces have been URI encoded", () => {
-    const resourceName = getResourceName("public/notes/Hello%20World.txt");
-
-    expect(resourceName).toEqual("Hello World.txt");
+  test("it returns the decoded resource name when spaces and special characters have been URI encoded", () => {
+    const resourceName = getResourceName(
+      "public/notes/Hello%20World%3AHello%40World%3BHello.txt"
+    );
+    expect(resourceName).toEqual("Hello World:Hello@World;Hello.txt");
   });
 });
 


### PR DESCRIPTION
This PR fixes a regression that undid the work merged with https://github.com/inrupt/pod-browser/pull/81/

In this PR:
- added back the changes to the `getResourceName` function.
- added back the updated tests.