### PR TITLE
Feature flags

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -46,6 +46,7 @@ import {
 import theme from "../src/theme";
 import { AlertProvider } from "../src/contexts/alertContext";
 import { ConfirmationDialogProvider } from "../src/contexts/confirmationDialogContext";
+import { FeatureProvider } from "../src/contexts/featureFlagsContext";
 import Notification from "../components/notification";
 import ConfirmationDialog from "../components/confirmationDialog";
 import PodBrowserHeader from "../components/header";
@@ -110,23 +111,25 @@ export default function App(props: AppProps): ReactElement {
       <StylesProvider jss={jss}>
         <ThemeProvider theme={theme}>
           <SessionProvider sessionId="pod-browser">
-            <AlertProvider>
-              <ConfirmationDialogProvider>
-                <CssBaseline />
-                <div className={bem("app-layout")}>
-                  <PodBrowserHeader />
-                  <main className={bem("app-layout__main")}>
-                    <Component {...pageProps} />
-                  </main>
-                  <div className={bem("app-layout__footer")}>
-                    <PodBrowserFooter />
+            <FeatureProvider>
+              <AlertProvider>
+                <ConfirmationDialogProvider>
+                  <CssBaseline />
+                  <div className={bem("app-layout")}>
+                    <PodBrowserHeader />
+                    <main className={bem("app-layout__main")}>
+                      <Component {...pageProps} />
+                    </main>
+                    <div className={bem("app-layout__footer")}>
+                      <PodBrowserFooter />
+                    </div>
                   </div>
-                </div>
 
-                <Notification />
-                <ConfirmationDialog />
-              </ConfirmationDialogProvider>
-            </AlertProvider>
+                  <Notification />
+                  <ConfirmationDialog />
+                </ConfirmationDialogProvider>
+              </AlertProvider>
+            </FeatureProvider>
           </SessionProvider>
         </ThemeProvider>
       </StylesProvider>

--- a/src/featureFlags/index.js
+++ b/src/featureFlags/index.js
@@ -19,46 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const tsConfig = require("./tsconfig.json");
+export const ACP_ENABLED = "acpEnabled";
+export const acpEnabled = () => false;
 
-module.exports = {
-  // Automatically clear mock calls and instances between every test
-  clearMocks: true,
+export const WAC_ENABLED = "wacEnabled";
+export const wacEnabled = () => true;
 
-  // The test environment that will be used for testing
-  testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>jest/setupTests.js"],
-
-  testPathIgnorePatterns: ["/node_modules/", "/__testUtils/"],
-
-  transform: {
-    "^.+\\.(js|jsx|ts|tsx)$": "ts-jest",
-    "^.+\\.ttl$": "jest-raw-loader",
-  },
-
-  // ts config
-  globals: {
-    "ts-jest": {
-      tsConfig: { ...tsConfig.compilerOptions, jsx: "react" },
-    },
-  },
-
-  // Coverage configs
-  collectCoverage: true,
-
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "/__testUtils/",
-    "styles.ts",
-    "/src/windowHelpers",
-  ],
-
-  coverageThreshold: {
-    global: {
-      branches: 89,
-      functions: 89,
-      lines: 95,
-      statements: 95,
-    },
-  },
-};
+export default () => ({
+  [ACP_ENABLED]: acpEnabled,
+  [WAC_ENABLED]: wacEnabled,
+});

--- a/src/featureFlags/index.test.js
+++ b/src/featureFlags/index.test.js
@@ -19,46 +19,23 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const tsConfig = require("./tsconfig.json");
+import rules, {
+  acpEnabled,
+  ACP_ENABLED,
+  wacEnabled,
+  WAC_ENABLED,
+} from "./index";
 
-module.exports = {
-  // Automatically clear mock calls and instances between every test
-  clearMocks: true,
+describe("rules", () => {
+  test("it indexes all rules", () => {
+    expect(Object.keys(rules())).toEqual([ACP_ENABLED, WAC_ENABLED]);
+  });
 
-  // The test environment that will be used for testing
-  testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>jest/setupTests.js"],
+  test("it has rules for acp", () => {
+    expect(acpEnabled()).toBe(false);
+  });
 
-  testPathIgnorePatterns: ["/node_modules/", "/__testUtils/"],
-
-  transform: {
-    "^.+\\.(js|jsx|ts|tsx)$": "ts-jest",
-    "^.+\\.ttl$": "jest-raw-loader",
-  },
-
-  // ts config
-  globals: {
-    "ts-jest": {
-      tsConfig: { ...tsConfig.compilerOptions, jsx: "react" },
-    },
-  },
-
-  // Coverage configs
-  collectCoverage: true,
-
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "/__testUtils/",
-    "styles.ts",
-    "/src/windowHelpers",
-  ],
-
-  coverageThreshold: {
-    global: {
-      branches: 89,
-      functions: 89,
-      lines: 95,
-      statements: 95,
-    },
-  },
-};
+  test("it has rules for wac", () => {
+    expect(wacEnabled()).toBe(true);
+  });
+});

--- a/src/hooks/useFeatureFlags/index.js
+++ b/src/hooks/useFeatureFlags/index.js
@@ -19,46 +19,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const tsConfig = require("./tsconfig.json");
+import { useContext } from "react";
+import FeatureContext from "../../contexts/featureFlagsContext";
 
-module.exports = {
-  // Automatically clear mock calls and instances between every test
-  clearMocks: true,
-
-  // The test environment that will be used for testing
-  testEnvironment: "jsdom",
-  setupFilesAfterEnv: ["<rootDir>jest/setupTests.js"],
-
-  testPathIgnorePatterns: ["/node_modules/", "/__testUtils/"],
-
-  transform: {
-    "^.+\\.(js|jsx|ts|tsx)$": "ts-jest",
-    "^.+\\.ttl$": "jest-raw-loader",
-  },
-
-  // ts config
-  globals: {
-    "ts-jest": {
-      tsConfig: { ...tsConfig.compilerOptions, jsx: "react" },
-    },
-  },
-
-  // Coverage configs
-  collectCoverage: true,
-
-  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "/__testUtils/",
-    "styles.ts",
-    "/src/windowHelpers",
-  ],
-
-  coverageThreshold: {
-    global: {
-      branches: 89,
-      functions: 89,
-      lines: 95,
-      statements: 95,
-    },
-  },
-};
+export default function useFeatureFlag(flag, context) {
+  const { enabled } = useContext(FeatureContext);
+  return enabled(flag, context);
+}

--- a/src/hooks/useFeatureFlags/index.test.jsx
+++ b/src/hooks/useFeatureFlags/index.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import * as React from "react";
+import { renderHook } from "@testing-library/react-hooks";
+import FeatureFlagContext from "../../contexts/featureFlagsContext";
+import useFeature from "./index";
+
+describe("useFeature() hook functional testing", () => {
+  it("The hook should return values set in the FeatureFlagContext", async () => {
+    const wrapper = ({ children }) => (
+      <FeatureFlagContext.Provider
+        value={{
+          enabled: (arg) => `${arg}-foo`,
+        }}
+      >
+        {children}
+      </FeatureFlagContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFeature("test"), { wrapper });
+
+    expect(result.current).toEqual("test-foo");
+  });
+});


### PR DESCRIPTION
# Feature Flags

# Checklist

- [x] All acceptance criteria are met.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

I ended up rewriting everything and simplifying feature flags instead of pulling in a library for it.

* Specify rules in src/featureFlags, which are functions which receive a session and any extra context you pass in to the `enabled` or `useFeature` functions
* In components, use `useFeature("feature-key")` which returns a boolean.
* In components, optionally use `useFeature("feature-key", { whatever: "some-value" })` if you need to pass additional data to a feature flag function.

Example:

```
import { WAC_ENABLED } from "../src/featureFlags";

function WACEnabledIndicator() {
  const wacEnabled = useFeature(WAC_ENABLED);
  return wacEnabled ? "yes" : "no";
}
```

This seems like a bit of overkill still (why not just call wacEnabled() directly?) but it'll make more sense once we need session data to enable/disable features, or to combine functions together, load querystrings, env variables, etc.