### PR TITLE
Feat/remove bookmark

### DIFF
--- a/components/bookmark/__snapshots__/index.test.jsx.snap
+++ b/components/bookmark/__snapshots__/index.test.jsx.snap
@@ -845,6 +845,7 @@ font-display: block;",
       >
         <button
           className="PodBrowser-button PodBrowser-button--text"
+          disabled={false}
           onClick={[Function]}
           type="button"
         >

--- a/components/bookmark/index.test.jsx
+++ b/components/bookmark/index.test.jsx
@@ -55,8 +55,11 @@ describe("toggleHandler", () => {
     );
 
     expect(tree.html()).toContain("bookmark-icon-unselected");
+  });
 
+  test("it updates the icon when adding bookmarks", async () => {
     const setBookmarked = jest.fn();
+    const setDisabled = jest.fn();
 
     const toggleHandler = toggleBookmarkHandler({
       bookmarks,
@@ -67,6 +70,7 @@ describe("toggleHandler", () => {
       setAlertOpen: jest.fn(),
       setBookmarked,
       setBookmarks,
+      setDisabled,
       fetch: jest.fn(),
     });
 
@@ -75,7 +79,32 @@ describe("toggleHandler", () => {
       .mockResolvedValueOnce({ response: bookmarks });
 
     await toggleHandler();
-    expect(setBookmarked).toHaveBeenCalled();
+    expect(setBookmarked).toHaveBeenCalledWith(true);
+    expect(setBookmarks).toHaveBeenCalled();
+  });
+  test("it updates the icon when removing bookmarks", async () => {
+    const setBookmarked = jest.fn();
+    const setDisabled = jest.fn();
+
+    const toggleHandler = toggleBookmarkHandler({
+      bookmarks,
+      bookmarked: true,
+      iri,
+      setSeverity: jest.fn(),
+      setMessage: jest.fn(),
+      setAlertOpen: jest.fn(),
+      setBookmarked,
+      setBookmarks,
+      setDisabled,
+      fetch: jest.fn(),
+    });
+
+    jest
+      .spyOn(bookmarkHelpers, "removeBookmark")
+      .mockResolvedValueOnce({ response: bookmarks });
+
+    await toggleHandler();
+    expect(setBookmarked).toHaveBeenCalledWith(false);
     expect(setBookmarks).toHaveBeenCalled();
   });
   test("it renders an error when it is unsuccessful in adding bookmark", async () => {
@@ -93,6 +122,7 @@ describe("toggleHandler", () => {
     const setAlertOpen = jest.fn();
     const setSeverity = jest.fn();
     const setMessage = jest.fn();
+    const setDisabled = jest.fn();
 
     const toggleHandler = toggleBookmarkHandler({
       bookmarks,
@@ -103,6 +133,7 @@ describe("toggleHandler", () => {
       setAlertOpen,
       setBookmarked,
       setBookmarks,
+      setDisabled,
       fetch: jest.fn(),
     });
 

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -25888,6 +25888,7 @@ font-display: block;",
                             >
                               <button
                                 className="PodBrowser-button PodBrowser-button--text"
+                                disabled={false}
                                 onClick={[Function]}
                                 type="button"
                               >
@@ -25947,6 +25948,7 @@ font-display: block;",
                             >
                               <button
                                 className="PodBrowser-button PodBrowser-button--text"
+                                disabled={false}
                                 onClick={[Function]}
                                 type="button"
                               >
@@ -26006,6 +26008,7 @@ font-display: block;",
                             >
                               <button
                                 className="PodBrowser-button PodBrowser-button--text"
+                                disabled={false}
                                 onClick={[Function]}
                                 type="button"
                               >

--- a/components/containerTableRow/__snapshots__/index.test.jsx.snap
+++ b/components/containerTableRow/__snapshots__/index.test.jsx.snap
@@ -863,6 +863,7 @@ font-display: block;",
                 >
                   <button
                     className="PodBrowser-button PodBrowser-button--text"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >
@@ -1771,6 +1772,7 @@ font-display: block;",
                 >
                   <button
                     className="PodBrowser-button PodBrowser-button--text"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >
@@ -2677,6 +2679,7 @@ font-display: block;",
                 >
                   <button
                     className="PodBrowser-button PodBrowser-button--text"
+                    disabled={false}
                     onClick={[Function]}
                     type="button"
                   >


### PR DESCRIPTION
# Add functionality to remove bookmark

Clicking on a previously bookmarked resource's bookmark icon will now remove the bookmark.

## Notes
To prevent errors from a user clicking too fast, the button is temporarily disabled until the bookmarks' dataset is effectively updated. 

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
