### PR TITLE
Fixing faulty WebIDs being added to address book

### DIFF
--- a/__testUtils/mockFetch.js
+++ b/__testUtils/mockFetch.js
@@ -32,7 +32,8 @@ export default function mockFetch(responses = {}) {
     } else {
       throw new Error(`URL (${url}) not mocked properly`);
     }
-    response.url = url;
+    const urlObj = new URL(url);
+    response.url = urlObj.origin + urlObj.pathname; // to mimic that calls for /card#me are actually /card
     return Promise.resolve(response);
   });
 }

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -26,7 +26,6 @@ import {
   getThing,
   getUrl,
   asUrl,
-  getSourceUrl,
 } from "@inrupt/solid-client";
 import { space, vcard, foaf } from "rdf-namespaces";
 
@@ -54,7 +53,7 @@ export async function fetchProfile(webId, fetch) {
   const profile = getThing(dataset, webId);
   return {
     ...getProfileFromPersonDataset(dataset),
-    webId: getSourceUrl(dataset),
+    webId,
     dataset,
     pods: getIriAll(profile, space.storage),
   };


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-502.

To test: Add a WebID to the address book. You should see the avatar and name. (Before the bug it only showed the avatar.)

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).