### PR TITLE
Fix: error handling regression in addContact

### DIFF
--- a/src/contexts/alertContext/__snapshots__/index.test.jsx.snap
+++ b/src/contexts/alertContext/__snapshots__/index.test.jsx.snap
@@ -4,7 +4,9 @@ exports[`AlertContext it has context data 1`] = `
 <ContextProvider
   value={
     Object {
+      "alertError": [Function],
       "alertOpen": false,
+      "alertSuccess": [Function],
       "message": "",
       "setAlertOpen": [Function],
       "setMessage": [Function],

--- a/src/contexts/alertContext/index.jsx
+++ b/src/contexts/alertContext/index.jsx
@@ -30,6 +30,8 @@ export const defaultAlertContext = {
   setAlertOpen: () => false,
   setMessage: () => "",
   setSeverity: () => "success",
+  alertSuccess: () => {},
+  alertError: () => {},
 };
 const AlertContext = createContext(defaultAlertContext);
 
@@ -37,16 +39,28 @@ function AlertProvider({ children }) {
   const [alertOpen, setAlertOpen] = useState(false);
   const [message, setMessage] = useState("");
   const [severity, setSeverity] = useState("success");
+  const alertSuccess = (msg) => {
+    setSeverity("success");
+    setMessage(msg);
+    setAlertOpen(true);
+  };
+  const alertError = (msg) => {
+    setSeverity("error");
+    setMessage(msg);
+    setAlertOpen(true);
+  };
 
   return (
     <AlertContext.Provider
       value={{
+        alertError,
         alertOpen,
+        alertSuccess,
         message,
-        severity,
         setAlertOpen,
         setMessage,
         setSeverity,
+        severity,
       }}
     >
       {children}
@@ -55,11 +69,7 @@ function AlertProvider({ children }) {
 }
 
 AlertProvider.propTypes = {
-  children: T.node,
-};
-
-AlertProvider.defaultProps = {
-  children: null,
+  children: T.node.isRequired,
 };
 
 export { AlertProvider };


### PR DESCRIPTION
In this PR: 

- Added back alertSuccess and alertError to AlertContext
- Changed "success" to "error" in alertError

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

