### PR TITLE
remove unnecessary check and save handcoded iris in constants

### DIFF
--- a/components/bookmark/index.jsx
+++ b/components/bookmark/index.jsx
@@ -27,7 +27,10 @@ import { useBem } from "@solid/lit-prism-patterns";
 import clsx from "clsx";
 import { getUrlAll } from "@inrupt/solid-client";
 import styles from "./styles";
-import { addBookmark } from "../../src/solidClientHelpers/bookmarks";
+import {
+  addBookmark,
+  RECALLS_PROPERTY_IRI,
+} from "../../src/solidClientHelpers/bookmarks";
 import BookmarksContext from "../../src/contexts/bookmarksContext";
 import AlertContext from "../../src/contexts/alertContext";
 
@@ -61,13 +64,7 @@ export const toggleBookmarkHandler = ({
 };
 
 const isBookmarked = (iri, dataset) => {
-  const listOfRecallsUrls = getUrlAll(
-    dataset,
-    "http://www.w3.org/2002/01/bookmark#recalls"
-  );
-  if (!listOfRecallsUrls) {
-    return false;
-  }
+  const listOfRecallsUrls = getUrlAll(dataset, RECALLS_PROPERTY_IRI);
   return listOfRecallsUrls.includes(iri);
 };
 

--- a/components/containerTableRow/index.test.jsx
+++ b/components/containerTableRow/index.test.jsx
@@ -21,6 +21,7 @@
 
 import React from "react";
 import * as routerFns from "next/router";
+import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import { useRouter } from "next/router";
 import { mountToJson } from "../../__testUtils/mountWithTheme";
 import { useFetchResourceDetails } from "../../src/hooks/solidClient";
@@ -29,10 +30,16 @@ import ContainerTableRow, {
   ResourceIcon,
   renderResourceType,
 } from "./index";
+import BookmarksContext from "../../src/contexts/bookmarksContext";
 
 jest.mock("@inrupt/solid-client");
 jest.mock("next/router");
 jest.mock("../../src/hooks/solidClient");
+
+const bookmarks = mockSolidDatasetFrom(
+  "https://somepod.com/bookmarks/index.ttl"
+);
+const setBookmarks = jest.fn();
 
 describe("ContainerTableRow", () => {
   beforeEach(() => {
@@ -58,7 +65,9 @@ describe("ContainerTableRow", () => {
     const tree = mountToJson(
       <table>
         <tbody>
-          <ContainerTableRow resource={resource} />
+          <BookmarksContext.Provider value={(bookmarks, setBookmarks)}>
+            <ContainerTableRow resource={resource} />
+          </BookmarksContext.Provider>
         </tbody>
       </table>
     );
@@ -78,7 +87,9 @@ describe("ContainerTableRow", () => {
     const tree = mountToJson(
       <table>
         <tbody>
-          <ContainerTableRow resource={resource} />
+          <BookmarksContext.Provider value={(bookmarks, setBookmarks)}>
+            <ContainerTableRow resource={resource} />
+          </BookmarksContext.Provider>
         </tbody>
       </table>
     );
@@ -98,7 +109,9 @@ describe("ContainerTableRow", () => {
     const tree = mountToJson(
       <table>
         <tbody>
-          <ContainerTableRow resource={resource} />
+          <BookmarksContext.Provider value={(bookmarks, setBookmarks)}>
+            <ContainerTableRow resource={resource} />
+          </BookmarksContext.Provider>
         </tbody>
       </table>
     );

--- a/src/solidClientHelpers/bookmarks.js
+++ b/src/solidClientHelpers/bookmarks.js
@@ -42,14 +42,18 @@ export async function initializeBookmarks(iri, fetch) {
   return { dataset: bookmarks, iri };
 }
 
+export const RECALLS_PROPERTY_IRI =
+  "http://www.w3.org/2002/01/bookmark#recalls";
+export const BOOKMARK_TYPE_IRI = "http://www.w3.org/2002/01/bookmark#Bookmark";
+
 export async function addBookmark(bookmarkIri, bookmarks, fetch) {
   const { dataset, iri } = bookmarks;
   const bookmarkTitle = getResourceName(bookmarkIri);
   const bookmark = defineThing(
     {},
-    (t) => addUrl(t, rdf.type, "http://www.w3.org/2002/01/bookmark#Bookmark"),
+    (t) => addUrl(t, rdf.type, BOOKMARK_TYPE_IRI),
     (t) => addStringNoLocale(t, dct.title, bookmarkTitle),
-    (t) => addUrl(t, "http://www.w3.org/2002/01/bookmark#recalls", bookmarkIri),
+    (t) => addUrl(t, RECALLS_PROPERTY_IRI, bookmarkIri),
     (t) => addDatetime(t, dct.created, new Date())
   );
 


### PR DESCRIPTION
Changes from previous PR:
- remove unnecessary check for `listOfRecallsUrls`
- update tests 
- save hardcoded IRIs in exported constants