### PR TITLE
Make saveContact generic to type

### DIFF
--- a/__testUtils/mockContactResource.js
+++ b/__testUtils/mockContactResource.js
@@ -19,29 +19,16 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import useSWR from "swr";
-import { useSession } from "@inrupt/solid-ui-react";
-import { getSourceUrl } from "@inrupt/solid-client";
-import { foaf } from "rdf-namespaces";
-import { getContacts } from "../../addressBook";
+import { addUrl, mockThingFrom } from "@inrupt/solid-client";
+import { vcard, rdf, foaf } from "rdf-namespaces";
+import { chain } from "../src/solidClientHelpers/utils";
 
-export default function usePeople(addressBook) {
-  const {
-    session: { fetch },
-  } = useSession();
+export const webIdUrl = "http://example.com/alice#me";
 
-  return useSWR(addressBook, async () => {
-    const contactsIri = getSourceUrl(addressBook);
-    const { response, error } = await getContacts(
-      foaf.Person,
-      contactsIri,
-      fetch
-    );
-
-    if (error) {
-      throw error;
-    }
-
-    return response;
-  });
+export function mockPersonContactDataset() {
+  return chain(
+    mockThingFrom(webIdUrl),
+    (t) => addUrl(t, rdf.type, vcard.Individual),
+    (t) => addUrl(t, foaf.openid, webIdUrl)
+  );
 }

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -20,7 +20,7 @@
  */
 
 import { addStringNoLocale, addUrl, mockThingFrom } from "@inrupt/solid-client";
-import { vcard, foaf } from "rdf-namespaces";
+import { vcard, foaf, rdf } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { packageProfile } from "../src/solidClientHelpers/profile";
 
@@ -34,7 +34,8 @@ export function mockPersonDatasetAlice() {
     mockThingFrom(aliceWebIdUrl),
     (t) => addStringNoLocale(t, vcard.fn, aliceName),
     (t) => addStringNoLocale(t, vcard.nickname, aliceNick),
-    (t) => addUrl(t, vcard.hasPhoto, alicePhoto)
+    (t) => addUrl(t, vcard.hasPhoto, alicePhoto),
+    (t) => addUrl(t, rdf.type, foaf.Person)
   );
 }
 
@@ -50,7 +51,8 @@ export function mockPersonDatasetBob() {
   return chain(
     mockThingFrom(bobWebIdUrl),
     (t) => addStringNoLocale(t, foaf.name, bobName),
-    (t) => addStringNoLocale(t, foaf.nick, bobNick)
+    (t) => addStringNoLocale(t, foaf.nick, bobNick),
+    (t) => addUrl(t, rdf.type, foaf.Person)
   );
 }
 

--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -63,7 +63,7 @@ export function handleSubmit({
     const addressBookIri = getSourceUrl(addressBook);
 
     try {
-      const { name, webId } = await fetchProfile(iri, fetch);
+      const { name, webId, types } = await fetchProfile(iri, fetch);
 
       const existingContact = await findContactInAddressBook(
         addressBookIri,
@@ -82,6 +82,7 @@ export function handleSubmit({
         const { response, error } = await saveContact(
           addressBookIri,
           contact,
+          types,
           fetch
         );
 

--- a/components/contactsList/__snapshots__/index.test.jsx.snap
+++ b/components/contactsList/__snapshots__/index.test.jsx.snap
@@ -2754,6 +2754,20 @@ font-display: block;",
                                   "value": "http://example.com/alice#me",
                                 },
                               },
+                              Quad {
+                                "graph": DefaultGraph {
+                                  "value": "",
+                                },
+                                "object": NamedNode {
+                                  "value": "http://xmlns.com/foaf/0.1/Person",
+                                },
+                                "predicate": NamedNode {
+                                  "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                                },
+                                "subject": NamedNode {
+                                  "value": "http://example.com/alice#me",
+                                },
+                              },
                             },
                           },
                           DatasetCore {
@@ -2795,6 +2809,20 @@ font-display: block;",
                                   "value": "http://example.com/bob#me",
                                 },
                               },
+                              Quad {
+                                "graph": DefaultGraph {
+                                  "value": "",
+                                },
+                                "object": NamedNode {
+                                  "value": "http://xmlns.com/foaf/0.1/Person",
+                                },
+                                "predicate": NamedNode {
+                                  "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                                },
+                                "subject": NamedNode {
+                                  "value": "http://example.com/bob#me",
+                                },
+                              },
                             },
                           },
                         ]
@@ -2818,12 +2846,18 @@ font-display: block;",
                               "avatar": "http://example.com/alice.jpg",
                               "name": "Alice",
                               "nickname": "A",
+                              "types": Array [
+                                "http://xmlns.com/foaf/0.1/Person",
+                              ],
                               "webId": "http://example.com/alice#me",
                             },
                             Object {
                               "avatar": null,
                               "name": "Bob",
                               "nickname": "B",
+                              "types": Array [
+                                "http://xmlns.com/foaf/0.1/Person",
+                              ],
                               "webId": "http://example.com/bob#me",
                             },
                           ]
@@ -2870,12 +2904,18 @@ font-display: block;",
                                 "avatar": "http://example.com/alice.jpg",
                                 "name": "Alice",
                                 "nickname": "A",
+                                "types": Array [
+                                  "http://xmlns.com/foaf/0.1/Person",
+                                ],
                                 "webId": "http://example.com/alice#me",
                               },
                               Object {
                                 "avatar": null,
                                 "name": "Bob",
                                 "nickname": "B",
+                                "types": Array [
+                                  "http://xmlns.com/foaf/0.1/Person",
+                                ],
                                 "webId": "http://example.com/bob#me",
                               },
                             ]
@@ -3703,6 +3743,20 @@ font-display: block;",
                                     "value": "http://example.com/alice#me",
                                   },
                                 },
+                                Quad {
+                                  "graph": DefaultGraph {
+                                    "value": "",
+                                  },
+                                  "object": NamedNode {
+                                    "value": "http://xmlns.com/foaf/0.1/Person",
+                                  },
+                                  "predicate": NamedNode {
+                                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                                  },
+                                  "subject": NamedNode {
+                                    "value": "http://example.com/alice#me",
+                                  },
+                                },
                               },
                             },
                           },
@@ -3742,6 +3796,20 @@ font-display: block;",
                                   },
                                   "predicate": NamedNode {
                                     "value": "http://xmlns.com/foaf/0.1/nick",
+                                  },
+                                  "subject": NamedNode {
+                                    "value": "http://example.com/bob#me",
+                                  },
+                                },
+                                Quad {
+                                  "graph": DefaultGraph {
+                                    "value": "",
+                                  },
+                                  "object": NamedNode {
+                                    "value": "http://xmlns.com/foaf/0.1/Person",
+                                  },
+                                  "predicate": NamedNode {
+                                    "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
                                   },
                                   "subject": NamedNode {
                                     "value": "http://example.com/bob#me",
@@ -3853,6 +3921,20 @@ font-display: block;",
                                         "value": "http://example.com/alice#me",
                                       },
                                     },
+                                    Quad {
+                                      "graph": DefaultGraph {
+                                        "value": "",
+                                      },
+                                      "object": NamedNode {
+                                        "value": "http://xmlns.com/foaf/0.1/Person",
+                                      },
+                                      "predicate": NamedNode {
+                                        "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                                      },
+                                      "subject": NamedNode {
+                                        "value": "http://example.com/alice#me",
+                                      },
+                                    },
                                   },
                                 }
                               }
@@ -3910,6 +3992,20 @@ font-display: block;",
                                           },
                                           "predicate": NamedNode {
                                             "value": "http://www.w3.org/2006/vcard/ns#hasPhoto",
+                                          },
+                                          "subject": NamedNode {
+                                            "value": "http://example.com/alice#me",
+                                          },
+                                        },
+                                        Quad {
+                                          "graph": DefaultGraph {
+                                            "value": "",
+                                          },
+                                          "object": NamedNode {
+                                            "value": "http://xmlns.com/foaf/0.1/Person",
+                                          },
+                                          "predicate": NamedNode {
+                                            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
                                           },
                                           "subject": NamedNode {
                                             "value": "http://example.com/alice#me",
@@ -16650,6 +16746,20 @@ font-display: block;",
                                         "value": "http://example.com/bob#me",
                                       },
                                     },
+                                    Quad {
+                                      "graph": DefaultGraph {
+                                        "value": "",
+                                      },
+                                      "object": NamedNode {
+                                        "value": "http://xmlns.com/foaf/0.1/Person",
+                                      },
+                                      "predicate": NamedNode {
+                                        "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                                      },
+                                      "subject": NamedNode {
+                                        "value": "http://example.com/bob#me",
+                                      },
+                                    },
                                   },
                                 }
                               }
@@ -16693,6 +16803,20 @@ font-display: block;",
                                           },
                                           "predicate": NamedNode {
                                             "value": "http://xmlns.com/foaf/0.1/nick",
+                                          },
+                                          "subject": NamedNode {
+                                            "value": "http://example.com/bob#me",
+                                          },
+                                        },
+                                        Quad {
+                                          "graph": DefaultGraph {
+                                            "value": "",
+                                          },
+                                          "object": NamedNode {
+                                            "value": "http://xmlns.com/foaf/0.1/Person",
+                                          },
+                                          "predicate": NamedNode {
+                                            "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
                                           },
                                           "subject": NamedNode {
                                             "value": "http://example.com/bob#me",

--- a/components/contactsList/contactsListSearch/__snapshots__/index.test.jsx.snap
+++ b/components/contactsList/contactsListSearch/__snapshots__/index.test.jsx.snap
@@ -900,6 +900,20 @@ font-display: block;",
                       "value": "http://example.com/alice#me",
                     },
                   },
+                  Quad {
+                    "graph": DefaultGraph {
+                      "value": "",
+                    },
+                    "object": NamedNode {
+                      "value": "http://xmlns.com/foaf/0.1/Person",
+                    },
+                    "predicate": NamedNode {
+                      "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                    },
+                    "subject": NamedNode {
+                      "value": "http://example.com/alice#me",
+                    },
+                  },
                 },
               },
               DatasetCore {
@@ -941,6 +955,20 @@ font-display: block;",
                       "value": "http://example.com/bob#me",
                     },
                   },
+                  Quad {
+                    "graph": DefaultGraph {
+                      "value": "",
+                    },
+                    "object": NamedNode {
+                      "value": "http://xmlns.com/foaf/0.1/Person",
+                    },
+                    "predicate": NamedNode {
+                      "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+                    },
+                    "subject": NamedNode {
+                      "value": "http://example.com/bob#me",
+                    },
+                  },
                 },
               },
             ]
@@ -964,12 +992,18 @@ font-display: block;",
                   "avatar": "http://example.com/alice.jpg",
                   "name": "Alice",
                   "nickname": "A",
+                  "types": Array [
+                    "http://xmlns.com/foaf/0.1/Person",
+                  ],
                   "webId": "http://example.com/alice#me",
                 },
                 Object {
                   "avatar": null,
                   "name": "Bob",
                   "nickname": "B",
+                  "types": Array [
+                    "http://xmlns.com/foaf/0.1/Person",
+                  ],
                   "webId": "http://example.com/bob#me",
                 },
               ]
@@ -1016,12 +1050,18 @@ font-display: block;",
                     "avatar": "http://example.com/alice.jpg",
                     "name": "Alice",
                     "nickname": "A",
+                    "types": Array [
+                      "http://xmlns.com/foaf/0.1/Person",
+                    ],
                     "webId": "http://example.com/alice#me",
                   },
                   Object {
                     "avatar": null,
                     "name": "Bob",
                     "nickname": "B",
+                    "types": Array [
+                      "http://xmlns.com/foaf/0.1/Person",
+                    ],
                     "webId": "http://example.com/bob#me",
                   },
                 ]

--- a/components/contactsList/contactsListSearch/index.jsx
+++ b/components/contactsList/contactsListSearch/index.jsx
@@ -28,7 +28,7 @@ import Router from "next/router";
 import { Autocomplete } from "@material-ui/lab";
 import { createStyles, TextField } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
-import { getProfileFromPersonDataset } from "../../../src/solidClientHelpers/profile";
+import { getProfileFromThing } from "../../../src/solidClientHelpers/profile";
 import SearchContext from "../../../src/contexts/searchContext";
 import { buildProfileLink } from "../../profileLink";
 import styles from "./styles";
@@ -40,7 +40,7 @@ export default function ContactsListSearch({ people }) {
   const { setSearch } = useContext(SearchContext);
   const classes = useStyles();
 
-  const profiles = people.map(getProfileFromPersonDataset);
+  const profiles = people.map(getProfileFromThing);
 
   return (
     <Autocomplete

--- a/src/hooks/usePeople/index.test.jsx
+++ b/src/hooks/usePeople/index.test.jsx
@@ -23,10 +23,11 @@ import React from "react";
 import { renderHook } from "@testing-library/react-hooks";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import { cache, SWRConfig } from "swr";
+import { foaf } from "rdf-namespaces";
 import usePeople from "./index";
 import mockSession from "../../../__testUtils/mockSession";
 import mockSessionContextProvider from "../../../__testUtils/mockSessionContextProvider";
-import { getPeople } from "../../addressBook";
+import { getContacts } from "../../addressBook";
 
 jest.mock("../../addressBook");
 
@@ -67,18 +68,22 @@ describe("usePeople", () => {
       cache.clear();
     });
 
-    it("should call getPeople", async () => {
-      getPeople.mockResolvedValue({ response });
+    it("should call getContacts", async () => {
+      getContacts.mockResolvedValue({ response });
 
       renderHook(() => usePeople(addressBook), {
         wrapper,
       });
 
-      expect(getPeople).toHaveBeenCalledWith(addressBookUrl, session.fetch);
+      expect(getContacts).toHaveBeenCalledWith(
+        foaf.Person,
+        addressBookUrl,
+        session.fetch
+      );
     });
 
     it("should return response", async () => {
-      getPeople.mockResolvedValue({ response });
+      getContacts.mockResolvedValue({ response });
 
       const { result, waitFor } = renderHook(() => usePeople(addressBook), {
         wrapper,
@@ -94,7 +99,7 @@ describe("usePeople", () => {
 
     it("should return error", async () => {
       const error = "Some error";
-      getPeople.mockResolvedValue({ error });
+      getContacts.mockResolvedValue({ error });
 
       const { result, waitFor } = renderHook(() => usePeople(addressBook), {
         wrapper,

--- a/src/solidClientHelpers/profile.test.js
+++ b/src/solidClientHelpers/profile.test.js
@@ -20,10 +20,11 @@
  */
 
 import { getSolidDataset } from "@inrupt/solid-client";
+import { schema, foaf } from "rdf-namespaces";
 import {
   displayProfileName,
   fetchProfile,
-  getProfileFromPersonDataset,
+  getProfileFromPersonThing,
 } from "./profile";
 import {
   mockPersonDatasetAlice,
@@ -60,31 +61,35 @@ describe("fetchProfile", () => {
 
     const profile = await fetchProfile(profileWebId, fetch);
     const dataset = await getSolidDataset(profileWebId, { fetch });
+
     expect(profile.webId).toEqual(profileWebId);
     expect(profile.name).toEqual("Test Testersen");
     expect(profile.nickname).toEqual("Testy");
     expect(profile.avatar).toEqual("http://example.com/photo.jpg");
     expect(profile.pods).toEqual(["http://example.com/"]);
+    expect(profile.types).toEqual([schema.Person, foaf.Person]);
     expect(profile.dataset).toEqual(dataset);
   });
 });
 
-describe("getProfileFromPersonDataset", () => {
+describe("getProfileFromPersonThing", () => {
   test("it maps people into profiles", async () => {
     const alice = mockProfileAlice();
-    expect(getProfileFromPersonDataset(mockPersonDatasetAlice())).toEqual({
+    expect(getProfileFromPersonThing(mockPersonDatasetAlice())).toEqual({
       avatar: alice.avatar,
       name: alice.name,
       nickname: alice.nickname,
       webId: alice.webId,
+      types: ["http://xmlns.com/foaf/0.1/Person"],
     });
 
     const bob = mockProfileBob();
-    expect(getProfileFromPersonDataset(mockPersonDatasetBob())).toEqual({
+    expect(getProfileFromPersonThing(mockPersonDatasetBob())).toEqual({
       avatar: bob.avatar,
       name: bob.name,
       nickname: bob.nickname,
       webId: bob.webId,
+      types: ["http://xmlns.com/foaf/0.1/Person"],
     });
   });
 });


### PR DESCRIPTION
This modifies `saveContact` to map types to container / file names.

We are currently storing all person contacts in “people.ttl” and the “People/” container. I have updated the code to allow for switching the index file and container name based on type of contact - which is currently pulled from the type of the profile (reading the Thing by foaf.primaryTopic or foaf.maker when defined.) If the profile is a foaf.Person (regardless of it it has multiple types), we treat it as a contact and add it to “people”, or otherwise we display an error message.

Using a specific file name (people.ttl, People/) is pretty hacky compared to including the contact type in an overall index file, but this maintains compatibility with databrowser.