### PR TITLE
Fix: add slash at the end of breadcrumb links to prevent auth errors

### DIFF
--- a/components/breadcrumbs/__snapshots__/index.test.jsx.snap
+++ b/components/breadcrumbs/__snapshots__/index.test.jsx.snap
@@ -1776,26 +1776,26 @@ font-display: block;",
                 crumb={
                   Object {
                     "label": "some",
-                    "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome",
+                    "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2F",
                   }
                 }
                 isLink={true}
-                key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
+                key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2F"
               >
                 <li
                   className="PodBrowser-breadcrumb__crumb"
-                  key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
+                  key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2F"
                 >
                   <i
                     className="PodBrowser-icon-caret-left PodBrowser-breadcrumb__caret PodBrowser-breadcrumb__caret--small"
                   />
                   <Link
-                    as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
+                    as="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2F"
                     href="/resource/[iri]"
                   >
                     <a
                       className="PodBrowser-breadcrumb__link"
-                      href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome"
+                      href="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2F"
                       onClick={[Function]}
                       onMouseEnter={[Function]}
                     >
@@ -1816,15 +1816,15 @@ font-display: block;",
                 crumb={
                   Object {
                     "label": "location",
-                    "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation",
+                    "uri": "/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation%2F",
                   }
                 }
                 isLink={false}
-                key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
+                key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation%2F"
               >
                 <li
                   className="PodBrowser-breadcrumb__crumb"
-                  key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation"
+                  key="/resource/https%3A%2F%2Fwww.mypodbrowser.com%2Fsome%2Flocation%2F"
                 >
                   <i
                     className="PodBrowser-icon-caret-left PodBrowser-breadcrumb__caret PodBrowser-breadcrumb__caret--small"

--- a/components/breadcrumbs/index.jsx
+++ b/components/breadcrumbs/index.jsx
@@ -50,7 +50,7 @@ export default function Breadcrumbs() {
     .filter((crumb) => !!crumb);
   const resourceHref = (index) => {
     return `/resource/${encodeURIComponent(
-      baseUri + uriParts.slice(0, index + 1).join("/")
+      `${baseUri + uriParts.slice(0, index + 1).join("/")}/`
     )}`;
   };
   const crumbs = [


### PR DESCRIPTION
This PR fixes broken breadcrumbs links causing 401 errors when navigating upwards between containers.

The error was caused by missing slashes at the end of links.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

