### PR TITLE
Add a Files link to the header nav leading to the pod root/files navigation view

### DIFF
--- a/components/header/__snapshots__/index.test.jsx.snap
+++ b/components/header/__snapshots__/index.test.jsx.snap
@@ -936,27 +936,6 @@ font-display: block;",
                       className="PodBrowser-main-nav__item"
                     >
                       <Link
-                        href="/contacts"
-                        replace={true}
-                      >
-                        <button
-                          className="PodBrowser-header-banner__aside-menu-trigger"
-                          onClick={[Function]}
-                          onMouseEnter={[Function]}
-                          type="button"
-                        >
-                          <i
-                            aria-label="Contacts"
-                            className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
-                          />
-                          Contacts
-                        </button>
-                      </Link>
-                    </li>
-                    <li
-                      className="PodBrowser-main-nav__item"
-                    >
-                      <Link
                         href="/"
                         replace={true}
                       >
@@ -971,6 +950,27 @@ font-display: block;",
                             className="PodBrowser-icon-files PodBrowser-header-banner__aside-menu-trigger-icon"
                           />
                           Files
+                        </button>
+                      </Link>
+                    </li>
+                    <li
+                      className="PodBrowser-main-nav__item"
+                    >
+                      <Link
+                        href="/contacts"
+                        replace={true}
+                      >
+                        <button
+                          className="PodBrowser-header-banner__aside-menu-trigger"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          type="button"
+                        >
+                          <i
+                            aria-label="Contacts"
+                            className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
+                          />
+                          Contacts
                         </button>
                       </Link>
                     </li>

--- a/components/header/__snapshots__/index.test.jsx.snap
+++ b/components/header/__snapshots__/index.test.jsx.snap
@@ -926,27 +926,56 @@ font-display: block;",
                 <PodIndicator />
               </div>
               <UserMenu>
-                <div
+                <nav
                   className="PodBrowser-header-banner__main-nav"
                 >
-                  <Link
-                    href="/contacts"
-                    replace={true}
+                  <ul
+                    className="PodBrowser-main-nav__list"
                   >
-                    <button
-                      className="PodBrowser-header-banner__aside-menu-trigger"
-                      onClick={[Function]}
-                      onMouseEnter={[Function]}
-                      type="button"
+                    <li
+                      className="PodBrowser-main-nav__item"
                     >
-                      <i
-                        aria-label="Contacts"
-                        className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
-                      />
-                      Contacts
-                    </button>
-                  </Link>
-                </div>
+                      <Link
+                        href="/contacts"
+                        replace={true}
+                      >
+                        <button
+                          className="PodBrowser-header-banner__aside-menu-trigger"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          type="button"
+                        >
+                          <i
+                            aria-label="Contacts"
+                            className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
+                          />
+                          Contacts
+                        </button>
+                      </Link>
+                    </li>
+                    <li
+                      className="PodBrowser-main-nav__item"
+                    >
+                      <Link
+                        href="/"
+                        replace={true}
+                      >
+                        <button
+                          className="PodBrowser-header-banner__aside-menu-trigger"
+                          onClick={[Function]}
+                          onMouseEnter={[Function]}
+                          type="button"
+                        >
+                          <i
+                            aria-label="Files"
+                            className="PodBrowser-icon-files PodBrowser-header-banner__aside-menu-trigger-icon"
+                          />
+                          Files
+                        </button>
+                      </Link>
+                    </li>
+                  </ul>
+                </nav>
                 <div>
                   <Link
                     href="/bookmarks"

--- a/components/header/userMenu/__snapshots__/index.test.jsx.snap
+++ b/components/header/userMenu/__snapshots__/index.test.jsx.snap
@@ -841,27 +841,56 @@ font-display: block;",
       }
     >
       <UserMenu>
-        <div
+        <nav
           className="PodBrowser-header-banner__main-nav"
         >
-          <Link
-            href="/contacts"
-            replace={true}
+          <ul
+            className="PodBrowser-main-nav__list"
           >
-            <button
-              className="PodBrowser-header-banner__aside-menu-trigger"
-              onClick={[Function]}
-              onMouseEnter={[Function]}
-              type="button"
+            <li
+              className="PodBrowser-main-nav__item"
             >
-              <i
-                aria-label="Contacts"
-                className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
-              />
-              Contacts
-            </button>
-          </Link>
-        </div>
+              <Link
+                href="/contacts"
+                replace={true}
+              >
+                <button
+                  className="PodBrowser-header-banner__aside-menu-trigger"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-label="Contacts"
+                    className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
+                  />
+                  Contacts
+                </button>
+              </Link>
+            </li>
+            <li
+              className="PodBrowser-main-nav__item"
+            >
+              <Link
+                href="/"
+                replace={true}
+              >
+                <button
+                  className="PodBrowser-header-banner__aside-menu-trigger"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-label="Files"
+                    className="PodBrowser-icon-files PodBrowser-header-banner__aside-menu-trigger-icon"
+                  />
+                  Files
+                </button>
+              </Link>
+            </li>
+          </ul>
+        </nav>
         <div>
           <Link
             href="/bookmarks"

--- a/components/header/userMenu/__snapshots__/index.test.jsx.snap
+++ b/components/header/userMenu/__snapshots__/index.test.jsx.snap
@@ -851,27 +851,6 @@ font-display: block;",
               className="PodBrowser-main-nav__item"
             >
               <Link
-                href="/contacts"
-                replace={true}
-              >
-                <button
-                  className="PodBrowser-header-banner__aside-menu-trigger"
-                  onClick={[Function]}
-                  onMouseEnter={[Function]}
-                  type="button"
-                >
-                  <i
-                    aria-label="Contacts"
-                    className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
-                  />
-                  Contacts
-                </button>
-              </Link>
-            </li>
-            <li
-              className="PodBrowser-main-nav__item"
-            >
-              <Link
                 href="/"
                 replace={true}
               >
@@ -886,6 +865,27 @@ font-display: block;",
                     className="PodBrowser-icon-files PodBrowser-header-banner__aside-menu-trigger-icon"
                   />
                   Files
+                </button>
+              </Link>
+            </li>
+            <li
+              className="PodBrowser-main-nav__item"
+            >
+              <Link
+                href="/contacts"
+                replace={true}
+              >
+                <button
+                  className="PodBrowser-header-banner__aside-menu-trigger"
+                  onClick={[Function]}
+                  onMouseEnter={[Function]}
+                  type="button"
+                >
+                  <i
+                    aria-label="Contacts"
+                    className="PodBrowser-icon-users PodBrowser-header-banner__aside-menu-trigger-icon"
+                  />
+                  Contacts
                 </button>
               </Link>
             </li>

--- a/components/header/userMenu/index.tsx
+++ b/components/header/userMenu/index.tsx
@@ -44,23 +44,6 @@ export default function UserMenu(): ReactElement {
       <nav className={bem("header-banner__main-nav")}>
         <ul className={bem("main-nav__list")}>
           <li className={bem("main-nav__item")}>
-            <Link href="/contacts" replace>
-              <button
-                className={bem("header-banner__aside-menu-trigger")}
-                type="button"
-              >
-                <i
-                  className={clsx(
-                    bem("icon-users"),
-                    bem("header-banner__aside-menu-trigger-icon")
-                  )}
-                  aria-label="Contacts"
-                />
-                Contacts
-              </button>
-            </Link>
-          </li>
-          <li className={bem("main-nav__item")}>
             <Link href="/" replace>
               <button
                 className={bem("header-banner__aside-menu-trigger")}
@@ -74,6 +57,23 @@ export default function UserMenu(): ReactElement {
                   aria-label="Files"
                 />
                 Files
+              </button>
+            </Link>
+          </li>
+          <li className={bem("main-nav__item")}>
+            <Link href="/contacts" replace>
+              <button
+                className={bem("header-banner__aside-menu-trigger")}
+                type="button"
+              >
+                <i
+                  className={clsx(
+                    bem("icon-users"),
+                    bem("header-banner__aside-menu-trigger-icon")
+                  )}
+                  aria-label="Contacts"
+                />
+                Contacts
               </button>
             </Link>
           </li>

--- a/components/header/userMenu/index.tsx
+++ b/components/header/userMenu/index.tsx
@@ -41,23 +41,44 @@ export default function UserMenu(): ReactElement {
 
   return (
     <>
-      <div className={bem("header-banner__main-nav")}>
-        <Link href="/contacts" replace>
-          <button
-            className={bem("header-banner__aside-menu-trigger")}
-            type="button"
-          >
-            <i
-              className={clsx(
-                bem("icon-users"),
-                bem("header-banner__aside-menu-trigger-icon")
-              )}
-              aria-label="Contacts"
-            />
-            Contacts
-          </button>
-        </Link>
-      </div>
+      <nav className={bem("header-banner__main-nav")}>
+        <ul className={bem("main-nav__list")}>
+          <li className={bem("main-nav__item")}>
+            <Link href="/contacts" replace>
+              <button
+                className={bem("header-banner__aside-menu-trigger")}
+                type="button"
+              >
+                <i
+                  className={clsx(
+                    bem("icon-users"),
+                    bem("header-banner__aside-menu-trigger-icon")
+                  )}
+                  aria-label="Contacts"
+                />
+                Contacts
+              </button>
+            </Link>
+          </li>
+          <li className={bem("main-nav__item")}>
+            <Link href="/" replace>
+              <button
+                className={bem("header-banner__aside-menu-trigger")}
+                type="button"
+              >
+                <i
+                  className={clsx(
+                    bem("icon-files"),
+                    bem("header-banner__aside-menu-trigger-icon")
+                  )}
+                  aria-label="Files"
+                />
+                Files
+              </button>
+            </Link>
+          </li>
+        </ul>
+      </nav>
       <div>
         <Link href="/bookmarks" replace>
           <button

--- a/components/header/userMenu/styles.ts
+++ b/components/header/userMenu/styles.ts
@@ -22,6 +22,6 @@
 import { PrismTheme, createStyles } from "@solid/lit-prism-patterns";
 
 const styles = (theme: PrismTheme) =>
-  createStyles(theme, ["headerBanner", "icons"]);
+  createStyles(theme, ["headerBanner", "icons", "mainNav"]);
 
 export default styles;


### PR DESCRIPTION
# "Files" link in header

Added a "Files" link to the header leading to the pod root/files navigator.

## Screenshot

![image](https://user-images.githubusercontent.com/28412960/95475140-35559180-0986-11eb-855a-e43af5bb201c.png)


# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
