### PR TITLE
Migrate away from deprecated solid-client funcs

### DIFF
--- a/__testUtils/createContainer.js
+++ b/__testUtils/createContainer.js
@@ -21,7 +21,7 @@
 
 import {
   addUrl,
-  createLitDataset,
+  createSolidDataset,
   createThing,
   addDatetime,
   addDecimal,
@@ -47,5 +47,5 @@ export default function createContainer(
     (t) => addUrl(t, ldp.contains, "https://user.dev.inrupt.net/public/games/"),
   ].reduce((acc, fn) => fn(acc), thing);
 
-  return setThing(createLitDataset(), publicContainer);
+  return setThing(createSolidDataset(), publicContainer);
 }

--- a/__testUtils/createDataset.js
+++ b/__testUtils/createDataset.js
@@ -21,7 +21,7 @@
 
 import {
   addUrl,
-  createLitDataset,
+  createSolidDataset,
   createThing,
   setThing,
 } from "@inrupt/solid-client";
@@ -35,5 +35,5 @@ export default function createDataset(
   const ops = [(t) => addUrl(t, rdf.type, ldp[type]), ...operations];
   const thing = ops.reduce((acc, fn) => fn(acc), createThing(options));
 
-  return setThing(createLitDataset(), thing);
+  return setThing(createSolidDataset(), thing);
 }

--- a/components/detailsContextMenu/index.test.jsx
+++ b/components/detailsContextMenu/index.test.jsx
@@ -233,24 +233,18 @@ describe("Contents", () => {
       .spyOn(SolidClientHookFns, "useFetchResourceDetails")
       .mockReturnValueOnce({ data });
 
-    jest
-      .spyOn(SolidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(SolidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(SolidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(SolidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
-    jest.spyOn(SolidClientFns, "unstable_getResourceAcl").mockReturnValueOnce();
+    jest.spyOn(SolidClientFns, "getResourceAcl").mockReturnValueOnce();
 
-    jest
-      .spyOn(SolidClientFns, "unstable_getAgentDefaultAccessOne")
-      .mockReturnValueOnce({
-        read: true,
-        write: true,
-        append: true,
-        control: true,
-      });
+    jest.spyOn(SolidClientFns, "getAgentDefaultAccess").mockReturnValueOnce({
+      read: true,
+      write: true,
+      append: true,
+      control: true,
+    });
 
     jest
       .spyOn(SolidClientHookFns, "useFetchResourceDetails")

--- a/components/header/mainNav/styles.ts
+++ b/components/header/mainNav/styles.ts
@@ -21,6 +21,7 @@
 
 import { PrismTheme, createStyles } from "@solid/lit-prism-patterns";
 
-const styles = (theme: PrismTheme) => createStyles(theme, ["icons", "headerBanner"]);
+const styles = (theme: PrismTheme) =>
+  createStyles(theme, ["icons", "headerBanner"]);
 
 export default styles;

--- a/components/header/styles.ts
+++ b/components/header/styles.ts
@@ -21,6 +21,7 @@
 
 import { PrismTheme, createStyles } from "@solid/lit-prism-patterns";
 
-const styles = (theme: PrismTheme) => createStyles(theme, ["appLayout", "headerBanner"]);
+const styles = (theme: PrismTheme) =>
+  createStyles(theme, ["appLayout", "headerBanner"]);
 
 export default styles;

--- a/components/header/userMenu/styles.ts
+++ b/components/header/userMenu/styles.ts
@@ -21,6 +21,7 @@
 
 import { PrismTheme, createStyles } from "@solid/lit-prism-patterns";
 
-const styles = (theme: PrismTheme) => createStyles(theme, ["headerBanner", "icons"]);
+const styles = (theme: PrismTheme) =>
+  createStyles(theme, ["headerBanner", "icons"]);
 
 export default styles;

--- a/components/permissionsForm/index.test.jsx
+++ b/components/permissionsForm/index.test.jsx
@@ -163,15 +163,13 @@ describe("PermissionsForm", () => {
     const setFormOpen = jest.fn();
 
     jest
-      .spyOn(SolidClientfns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientfns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce({});
 
-    jest
-      .spyOn(SolidClientfns, "unstable_getResourceAcl")
-      .mockResolvedValueOnce({});
+    jest.spyOn(SolidClientfns, "getResourceAcl").mockResolvedValueOnce({});
 
     jest
-      .spyOn(SolidClientfns, "unstable_setAgentResourceAccess")
+      .spyOn(SolidClientfns, "setAgentResourceAccess")
       .mockResolvedValueOnce({});
 
     jest

--- a/components/permissionsForm/styles.ts
+++ b/components/permissionsForm/styles.ts
@@ -53,7 +53,7 @@ const styles = (theme: PrismTheme) => {
     label: smallFontSize,
     checkbox: {
       padding: 0,
-    }
+    },
   });
 };
 

--- a/components/resourceDetails/resourceSharing/index.jsx
+++ b/components/resourceDetails/resourceSharing/index.jsx
@@ -37,10 +37,10 @@ import PersonIcon from "@material-ui/icons/Person";
 import ChevronLeftIcon from "@material-ui/icons/ChevronLeft";
 import { makeStyles } from "@material-ui/styles";
 import {
-  unstable_hasResourceAcl,
-  unstable_hasAccessibleAcl,
-  unstable_getResourceAcl,
-  unstable_getAgentDefaultAccessOne,
+  hasResourceAcl,
+  hasAccessibleAcl,
+  getResourceAcl,
+  getAgentDefaultAccess,
 } from "@inrupt/solid-client";
 import SessionContext from "../../../src/contexts/sessionContext";
 import { resourceContextRedirect } from "../../resourceLink";
@@ -271,9 +271,9 @@ function ResourceSharing({
     },
   };
 
-  if (unstable_hasResourceAcl(dataset) && unstable_hasAccessibleAcl(dataset)) {
-    const resourceAcl = unstable_getResourceAcl(dataset);
-    const acl = unstable_getAgentDefaultAccessOne(resourceAcl, webId);
+  if (hasResourceAcl(dataset) && hasAccessibleAcl(dataset)) {
+    const resourceAcl = getResourceAcl(dataset);
+    const acl = getAgentDefaultAccess(resourceAcl, webId);
     defaultPermission.acl = acl;
   }
 

--- a/components/resourceDetails/resourceSharing/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/index.test.jsx
@@ -78,22 +78,18 @@ describe("ResourceSharing", () => {
       .spyOn(RouterFns, "useRouter")
       .mockReturnValueOnce({ pathname: "/pathname/", replace: jest.fn() });
 
-    jest.spyOn(SolidClientFns, "unstable_hasResourceAcl").mockReturnValue(true);
+    jest.spyOn(SolidClientFns, "hasResourceAcl").mockReturnValue(true);
 
-    jest
-      .spyOn(SolidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValue(true);
+    jest.spyOn(SolidClientFns, "hasAccessibleAcl").mockReturnValue(true);
 
-    jest.spyOn(SolidClientFns, "unstable_getResourceAcl").mockReturnValueOnce();
+    jest.spyOn(SolidClientFns, "getResourceAcl").mockReturnValueOnce();
 
-    jest
-      .spyOn(SolidClientFns, "unstable_getAgentDefaultAccessOne")
-      .mockReturnValueOnce({
-        read: true,
-        write: true,
-        append: true,
-        control: true,
-      });
+    jest.spyOn(SolidClientFns, "getAgentDefaultAccess").mockReturnValueOnce({
+      read: true,
+      write: true,
+      append: true,
+      control: true,
+    });
 
     const tree = mountToJson(
       <SessionContext.Provider value={{ session }}>
@@ -141,22 +137,18 @@ describe("ResourceSharing", () => {
       .spyOn(RouterFns, "useRouter")
       .mockReturnValueOnce({ pathname: "/pathname/", replace: jest.fn() });
 
-    jest.spyOn(SolidClientFns, "unstable_hasResourceAcl").mockReturnValue(true);
+    jest.spyOn(SolidClientFns, "hasResourceAcl").mockReturnValue(true);
 
-    jest
-      .spyOn(SolidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValue(true);
+    jest.spyOn(SolidClientFns, "hasAccessibleAcl").mockReturnValue(true);
 
-    jest.spyOn(SolidClientFns, "unstable_getResourceAcl").mockReturnValueOnce();
+    jest.spyOn(SolidClientFns, "getResourceAcl").mockReturnValueOnce();
 
-    jest
-      .spyOn(SolidClientFns, "unstable_getAgentDefaultAccessOne")
-      .mockReturnValueOnce({
-        read: true,
-        write: true,
-        append: true,
-        control: true,
-      });
+    jest.spyOn(SolidClientFns, "getAgentDefaultAccess").mockReturnValueOnce({
+      read: true,
+      write: true,
+      append: true,
+      control: true,
+    });
 
     const tree = mountToJson(
       <SessionContext.Provider value={{ session }}>

--- a/components/resourceDetails/styles.ts
+++ b/components/resourceDetails/styles.ts
@@ -62,8 +62,8 @@ const rules = {
     marginLeft: "auto",
   },
   downloadButton: {
-    marginTop: "1rem" ,
-    marginBottom: "1rem" ,
+    marginTop: "1rem",
+    marginBottom: "1rem",
   },
   agentInput: {
     width: "100%",
@@ -71,7 +71,7 @@ const rules = {
   },
   agentAddButton: {
     marginBottom: "1rem",
-  }
+  },
 };
 
 export default function styles(theme: PrismTheme): StyleRules {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,9 +1777,9 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-0.3.0.tgz",
-      "integrity": "sha512-4N5rFlB7nZ1YW9Fe2OMWOG59YX7Bk1KAyOHt3QPuN1eQKj0V2y3uwge01uj9olYOf/TeihWo8d+gMHNlcyPtLg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-0.4.0.tgz",
+      "integrity": "sha512-Y7HLlfTp9iXxcjPayTOfpFO3lIkR5/hS4S8Mj0/+xLLgrwCA4q5YCHQq+Ue+nqapgEXUP2WCY2W42GFhTFpKew==",
       "requires": {
         "@rdfjs/dataset": "^1.0.1",
         "@types/n3": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/inrupt/pod-browser#readme",
   "dependencies": {
     "@inrupt/prism-react-components": "^0.7.4",
-    "@inrupt/solid-client": "^0.3.0",
+    "@inrupt/solid-client": "^0.4.0",
     "@inrupt/solid-client-authn-browser": "^0.1.3-master-244585248-713.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/pages/styles.css
+++ b/pages/styles.css
@@ -1,24 +1,29 @@
 @font-face {
-  font-family: 'Font Awesome 5 Free';
+  font-family: "Font Awesome 5 Free";
   font-style: normal;
   font-weight: 900;
   font-display: block;
   src: url("/fontawesome-solid/fa-solid-900.eot"); /* IE9 Compat Modes */
-  src: url("/fontawesome-solid/fa-solid-900.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-  url("/fontawesome-solid/fa-solid-900.woff2") format("woff2"), /* Modern Browsers */
-  url("/fontawesome-solid/fa-solid-900.woff") format("woff"), /* Modern Browsers */
-  url("/fontawesome-solid/fa-solid-900.ttf") format("truetype"), /* Safari, Android, iOS */
-  url("/fontawesome-solid/fa-solid-900.svg#fontawesome") format("svg"); /* Legacy iOS */
+  src: url("/fontawesome-solid/fa-solid-900.eot?#iefix")
+      format("embedded-opentype"),
+    /* IE6-IE8 */ url("/fontawesome-solid/fa-solid-900.woff2") format("woff2"),
+    /* Modern Browsers */ url("/fontawesome-solid/fa-solid-900.woff")
+      format("woff"),
+    /* Modern Browsers */ url("/fontawesome-solid/fa-solid-900.ttf")
+      format("truetype"),
+    /* Safari, Android, iOS */
+      url("/fontawesome-solid/fa-solid-900.svg#fontawesome") format("svg"); /* Legacy iOS */
 }
 @font-face {
   font-family: "Raleway-Medium";
   src: url("/Raleway/Raleway-Medium.eot"); /* IE9 Compat Modes */
-  src: url("/Raleway/Raleway-Medium.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-  url("/Raleway/Raleway-Medium.otf") format("opentype"), /* Open Type Font */
-  url("/Raleway/Raleway-Medium.svg") format("svg"), /* Legacy iOS */
-  url("/Raleway/Raleway-Medium.ttf") format("truetype"), /* Safari, Android, iOS */
-  url("/Raleway/Raleway-Medium.woff") format("woff"), /* Modern Browsers */
-  url("/Raleway/Raleway-Medium.woff2") format("woff2"); /* Modern Browsers */
+  src: url("/Raleway/Raleway-Medium.eot?#iefix") format("embedded-opentype"),
+    /* IE6-IE8 */ url("/Raleway/Raleway-Medium.otf") format("opentype"),
+    /* Open Type Font */ url("/Raleway/Raleway-Medium.svg") format("svg"),
+    /* Legacy iOS */ url("/Raleway/Raleway-Medium.ttf") format("truetype"),
+    /* Safari, Android, iOS */ url("/Raleway/Raleway-Medium.woff")
+      format("woff"),
+    /* Modern Browsers */ url("/Raleway/Raleway-Medium.woff2") format("woff2"); /* Modern Browsers */
   font-weight: normal;
   font-style: normal;
 }
@@ -26,12 +31,14 @@
 @font-face {
   font-family: "Raleway-ExtraBold";
   src: url("/Raleway/Raleway-ExtraBold.eot"); /* IE9 Compat Modes */
-  src: url("/Raleway/Raleway-ExtraBold.eot?#iefix") format("embedded-opentype"), /* IE6-IE8 */
-  url("/Raleway/Raleway-ExtraBold.otf") format("opentype"), /* Open Type Font */
-  url("/Raleway/Raleway-ExtraBold.svg") format("svg"), /* Legacy iOS */
-  url("/Raleway/Raleway-ExtraBold.ttf") format("truetype"), /* Safari, Android, iOS */
-  url("/Raleway/Raleway-ExtraBold.woff") format("woff"), /* Modern Browsers */
-  url("/Raleway/Raleway-ExtraBold.woff2") format("woff2"); /* Modern Browsers */
+  src: url("/Raleway/Raleway-ExtraBold.eot?#iefix") format("embedded-opentype"),
+    /* IE6-IE8 */ url("/Raleway/Raleway-ExtraBold.otf") format("opentype"),
+    /* Open Type Font */ url("/Raleway/Raleway-ExtraBold.svg") format("svg"),
+    /* Legacy iOS */ url("/Raleway/Raleway-ExtraBold.ttf") format("truetype"),
+    /* Safari, Android, iOS */ url("/Raleway/Raleway-ExtraBold.woff")
+      format("woff"),
+    /* Modern Browsers */ url("/Raleway/Raleway-ExtraBold.woff2")
+      format("woff2"); /* Modern Browsers */
   font-weight: normal;
   font-style: normal;
 }

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -22,7 +22,7 @@
 /* eslint-disable camelcase */
 
 import {
-  addStringUnlocalized,
+  addStringNoLocale,
   addUrl,
   getStringNoLocale,
   getStringNoLocaleAll,
@@ -61,7 +61,7 @@ export function createAddressBook({ iri, owner, title = "Contacts" }) {
     { name: "this" },
     (t) => addUrl(t, rdf.type, vcardExtras("AddressBook")),
     (t) => addUrl(t, acl.owner, owner),
-    (t) => addStringUnlocalized(t, dc.title, title),
+    (t) => addStringNoLocale(t, dc.title, title),
     (t) => addUrl(t, vcardExtras("nameEmailIndex"), peopleIri),
     (t) => addUrl(t, vcardExtras("groupIndex"), groupsIri)
   );
@@ -205,21 +205,20 @@ export async function saveNewAddressBook(
 
 export const schemaFunctionMappings = {
   webId: (v) => (t) => addUrl(t, foaf.openid, v),
-  fn: (v) => (t) => addStringUnlocalized(t, vcard.fn, v),
-  name: (v) => (t) => addStringUnlocalized(t, foaf.name, v),
+  fn: (v) => (t) => addStringNoLocale(t, vcard.fn, v),
+  name: (v) => (t) => addStringNoLocale(t, foaf.name, v),
   organizationName: (v) => (t) =>
-    addStringUnlocalized(t, vcardExtras("organization-name"), v),
-  role: (v) => (t) => addStringUnlocalized(t, vcard.role, v),
+    addStringNoLocale(t, vcardExtras("organization-name"), v),
+  role: (v) => (t) => addStringNoLocale(t, vcard.role, v),
   countryName: (v) => (t) =>
-    addStringUnlocalized(t, vcardExtras("country-name"), v),
-  locality: (v) => (t) => addStringUnlocalized(t, vcard.locality, v),
-  postalCode: (v) => (t) =>
-    addStringUnlocalized(t, vcardExtras("postal-code"), v),
-  region: (v) => (t) => addStringUnlocalized(t, vcard.region, v),
+    addStringNoLocale(t, vcardExtras("country-name"), v),
+  locality: (v) => (t) => addStringNoLocale(t, vcard.locality, v),
+  postalCode: (v) => (t) => addStringNoLocale(t, vcardExtras("postal-code"), v),
+  region: (v) => (t) => addStringNoLocale(t, vcard.region, v),
   streetAddress: (v) => (t) =>
-    addStringUnlocalized(t, vcardExtras("street-address"), v),
-  type: (v) => (t) => addStringUnlocalized(t, rdf.type, v),
-  value: (v) => (t) => addStringUnlocalized(t, vcard.value, v),
+    addStringNoLocale(t, vcardExtras("street-address"), v),
+  type: (v) => (t) => addStringNoLocale(t, rdf.type, v),
+  value: (v) => (t) => addStringNoLocale(t, vcard.value, v),
 };
 
 export function getSchemaFunction(type, value) {
@@ -319,7 +318,7 @@ export async function saveContact(addressBookIri, schema, fetch) {
 
   const peopleThing = defineThing(
     { name: "this  " },
-    (t) => addStringUnlocalized(t, vcard.fn, schema.fn || schema.name),
+    (t) => addStringNoLocale(t, vcard.fn, schema.fn || schema.name),
     (t) => addUrl(t, vcardExtras("inAddressBook"), indexIri)
   );
 

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -40,7 +40,7 @@ import {
 } from "./index";
 
 const {
-  createLitDataset,
+  createSolidDataset,
   createThing,
   getStringNoLocale,
   getStringNoLocaleAll,
@@ -405,15 +405,15 @@ describe("saveContact", () => {
     const webId = "https://user.example.com/card#me";
     const schema = { webId, fn: "Test Person" };
     const contactDataset = setThing(
-      createLitDataset(),
+      createSolidDataset(),
       createThing({ name: "this" })
     );
     const peopleIndexDataset = setThing(
-      createLitDataset(),
+      createSolidDataset(),
       createThing({ name: "this" })
     );
     const peopleDataset = setThing(
-      createLitDataset(),
+      createSolidDataset(),
       createThing({ name: "this" })
     );
 

--- a/src/hooks/solidClient/index.js
+++ b/src/hooks/solidClient/index.js
@@ -25,15 +25,15 @@ import useSWR from "swr";
 import { space, ldp } from "rdf-namespaces";
 
 import {
-  fetchLitDataset,
-  fetchResourceInfoWithAcl,
+  getSolidDataset,
+  getResourceInfoWithAcl,
   getIriAll,
   getResourceAcl,
   getThing,
   hasResourceAcl,
   isContainer,
-  unstable_getAgentAccessAll,
-  unstable_getAgentDefaultAccessAll,
+  getAgentAccessAll,
+  getAgentDefaultAccessAll,
 } from "@inrupt/solid-client";
 
 import { getIriPath } from "../../solidClientHelpers/utils";
@@ -43,7 +43,7 @@ import { fetchResourceWithAcl } from "../../solidClientHelpers/resource";
 import SessionContext from "../../contexts/sessionContext";
 
 export async function fetchContainerResourceIris(containerIri, fetch) {
-  const litDataset = await fetchLitDataset(containerIri, { fetch });
+  const litDataset = await getSolidDataset(containerIri, { fetch });
   const container = getThing(litDataset, containerIri);
   const iris = getIriAll(container, ldp.contains);
   return iris;
@@ -61,17 +61,15 @@ export function useFetchContainerResourceIris(iri) {
 
 export async function fetchResourceDetails(iri, fetch) {
   const name = getIriPath(iri);
-  const resourceInfo = await fetchResourceInfoWithAcl(iri, { fetch });
+  const resourceInfo = await getResourceInfoWithAcl(iri, { fetch });
   let defaultPermissions = [];
   let permissions = [];
 
   if (hasResourceAcl(resourceInfo)) {
-    const accessModeList = unstable_getAgentAccessAll(resourceInfo);
+    const accessModeList = getAgentAccessAll(resourceInfo);
     permissions = await normalizePermissions(accessModeList, fetch);
     const resourceAcl = getResourceAcl(resourceInfo);
-    const defaultAccessModeList = unstable_getAgentDefaultAccessAll(
-      resourceAcl
-    );
+    const defaultAccessModeList = getAgentDefaultAccessAll(resourceAcl);
 
     defaultPermissions = await normalizePermissions(
       defaultAccessModeList,
@@ -114,7 +112,7 @@ export function useFetchResourceWithAcl(iri) {
 }
 
 export async function fetchPodIrisFromWebId(webId, fetch) {
-  const profileDoc = await fetchLitDataset(webId, { fetch });
+  const profileDoc = await getSolidDataset(webId, { fetch });
   const profile = getThing(profileDoc, webId);
 
   return getIriAll(profile, space.storage);

--- a/src/hooks/solidClient/index.test.js
+++ b/src/hooks/solidClient/index.test.js
@@ -22,10 +22,10 @@
 /* eslint-disable camelcase */
 
 import {
-  fetchLitDataset,
+  getSolidDataset,
   getThing,
   getIriAll,
-  unstable_fetchResourceInfoWithAcl,
+  getResourceInfoWithAcl,
 } from "@inrupt/solid-client";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as PermissionHelpers from "../../solidClientHelpers/permissions";
@@ -57,7 +57,7 @@ describe("fetchResourceDetails", () => {
   test("it fetches the resource, adding a human-readable name", async () => {
     const iri = "https://dayton.dev.inrupt.net/public/";
 
-    unstable_fetchResourceInfoWithAcl.mockResolvedValue({
+    getResourceInfoWithAcl.mockResolvedValue({
       resourceInfo: {
         fetchedFrom: "https://dayton.dev.inrupt.net/public/",
         contentType: "application/octet-stream; charset=utf-8",
@@ -153,13 +153,13 @@ describe("PodIrisFromWebId", () => {
     const iri = "https://mypod.myhost.com/profile/card#me";
     const iris = ["https://mypod.myhost.com/profile"];
 
-    fetchLitDataset.mockResolvedValue({});
+    getSolidDataset.mockResolvedValue({});
     getThing.mockImplementationOnce(() => {});
     getIriAll.mockImplementationOnce(() => iris);
 
     expect(await fetchPodIrisFromWebId(iri)).toEqual(iris);
 
-    expect(fetchLitDataset).toHaveBeenCalled();
+    expect(getSolidDataset).toHaveBeenCalled();
     expect(getThing).toHaveBeenCalled();
     expect(getIriAll).toHaveBeenCalled();
   });

--- a/src/solidClientHelpers/permissions.js
+++ b/src/solidClientHelpers/permissions.js
@@ -22,13 +22,13 @@
 /* eslint-disable camelcase */
 import {
   createAcl,
-  unstable_fetchLitDatasetWithAcl,
-  unstable_getResourceAcl,
-  unstable_hasAccessibleAcl,
-  unstable_hasResourceAcl,
-  unstable_saveAclFor,
-  unstable_setAgentDefaultAccess,
-  unstable_setAgentResourceAccess,
+  getSolidDatasetWithAcl,
+  getResourceAcl,
+  hasAccessibleAcl,
+  hasResourceAcl,
+  saveAclFor,
+  setAgentDefaultAccess,
+  setAgentResourceAccess,
 } from "@inrupt/solid-client";
 import { isUrl } from "../stringHelpers";
 import { createResponder, chain } from "./utils";
@@ -102,8 +102,8 @@ export function parseStringAcl(access) {
 export function defineAcl(dataset, webId, access = ACL.CONTROL.acl) {
   const aclDataset = chain(
     createAcl(dataset),
-    (a) => unstable_setAgentResourceAccess(a, webId, access),
-    (a) => unstable_setAgentDefaultAccess(a, webId, access)
+    (a) => setAgentResourceAccess(a, webId, access),
+    (a) => setAgentDefaultAccess(a, webId, access)
   );
 
   return aclDataset;
@@ -167,25 +167,25 @@ export function getThirdPartyPermissions(id, permissions) {
 
 export async function savePermissions({ iri, webId, access, fetch }) {
   const { respond, error } = createResponder();
-  const dataset = await unstable_fetchLitDatasetWithAcl(iri, { fetch });
+  const dataset = await getSolidDatasetWithAcl(iri, { fetch });
 
   if (!dataset) return error("dataset is empty");
 
-  if (!unstable_hasResourceAcl(dataset)) {
+  if (!hasResourceAcl(dataset)) {
     return error("dataset does not have resource ACL");
   }
 
-  if (!unstable_hasAccessibleAcl(dataset)) {
+  if (!hasAccessibleAcl(dataset)) {
     return error("dataset does not have accessible ACL");
   }
 
-  const aclDataset = unstable_getResourceAcl(dataset);
+  const aclDataset = getResourceAcl(dataset);
   if (!aclDataset) return error("aclDataset is empty");
 
-  const updatedAcl = unstable_setAgentResourceAccess(aclDataset, webId, access);
+  const updatedAcl = setAgentResourceAccess(aclDataset, webId, access);
   if (!updatedAcl) return error("updatedAcl is empty");
 
-  const response = await unstable_saveAclFor(dataset, updatedAcl, { fetch });
+  const response = await saveAclFor(dataset, updatedAcl, { fetch });
   if (!response) return error("response is empty");
 
   return respond(response);
@@ -193,25 +193,25 @@ export async function savePermissions({ iri, webId, access, fetch }) {
 
 export async function saveDefaultPermissions({ iri, webId, access, fetch }) {
   const { respond, error } = createResponder();
-  const dataset = await unstable_fetchLitDatasetWithAcl(iri, { fetch });
+  const dataset = await getSolidDatasetWithAcl(iri, { fetch });
   if (!dataset) return error("dataset is empty");
 
-  if (!unstable_hasResourceAcl(dataset)) {
+  if (!hasResourceAcl(dataset)) {
     return error("dataset does not have resource ACL");
   }
 
-  if (!unstable_hasAccessibleAcl(dataset)) {
+  if (!hasAccessibleAcl(dataset)) {
     return error("dataset does not have accessible ACL");
   }
 
-  const aclDataset = unstable_getResourceAcl(dataset);
+  const aclDataset = getResourceAcl(dataset);
   if (!aclDataset) return error("aclDataset is empty");
 
-  const updatedAcl = unstable_setAgentDefaultAccess(aclDataset, webId, access);
+  const updatedAcl = setAgentDefaultAccess(aclDataset, webId, access);
 
   if (!updatedAcl) return error("updatedAcl is empty");
 
-  const response = await unstable_saveAclFor(dataset, updatedAcl, { fetch });
+  const response = await saveAclFor(dataset, updatedAcl, { fetch });
   if (!response) return error("response is empty");
 
   return respond(response);

--- a/src/solidClientHelpers/permissions.test.js
+++ b/src/solidClientHelpers/permissions.test.js
@@ -37,7 +37,7 @@ import {
 } from "./permissions";
 
 describe("parseStringAcl", () => {
-  test("it parses a list of string permissions into an unstable_Access", () => {
+  test("it parses a list of string permissions into an Access", () => {
     const fullControl = parseStringAcl("read write append control");
 
     expect(fullControl.read).toBe(true);
@@ -267,22 +267,22 @@ describe("defineAcl", () => {
     jest.spyOn(solidClientFns, "createAcl").mockImplementationOnce(() => "acl");
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentResourceAccess")
+      .spyOn(solidClientFns, "setAgentResourceAccess")
       .mockImplementationOnce((x) => x);
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentDefaultAccess")
+      .spyOn(solidClientFns, "setAgentDefaultAccess")
       .mockImplementationOnce((x) => x);
 
     const access = defineAcl("dataset", "webId");
 
     expect(solidClientFns.createAcl).toHaveBeenCalledWith("dataset");
-    expect(solidClientFns.unstable_setAgentResourceAccess).toHaveBeenCalledWith(
+    expect(solidClientFns.setAgentResourceAccess).toHaveBeenCalledWith(
       "acl",
       "webId",
       ACL.CONTROL.acl
     );
-    expect(solidClientFns.unstable_setAgentDefaultAccess).toHaveBeenCalledWith(
+    expect(solidClientFns.setAgentDefaultAccess).toHaveBeenCalledWith(
       "acl",
       "webId",
       ACL.CONTROL.acl
@@ -294,22 +294,22 @@ describe("defineAcl", () => {
     jest.spyOn(solidClientFns, "createAcl").mockImplementationOnce(() => "acl");
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentResourceAccess")
+      .spyOn(solidClientFns, "setAgentResourceAccess")
       .mockImplementationOnce((x) => x);
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentDefaultAccess")
+      .spyOn(solidClientFns, "setAgentDefaultAccess")
       .mockImplementationOnce((x) => x);
 
     const access = defineAcl("dataset", "webId", ACL.READ.acl);
 
     expect(solidClientFns.createAcl).toHaveBeenCalledWith("dataset");
-    expect(solidClientFns.unstable_setAgentResourceAccess).toHaveBeenCalledWith(
+    expect(solidClientFns.setAgentResourceAccess).toHaveBeenCalledWith(
       "acl",
       "webId",
       ACL.READ.acl
     );
-    expect(solidClientFns.unstable_setAgentDefaultAccess).toHaveBeenCalledWith(
+    expect(solidClientFns.setAgentDefaultAccess).toHaveBeenCalledWith(
       "acl",
       "webId",
       ACL.READ.acl
@@ -432,44 +432,38 @@ describe("savePermissions", () => {
     const updatedAcl = "updatedAcl";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
+      .spyOn(solidClientFns, "getResourceAcl")
       .mockReturnValueOnce(aclDataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentResourceAccess")
+      .spyOn(solidClientFns, "setAgentResourceAccess")
       .mockReturnValue(updatedAcl);
 
     jest
-      .spyOn(solidClientFns, "unstable_saveAclFor")
+      .spyOn(solidClientFns, "saveAclFor")
       .mockImplementationOnce(jest.fn().mockResolvedValueOnce("response"));
 
     const fetch = jest.fn();
     const { response } = await savePermissions({ iri, webId, access, fetch });
 
-    expect(
-      solidClientFns.unstable_fetchLitDatasetWithAcl
-    ).toHaveBeenCalledWith(iri, { fetch });
-    expect(solidClientFns.unstable_getResourceAcl).toHaveBeenCalledWith(
-      dataset
-    );
-    expect(solidClientFns.unstable_setAgentResourceAccess).toHaveBeenCalledWith(
+    expect(solidClientFns.getSolidDatasetWithAcl).toHaveBeenCalledWith(iri, {
+      fetch,
+    });
+    expect(solidClientFns.getResourceAcl).toHaveBeenCalledWith(dataset);
+    expect(solidClientFns.setAgentResourceAccess).toHaveBeenCalledWith(
       aclDataset,
       webId,
       access
     );
-    expect(solidClientFns.unstable_saveAclFor).toHaveBeenCalledWith(
+    expect(solidClientFns.saveAclFor).toHaveBeenCalledWith(
       dataset,
       updatedAcl,
       { fetch }
@@ -489,7 +483,7 @@ describe("savePermissions", () => {
     };
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(null);
 
     const { error } = await savePermissions({ iri, webId, access });
@@ -509,12 +503,10 @@ describe("savePermissions", () => {
     const dataset = "dataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(false);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(false);
 
     const { error } = await savePermissions({ iri, webId, access });
 
@@ -533,16 +525,12 @@ describe("savePermissions", () => {
     const dataset = "dataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(false);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(false);
 
     const { error } = await savePermissions({ iri, webId, access });
 
@@ -561,20 +549,14 @@ describe("savePermissions", () => {
     const dataset = "dataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
-      .mockReturnValueOnce(null);
+    jest.spyOn(solidClientFns, "getResourceAcl").mockReturnValueOnce(null);
 
     const { error } = await savePermissions({ iri, webId, access });
 
@@ -594,24 +576,18 @@ describe("savePermissions", () => {
     const aclDataset = "aclDataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
+      .spyOn(solidClientFns, "getResourceAcl")
       .mockReturnValueOnce(aclDataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_setAgentResourceAccess")
-      .mockReturnValue(null);
+    jest.spyOn(solidClientFns, "setAgentResourceAccess").mockReturnValue(null);
 
     const { error } = await savePermissions({ iri, webId, access });
 
@@ -632,28 +608,22 @@ describe("savePermissions", () => {
     const updatedAcl = "updatedAcl";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
+      .spyOn(solidClientFns, "getResourceAcl")
       .mockReturnValueOnce(aclDataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentResourceAccess")
+      .spyOn(solidClientFns, "setAgentResourceAccess")
       .mockReturnValue(updatedAcl);
 
-    jest
-      .spyOn(solidClientFns, "unstable_saveAclFor")
-      .mockResolvedValueOnce(null);
+    jest.spyOn(solidClientFns, "saveAclFor").mockResolvedValueOnce(null);
 
     const { error } = await savePermissions({ iri, webId, access });
 
@@ -676,27 +646,23 @@ describe("saveDefaultPermissions", () => {
     const updatedAcl = "updatedAcl";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
+      .spyOn(solidClientFns, "getResourceAcl")
       .mockReturnValueOnce(aclDataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentDefaultAccess")
+      .spyOn(solidClientFns, "setAgentDefaultAccess")
       .mockReturnValue(updatedAcl);
 
     jest
-      .spyOn(solidClientFns, "unstable_saveAclFor")
+      .spyOn(solidClientFns, "saveAclFor")
       .mockImplementationOnce(jest.fn().mockResolvedValueOnce("response"));
 
     const fetch = jest.fn();
@@ -708,18 +674,16 @@ describe("saveDefaultPermissions", () => {
       fetch,
     });
 
-    expect(
-      solidClientFns.unstable_fetchLitDatasetWithAcl
-    ).toHaveBeenCalledWith(iri, { fetch });
-    expect(solidClientFns.unstable_getResourceAcl).toHaveBeenCalledWith(
-      dataset
-    );
-    expect(solidClientFns.unstable_setAgentDefaultAccess).toHaveBeenCalledWith(
+    expect(solidClientFns.getSolidDatasetWithAcl).toHaveBeenCalledWith(iri, {
+      fetch,
+    });
+    expect(solidClientFns.getResourceAcl).toHaveBeenCalledWith(dataset);
+    expect(solidClientFns.setAgentDefaultAccess).toHaveBeenCalledWith(
       aclDataset,
       webId,
       access
     );
-    expect(solidClientFns.unstable_saveAclFor).toHaveBeenCalledWith(
+    expect(solidClientFns.saveAclFor).toHaveBeenCalledWith(
       dataset,
       updatedAcl,
       { fetch }
@@ -739,7 +703,7 @@ describe("saveDefaultPermissions", () => {
     };
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(null);
 
     const { error } = await saveDefaultPermissions({ iri, webId, access });
@@ -759,12 +723,10 @@ describe("saveDefaultPermissions", () => {
     const dataset = "dataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(false);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(false);
 
     const { error } = await saveDefaultPermissions({ iri, webId, access });
 
@@ -783,16 +745,12 @@ describe("saveDefaultPermissions", () => {
     const dataset = "dataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(false);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(false);
 
     const { error } = await saveDefaultPermissions({ iri, webId, access });
 
@@ -811,20 +769,14 @@ describe("saveDefaultPermissions", () => {
     const dataset = "dataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
-    jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
-      .mockReturnValueOnce(null);
+    jest.spyOn(solidClientFns, "getResourceAcl").mockReturnValueOnce(null);
 
     const { error } = await saveDefaultPermissions({ iri, webId, access });
 
@@ -844,24 +796,18 @@ describe("saveDefaultPermissions", () => {
     const aclDataset = "aclDataset";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
+
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
-
-    jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
+      .spyOn(solidClientFns, "getResourceAcl")
       .mockReturnValueOnce(aclDataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_setAgentDefaultAccess")
-      .mockReturnValue(null);
+    jest.spyOn(solidClientFns, "setAgentDefaultAccess").mockReturnValue(null);
 
     const { error } = await saveDefaultPermissions({ iri, webId, access });
 
@@ -882,28 +828,22 @@ describe("saveDefaultPermissions", () => {
     const updatedAcl = "updatedAcl";
 
     jest
-      .spyOn(solidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(solidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasResourceAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasResourceAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_getResourceAcl")
+      .spyOn(solidClientFns, "getResourceAcl")
       .mockReturnValueOnce(aclDataset);
 
-    jest
-      .spyOn(solidClientFns, "unstable_hasAccessibleAcl")
-      .mockReturnValueOnce(true);
+    jest.spyOn(solidClientFns, "hasAccessibleAcl").mockReturnValueOnce(true);
 
     jest
-      .spyOn(solidClientFns, "unstable_setAgentDefaultAccess")
+      .spyOn(solidClientFns, "setAgentDefaultAccess")
       .mockReturnValue(updatedAcl);
 
-    jest
-      .spyOn(solidClientFns, "unstable_saveAclFor")
-      .mockResolvedValueOnce(null);
+    jest.spyOn(solidClientFns, "saveAclFor").mockResolvedValueOnce(null);
 
     const { error } = await saveDefaultPermissions({ iri, webId, access });
 

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -20,7 +20,7 @@
  */
 
 import {
-  fetchLitDataset,
+  getSolidDataset,
   getIri,
   getIriAll,
   getStringNoLocale,
@@ -35,7 +35,7 @@ export function displayProfileName({ nickname, name, webId }) {
 }
 
 export async function fetchProfile(webId, fetch) {
-  const dataset = await fetchLitDataset(webId, { fetch });
+  const dataset = await getSolidDataset(webId, { fetch });
 
   const profile = getThing(dataset, webId);
   const nickname = getStringNoLocale(profile, foaf.nick);

--- a/src/solidClientHelpers/profile.test.js
+++ b/src/solidClientHelpers/profile.test.js
@@ -49,7 +49,7 @@ describe("fetchProfile", () => {
     const profileDataset = {};
 
     jest
-      .spyOn(solidClientFns, "fetchLitDataset")
+      .spyOn(solidClientFns, "getSolidDataset")
       .mockResolvedValue(profileDataset);
 
     jest.spyOn(solidClientFns, "getThing").mockReturnValue(profileDataset);
@@ -69,7 +69,7 @@ describe("fetchProfile", () => {
     const fetch = jest.fn();
     const profile = await fetchProfile(profileWebId, fetch);
 
-    expect(solidClientFns.fetchLitDataset).toHaveBeenCalledWith(profileWebId, {
+    expect(solidClientFns.getSolidDataset).toHaveBeenCalledWith(profileWebId, {
       fetch,
     });
     expect(solidClientFns.getStringNoLocale).toHaveBeenCalledWith(

--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -21,12 +21,12 @@
 
 /* eslint-disable camelcase */
 import {
-  fetchLitDataset,
+  getSolidDataset,
   saveSolidDatasetAt,
-  unstable_fetchFile,
-  unstable_fetchLitDatasetWithAcl,
-  unstable_getAgentAccessAll,
-  unstable_saveAclFor,
+  getFile,
+  getSolidDatasetWithAcl,
+  getAgentAccessAll,
+  saveAclFor,
 } from "@inrupt/solid-client";
 import camelCase from "camelcase";
 import { parseUrl, isUrl, hasHash, stripHash } from "../stringHelpers";
@@ -69,7 +69,7 @@ export async function getResource(iri, fetch) {
   const { respond, error } = createResponder();
 
   try {
-    const dataset = await fetchLitDataset(iri, { fetch });
+    const dataset = await getSolidDataset(iri, { fetch });
     const resource = { dataset, iri };
 
     return respond(resource);
@@ -82,8 +82,8 @@ export async function getResourceWithPermissions(iri, fetch) {
   const { respond, error } = createResponder();
 
   try {
-    const dataset = await unstable_fetchLitDatasetWithAcl(iri, { fetch });
-    const access = unstable_getAgentAccessAll(dataset);
+    const dataset = await getSolidDatasetWithAcl(iri, { fetch });
+    const access = getAgentAccessAll(dataset);
     const permissions = normalizePermissions(access);
 
     return respond({ dataset, iri, permissions });
@@ -93,7 +93,7 @@ export async function getResourceWithPermissions(iri, fetch) {
 }
 
 export async function fetchFileWithAcl(iri, fetch) {
-  const file = await unstable_fetchFile(iri, { fetch });
+  const file = await getFile(iri, { fetch });
   const {
     internal_resourceInfo: { permissions: filePermissions, contentType: type },
   } = file;
@@ -129,8 +129,8 @@ export async function fetchResourceWithAcl(
   fetch,
   normalizePermissionsFn = normalizePermissions
 ) {
-  const dataset = await unstable_fetchLitDatasetWithAcl(iri, { fetch });
-  const access = unstable_getAgentAccessAll(dataset);
+  const dataset = await getSolidDatasetWithAcl(iri, { fetch });
+  const access = getAgentAccessAll(dataset);
   const permissions = access
     ? await normalizePermissionsFn(access, fetch)
     : undefined;
@@ -158,8 +158,8 @@ export async function saveResourcePermissions(
   const { respond, error } = createResponder();
 
   try {
-    const saveResponse = await unstable_saveAclFor(dataset, acl);
-    const access = unstable_getAgentAccessAll(saveResponse);
+    const saveResponse = await saveAclFor(dataset, acl);
+    const access = getAgentAccessAll(saveResponse);
     const permissions = normalizePermissions(access);
 
     return respond({ dataset, iri, permissions });

--- a/src/solidClientHelpers/resource.test.js
+++ b/src/solidClientHelpers/resource.test.js
@@ -41,7 +41,7 @@ const { displayPermissions, ACL } = permissionFns;
 
 describe("fetchFileWithAcl", () => {
   test("it fetches a file and parses the wac-allow header", async () => {
-    jest.spyOn(SolidClientFns, "unstable_fetchFile").mockResolvedValue({
+    jest.spyOn(SolidClientFns, "getFile").mockResolvedValue({
       text: "file contents",
       internal_resourceInfo: {
         contentType: "type",
@@ -75,7 +75,7 @@ describe("fetchFileWithAcl", () => {
   });
 
   test("it defaults to empty permissions if none are returned", async () => {
-    jest.spyOn(SolidClientFns, "unstable_fetchFile").mockResolvedValue({
+    jest.spyOn(SolidClientFns, "getFile").mockResolvedValue({
       text: "file contents",
       internal_resourceInfo: {
         contentType: "type",
@@ -88,7 +88,7 @@ describe("fetchFileWithAcl", () => {
   });
 
   test("it defaults to an empty array if there is no type", async () => {
-    jest.spyOn(SolidClientFns, "unstable_fetchFile").mockResolvedValue({
+    jest.spyOn(SolidClientFns, "getFile").mockResolvedValue({
       text: "file contents",
       internal_resourceInfo: {},
     });
@@ -119,10 +119,10 @@ describe("fetchResourceWithAcl", () => {
     const expectedIri = "https://user.dev.inrupt.net/public/";
 
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(createContainer());
     jest
-      .spyOn(SolidClientFns, "unstable_getAgentAccessAll")
+      .spyOn(SolidClientFns, "getAgentAccessAll")
       .mockResolvedValueOnce(perms);
 
     const normalizePermissionsFn = jest.fn().mockResolvedValue([
@@ -174,11 +174,11 @@ describe("fetchResourceWithAcl", () => {
 
   test("it returns no permissions when acl is not returned", async () => {
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(createContainer());
 
     jest
-      .spyOn(SolidClientFns, "unstable_getAgentAccessAll")
+      .spyOn(SolidClientFns, "getAgentAccessAll")
       .mockResolvedValueOnce(undefined);
 
     const { permissions, acl: access } = await fetchResourceWithAcl(
@@ -194,7 +194,7 @@ describe("getResource", () => {
   test("it returns a dataset and an iri", async () => {
     const dataset = createContainer();
     jest
-      .spyOn(SolidClientFns, "fetchLitDataset")
+      .spyOn(SolidClientFns, "getSolidDataset")
       .mockResolvedValueOnce(dataset);
     const iri = "https://user.example.com";
     const { response } = await getResource(iri, jest.fn());
@@ -204,7 +204,7 @@ describe("getResource", () => {
   });
 
   test("it returns an error message when it throws an error", async () => {
-    jest.spyOn(SolidClientFns, "fetchLitDataset").mockImplementationOnce(() => {
+    jest.spyOn(SolidClientFns, "getSolidDataset").mockImplementationOnce(() => {
       throw new Error("boom");
     });
     const iri = "https://user.example.com";
@@ -241,12 +241,10 @@ describe("getResourceWithPermissions", () => {
     const fetch = jest.fn();
     const access = { [iri]: ACL.CONTROL.acl };
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValueOnce(dataset);
 
-    jest
-      .spyOn(SolidClientFns, "unstable_getAgentAccessAll")
-      .mockReturnValueOnce(access);
+    jest.spyOn(SolidClientFns, "getAgentAccessAll").mockReturnValueOnce(access);
 
     const { response } = await getResourceWithPermissions(iri, fetch);
 
@@ -263,7 +261,7 @@ describe("getResourceWithPermissions", () => {
 
   test("it returns an error message when it throws an error", async () => {
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockImplementationOnce(() => {
         throw new Error("boom");
       });
@@ -376,7 +374,7 @@ describe("saveResourceWithPermissions", () => {
       .mockResolvedValueOnce("dataset");
 
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockImplementationOnce(() => {
         throw new Error("boom");
       });
@@ -404,18 +402,14 @@ describe("saveResourceWithPermissions", () => {
       .mockResolvedValueOnce("dataset");
 
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValue("dataset");
 
-    jest
-      .spyOn(SolidClientFns, "unstable_getAgentAccessAll")
-      .mockReturnValue(access);
+    jest.spyOn(SolidClientFns, "getAgentAccessAll").mockReturnValue(access);
 
-    jest
-      .spyOn(SolidClientFns, "unstable_saveAclFor")
-      .mockImplementationOnce(() => {
-        throw new Error("boom");
-      });
+    jest.spyOn(SolidClientFns, "saveAclFor").mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
 
     const { error } = await saveResourceWithPermissions(
       {
@@ -439,17 +433,15 @@ describe("saveResourceWithPermissions", () => {
       .mockResolvedValueOnce("dataset");
 
     jest
-      .spyOn(SolidClientFns, "unstable_fetchLitDatasetWithAcl")
+      .spyOn(SolidClientFns, "getSolidDatasetWithAcl")
       .mockResolvedValue("dataset");
 
     jest
-      .spyOn(SolidClientFns, "unstable_getAgentAccessAll")
+      .spyOn(SolidClientFns, "getAgentAccessAll")
       .mockReturnValueOnce(access)
       .mockReturnValueOnce(access);
 
-    jest
-      .spyOn(SolidClientFns, "unstable_saveAclFor")
-      .mockResolvedValueOnce("saved acl");
+    jest.spyOn(SolidClientFns, "saveAclFor").mockResolvedValueOnce("saved acl");
 
     const { response } = await saveResourceWithPermissions({
       dataset: "dataset",
@@ -462,11 +454,9 @@ describe("saveResourceWithPermissions", () => {
 
 describe("saveResourcePermissions", () => {
   test("it returns an error if the permission save fails", async () => {
-    jest
-      .spyOn(SolidClientFns, "unstable_saveAclFor")
-      .mockImplementationOnce(() => {
-        throw new Error("boom");
-      });
+    jest.spyOn(SolidClientFns, "saveAclFor").mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
 
     const { error } = await saveResourcePermissions({
       dataset: "dataset",
@@ -484,18 +474,14 @@ describe("saveResourcePermissions", () => {
       iri: "iri",
     };
 
-    jest
-      .spyOn(SolidClientFns, "unstable_saveAclFor")
-      .mockResolvedValueOnce("response");
+    jest.spyOn(SolidClientFns, "saveAclFor").mockResolvedValueOnce("response");
 
-    jest
-      .spyOn(SolidClientFns, "unstable_getAgentAccessAll")
-      .mockReturnValue(access);
+    jest.spyOn(SolidClientFns, "getAgentAccessAll").mockReturnValue(access);
 
     const { response } = await saveResourcePermissions(resource);
     const [permission] = response.permissions;
 
-    expect(SolidClientFns.unstable_saveAclFor).toHaveBeenCalledWith(
+    expect(SolidClientFns.saveAclFor).toHaveBeenCalledWith(
       "dataset",
       ACL.CONTROL.acl
     );

--- a/src/solidClientHelpers/utils.js
+++ b/src/solidClientHelpers/utils.js
@@ -22,7 +22,7 @@
 /* eslint-disable camelcase */
 
 import {
-  createLitDataset,
+  createSolidDataset,
   createThing,
   getDatetime,
   getDecimal,
@@ -141,7 +141,7 @@ export function defineThing(options, ...operations) {
 }
 
 export function defineDataset(options, ...operations) {
-  return setThing(createLitDataset(), defineThing(options, ...operations));
+  return setThing(createSolidDataset(), defineThing(options, ...operations));
 }
 
 export function changeThing(thing, ...operations) {

--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -41,7 +41,7 @@ const TIMESTAMP = new Date(Date.UTC(2020, 5, 2, 15, 59, 21));
 function createDataset(url, type = "http://www.w3.org/ns/ldp#BasicContainer") {
   const {
     addUrl,
-    createLitDataset,
+    createSolidDataset,
     createThing,
     setDatetime,
     setDecimal,
@@ -86,7 +86,7 @@ function createDataset(url, type = "http://www.w3.org/ns/ldp#BasicContainer") {
     4096
   );
 
-  return setThing(createLitDataset(), publicContainer);
+  return setThing(createSolidDataset(), publicContainer);
 }
 
 describe("changeThing", () => {
@@ -134,7 +134,7 @@ describe("defineDataset", () => {
       .spyOn(solidClientFns, "setThing")
       .mockImplementationOnce(jest.fn((x) => x));
     jest
-      .spyOn(solidClientFns, "createLitDataset")
+      .spyOn(solidClientFns, "createSolidDataset")
       .mockReturnValueOnce("dataset");
 
     const thing = defineDataset({ name: "this" }, opOne, opTwo);


### PR DESCRIPTION
This PR replaces calls to deprecated functions from solid-client by their replacements. There are a number of errors thrown when running the tests, but that already was the case before my changes, so I presume that that's normal. Other than that, all the tests succeed again.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable. (Is this point even relevant?)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
