### PR TITLE
Fix: encode resource iri before fetching

### DIFF
--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -4578,3 +4578,1554 @@ font-display: block;",
   </StylesProvider>
 </Component>
 `;
+
+exports[`ResourceDrawer view it renders without errors when iri contains spaces 1`] = `
+<Component
+  theme={
+    Object {
+      "breakpoints": Object {
+        "between": [Function],
+        "down": [Function],
+        "keys": Array [
+          "xs",
+          "sm",
+          "md",
+          "lg",
+          "xl",
+        ],
+        "only": [Function],
+        "up": [Function],
+        "values": Object {
+          "lg": 1280,
+          "md": 960,
+          "sm": 600,
+          "xl": 1920,
+          "xs": 0,
+        },
+        "width": [Function],
+      },
+      "direction": "ltr",
+      "iconSet": Object {
+        "config": Object {
+          "cssFiles": Array [
+            "css/all.css",
+          ],
+          "fonts": Array [
+            Object {
+              "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+              "fontsPath": "./webfonts",
+              "licensePath": "./LICENSE.txt",
+              "source": "fa-solid-900.eot",
+              "sources": Array [
+                Object {
+                  "format": "embedded-opentype",
+                  "path": "fa-solid-900.eot",
+                  "urlAddition": "?#iefix",
+                },
+                Object {
+                  "format": "woff2",
+                  "path": "fa-solid-900.woff2",
+                },
+                Object {
+                  "format": "woff",
+                  "path": "fa-solid-900.woff",
+                },
+                Object {
+                  "format": "truetype",
+                  "path": "fa-solid-900.ttf",
+                },
+                Object {
+                  "format": "svg",
+                  "path": "fa-solid-900.svg",
+                  "urlAddition": "#fontawesome",
+                },
+              ],
+            },
+          ],
+          "label": "Font Awesome Solid",
+          "name": "fontawesome-solid",
+          "npmModule": "@fortawesome/fontawesome-free",
+          "type": 0,
+        },
+        "iconColor": [Function],
+        "styles": [Function],
+      },
+      "icons": Object {
+        "config": Object {
+          "cssFiles": Array [
+            "css/all.css",
+          ],
+          "fonts": Array [
+            Object {
+              "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+              "fontsPath": "./webfonts",
+              "licensePath": "./LICENSE.txt",
+              "source": "fa-solid-900.eot",
+              "sources": Array [
+                Object {
+                  "format": "embedded-opentype",
+                  "path": "fa-solid-900.eot",
+                  "urlAddition": "?#iefix",
+                },
+                Object {
+                  "format": "woff2",
+                  "path": "fa-solid-900.woff2",
+                },
+                Object {
+                  "format": "woff",
+                  "path": "fa-solid-900.woff",
+                },
+                Object {
+                  "format": "truetype",
+                  "path": "fa-solid-900.ttf",
+                },
+                Object {
+                  "format": "svg",
+                  "path": "fa-solid-900.svg",
+                  "urlAddition": "#fontawesome",
+                },
+              ],
+            },
+          ],
+          "label": "Font Awesome Solid",
+          "name": "fontawesome-solid",
+          "npmModule": "@fortawesome/fontawesome-free",
+          "type": 0,
+        },
+        "iconColor": [Function],
+        "styles": [Function],
+      },
+      "label": "SDK Default",
+      "licenses": Array [
+        "fonts/Raleway/OFL.txt",
+      ],
+      "localFonts": Object {
+        "fonts/Raleway/Raleway-ExtraBold": [Function],
+        "fonts/Raleway/Raleway-Medium": [Function],
+      },
+      "mixins": Object {
+        "gutters": [Function],
+        "toolbar": Object {
+          "@media (min-width:0px) and (orientation: landscape)": Object {
+            "minHeight": 48,
+          },
+          "@media (min-width:600px)": Object {
+            "minHeight": 64,
+          },
+          "minHeight": 56,
+        },
+      },
+      "name": "sdk-default",
+      "overrides": Object {},
+      "palette": Object {
+        "action": Object {
+          "activatedOpacity": 0.12,
+          "active": "rgba(0, 0, 0, 0.54)",
+          "disabled": "rgba(0, 0, 0, 0.26)",
+          "disabledBackground": "rgba(0, 0, 0, 0.12)",
+          "disabledOpacity": 0.38,
+          "focus": "rgba(0, 0, 0, 0.12)",
+          "focusOpacity": 0.12,
+          "hover": "rgba(0, 0, 0, 0.04)",
+          "hoverOpacity": 0.04,
+          "selected": "rgba(0, 0, 0, 0.08)",
+          "selectedOpacity": 0.08,
+        },
+        "adjustAlpha": [Function],
+        "augmentColor": [Function],
+        "background": Object {
+          "default": "#FFFFFF",
+          "paper": "#fff",
+        },
+        "common": Object {
+          "black": "#000",
+          "white": "#fff",
+        },
+        "contrastThreshold": 3,
+        "divider": "rgba(0, 0, 0, 0.12)",
+        "error": Object {
+          "contrastText": "#fff",
+          "dark": "#d32f2f",
+          "light": "#e57373",
+          "main": "#f44336",
+        },
+        "getContrastText": [Function],
+        "grey": Object {
+          "100": "#f5f5f5",
+          "200": "#eeeeee",
+          "300": "#e0e0e0",
+          "400": "#bdbdbd",
+          "50": "#fafafa",
+          "500": "#9e9e9e",
+          "600": "#757575",
+          "700": "#616161",
+          "800": "#424242",
+          "900": "#212121",
+          "A100": "#d5d5d5",
+          "A200": "#aaaaaa",
+          "A400": "#303030",
+          "A700": "#616161",
+        },
+        "info": Object {
+          "contrastText": "#fff",
+          "dark": "#1976d2",
+          "light": "#64b5f6",
+          "main": "#2196f3",
+        },
+        "primary": Object {
+          "contrastText": "#fff",
+          "dark": "rgb(86, 53, 178)",
+          "light": "rgb(150, 112, 255)",
+          "main": "#7C4DFF",
+        },
+        "secondary": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#083575",
+          "light": "#01C9EA",
+          "main": "#18A9E6",
+        },
+        "success": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#388e3c",
+          "light": "#81c784",
+          "main": "#4caf50",
+        },
+        "text": Object {
+          "disabled": "rgba(0, 0, 0, 0.38)",
+          "hint": "rgba(0, 0, 0, 0.38)",
+          "primary": "#4E4E4E",
+          "secondary": "#4E4E4E",
+        },
+        "tonalOffset": 0.2,
+        "type": "light",
+        "warning": Object {
+          "contrastText": "rgba(0, 0, 0, 0.87)",
+          "dark": "#f57c00",
+          "light": "#ffb74d",
+          "main": "#ff9800",
+        },
+      },
+      "props": Object {},
+      "shadows": Array [
+        "none",
+        "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+        "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+        "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+        "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+        "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+        "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+        "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+        "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+        "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+        "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+        "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+        "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+        "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+        "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+        "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+        "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+        "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+        "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+        "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+        "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+      ],
+      "shape": Object {
+        "borderRadius": 4,
+      },
+      "spacing": [Function],
+      "stylesheets": Array [
+        "https://fonts.googleapis.com/css?family=Raleway:500,800&display=swap",
+      ],
+      "transitions": Object {
+        "create": [Function],
+        "duration": Object {
+          "complex": 375,
+          "enteringScreen": 225,
+          "leavingScreen": 195,
+          "short": 250,
+          "shorter": 200,
+          "shortest": 150,
+          "standard": 300,
+        },
+        "easing": Object {
+          "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+          "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+          "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+          "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+        },
+        "getAutoHeightDuration": [Function],
+      },
+      "typography": Object {
+        "body": Object {
+          "fontFamily": "\\"Raleway-Medium\\"",
+          "fontSize": "0.9375rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.43,
+        },
+        "body1": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "body2": Object {
+          "fontFamily": "\\"Raleway-Medium\\"",
+          "fontSize": "0.9375rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.01071em",
+          "lineHeight": 1.43,
+        },
+        "button": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.02857em",
+          "lineHeight": 1.75,
+          "textTransform": "uppercase",
+        },
+        "caption": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.03333em",
+          "lineHeight": 1.66,
+        },
+        "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+        "fontSize": 14,
+        "fontWeightBold": 800,
+        "fontWeightLight": 500,
+        "fontWeightMedium": 500,
+        "fontWeightRegular": 400,
+        "h1": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.375rem",
+          "fontWeight": 800,
+          "letterSpacing": "-0.01562em",
+          "lineHeight": 1.45,
+        },
+        "h2": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.125rem",
+          "fontWeight": 800,
+          "letterSpacing": "-0.00833em",
+          "lineHeight": 1.27,
+        },
+        "h3": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1.05rem",
+          "fontWeight": 800,
+          "letterSpacing": "0em",
+          "lineHeight": 1.2,
+        },
+        "h4": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00735em",
+          "lineHeight": 1.1,
+        },
+        "h5": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0em",
+          "lineHeight": 1,
+        },
+        "h6": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "0.625rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.0075em",
+          "lineHeight": 1,
+        },
+        "heading": Object {
+          "fontFamily": "\\"Raleway-ExtraBold\\"",
+          "fontSize": "1rem",
+          "fontWeight": 800,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.5,
+        },
+        "htmlFontSize": 16,
+        "overline": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.75rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.08333em",
+          "lineHeight": 2.66,
+          "textTransform": "uppercase",
+        },
+        "pxToRem": [Function],
+        "round": [Function],
+        "subtitle1": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "1rem",
+          "fontWeight": 400,
+          "letterSpacing": "0.00938em",
+          "lineHeight": 1.75,
+        },
+        "subtitle2": Object {
+          "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+          "fontSize": "0.875rem",
+          "fontWeight": 500,
+          "letterSpacing": "0.00714em",
+          "lineHeight": 1.57,
+        },
+      },
+      "zIndex": Object {
+        "appBar": 1100,
+        "drawer": 1200,
+        "mobileStepper": 1000,
+        "modal": 1300,
+        "snackbar": 1400,
+        "speedDial": 1050,
+        "tooltip": 1500,
+      },
+      Symbol(mui.nested): false,
+    }
+  }
+>
+  <StylesProvider
+    generateClassName={[Function]}
+  >
+    <ThemeProvider
+      theme={
+        Object {
+          "breakpoints": Object {
+            "between": [Function],
+            "down": [Function],
+            "keys": Array [
+              "xs",
+              "sm",
+              "md",
+              "lg",
+              "xl",
+            ],
+            "only": [Function],
+            "up": [Function],
+            "values": Object {
+              "lg": 1280,
+              "md": 960,
+              "sm": 600,
+              "xl": 1920,
+              "xs": 0,
+            },
+            "width": [Function],
+          },
+          "direction": "ltr",
+          "iconSet": Object {
+            "config": Object {
+              "cssFiles": Array [
+                "css/all.css",
+              ],
+              "fonts": Array [
+                Object {
+                  "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+                  "fontsPath": "./webfonts",
+                  "licensePath": "./LICENSE.txt",
+                  "source": "fa-solid-900.eot",
+                  "sources": Array [
+                    Object {
+                      "format": "embedded-opentype",
+                      "path": "fa-solid-900.eot",
+                      "urlAddition": "?#iefix",
+                    },
+                    Object {
+                      "format": "woff2",
+                      "path": "fa-solid-900.woff2",
+                    },
+                    Object {
+                      "format": "woff",
+                      "path": "fa-solid-900.woff",
+                    },
+                    Object {
+                      "format": "truetype",
+                      "path": "fa-solid-900.ttf",
+                    },
+                    Object {
+                      "format": "svg",
+                      "path": "fa-solid-900.svg",
+                      "urlAddition": "#fontawesome",
+                    },
+                  ],
+                },
+              ],
+              "label": "Font Awesome Solid",
+              "name": "fontawesome-solid",
+              "npmModule": "@fortawesome/fontawesome-free",
+              "type": 0,
+            },
+            "iconColor": [Function],
+            "styles": [Function],
+          },
+          "icons": Object {
+            "config": Object {
+              "cssFiles": Array [
+                "css/all.css",
+              ],
+              "fonts": Array [
+                Object {
+                  "fontFace": "
+font-family: 'Font Awesome 5 Free';
+font-style: normal;
+font-weight: 900;
+font-display: block;",
+                  "fontsPath": "./webfonts",
+                  "licensePath": "./LICENSE.txt",
+                  "source": "fa-solid-900.eot",
+                  "sources": Array [
+                    Object {
+                      "format": "embedded-opentype",
+                      "path": "fa-solid-900.eot",
+                      "urlAddition": "?#iefix",
+                    },
+                    Object {
+                      "format": "woff2",
+                      "path": "fa-solid-900.woff2",
+                    },
+                    Object {
+                      "format": "woff",
+                      "path": "fa-solid-900.woff",
+                    },
+                    Object {
+                      "format": "truetype",
+                      "path": "fa-solid-900.ttf",
+                    },
+                    Object {
+                      "format": "svg",
+                      "path": "fa-solid-900.svg",
+                      "urlAddition": "#fontawesome",
+                    },
+                  ],
+                },
+              ],
+              "label": "Font Awesome Solid",
+              "name": "fontawesome-solid",
+              "npmModule": "@fortawesome/fontawesome-free",
+              "type": 0,
+            },
+            "iconColor": [Function],
+            "styles": [Function],
+          },
+          "label": "SDK Default",
+          "licenses": Array [
+            "fonts/Raleway/OFL.txt",
+          ],
+          "localFonts": Object {
+            "fonts/Raleway/Raleway-ExtraBold": [Function],
+            "fonts/Raleway/Raleway-Medium": [Function],
+          },
+          "mixins": Object {
+            "gutters": [Function],
+            "toolbar": Object {
+              "@media (min-width:0px) and (orientation: landscape)": Object {
+                "minHeight": 48,
+              },
+              "@media (min-width:600px)": Object {
+                "minHeight": 64,
+              },
+              "minHeight": 56,
+            },
+          },
+          "name": "sdk-default",
+          "overrides": Object {},
+          "palette": Object {
+            "action": Object {
+              "activatedOpacity": 0.12,
+              "active": "rgba(0, 0, 0, 0.54)",
+              "disabled": "rgba(0, 0, 0, 0.26)",
+              "disabledBackground": "rgba(0, 0, 0, 0.12)",
+              "disabledOpacity": 0.38,
+              "focus": "rgba(0, 0, 0, 0.12)",
+              "focusOpacity": 0.12,
+              "hover": "rgba(0, 0, 0, 0.04)",
+              "hoverOpacity": 0.04,
+              "selected": "rgba(0, 0, 0, 0.08)",
+              "selectedOpacity": 0.08,
+            },
+            "adjustAlpha": [Function],
+            "augmentColor": [Function],
+            "background": Object {
+              "default": "#FFFFFF",
+              "paper": "#fff",
+            },
+            "common": Object {
+              "black": "#000",
+              "white": "#fff",
+            },
+            "contrastThreshold": 3,
+            "divider": "rgba(0, 0, 0, 0.12)",
+            "error": Object {
+              "contrastText": "#fff",
+              "dark": "#d32f2f",
+              "light": "#e57373",
+              "main": "#f44336",
+            },
+            "getContrastText": [Function],
+            "grey": Object {
+              "100": "#f5f5f5",
+              "200": "#eeeeee",
+              "300": "#e0e0e0",
+              "400": "#bdbdbd",
+              "50": "#fafafa",
+              "500": "#9e9e9e",
+              "600": "#757575",
+              "700": "#616161",
+              "800": "#424242",
+              "900": "#212121",
+              "A100": "#d5d5d5",
+              "A200": "#aaaaaa",
+              "A400": "#303030",
+              "A700": "#616161",
+            },
+            "info": Object {
+              "contrastText": "#fff",
+              "dark": "#1976d2",
+              "light": "#64b5f6",
+              "main": "#2196f3",
+            },
+            "primary": Object {
+              "contrastText": "#fff",
+              "dark": "rgb(86, 53, 178)",
+              "light": "rgb(150, 112, 255)",
+              "main": "#7C4DFF",
+            },
+            "secondary": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#083575",
+              "light": "#01C9EA",
+              "main": "#18A9E6",
+            },
+            "success": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#388e3c",
+              "light": "#81c784",
+              "main": "#4caf50",
+            },
+            "text": Object {
+              "disabled": "rgba(0, 0, 0, 0.38)",
+              "hint": "rgba(0, 0, 0, 0.38)",
+              "primary": "#4E4E4E",
+              "secondary": "#4E4E4E",
+            },
+            "tonalOffset": 0.2,
+            "type": "light",
+            "warning": Object {
+              "contrastText": "rgba(0, 0, 0, 0.87)",
+              "dark": "#f57c00",
+              "light": "#ffb74d",
+              "main": "#ff9800",
+            },
+          },
+          "props": Object {},
+          "shadows": Array [
+            "none",
+            "0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12)",
+            "0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)",
+            "0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)",
+            "0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12)",
+            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12)",
+            "0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12)",
+            "0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12)",
+            "0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12)",
+            "0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12)",
+            "0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12)",
+            "0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12)",
+            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12)",
+            "0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12)",
+            "0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12)",
+            "0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12)",
+            "0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12)",
+            "0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12)",
+            "0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12)",
+            "0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12)",
+            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12)",
+            "0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12)",
+            "0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12)",
+            "0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12)",
+            "0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12)",
+          ],
+          "shape": Object {
+            "borderRadius": 4,
+          },
+          "spacing": [Function],
+          "stylesheets": Array [
+            "https://fonts.googleapis.com/css?family=Raleway:500,800&display=swap",
+          ],
+          "transitions": Object {
+            "create": [Function],
+            "duration": Object {
+              "complex": 375,
+              "enteringScreen": 225,
+              "leavingScreen": 195,
+              "short": 250,
+              "shorter": 200,
+              "shortest": 150,
+              "standard": 300,
+            },
+            "easing": Object {
+              "easeIn": "cubic-bezier(0.4, 0, 1, 1)",
+              "easeInOut": "cubic-bezier(0.4, 0, 0.2, 1)",
+              "easeOut": "cubic-bezier(0.0, 0, 0.2, 1)",
+              "sharp": "cubic-bezier(0.4, 0, 0.6, 1)",
+            },
+            "getAutoHeightDuration": [Function],
+          },
+          "typography": Object {
+            "body": Object {
+              "fontFamily": "\\"Raleway-Medium\\"",
+              "fontSize": "0.9375rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.01071em",
+              "lineHeight": 1.43,
+            },
+            "body1": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.5,
+            },
+            "body2": Object {
+              "fontFamily": "\\"Raleway-Medium\\"",
+              "fontSize": "0.9375rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.01071em",
+              "lineHeight": 1.43,
+            },
+            "button": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.875rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.02857em",
+              "lineHeight": 1.75,
+              "textTransform": "uppercase",
+            },
+            "caption": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.03333em",
+              "lineHeight": 1.66,
+            },
+            "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+            "fontSize": 14,
+            "fontWeightBold": 800,
+            "fontWeightLight": 500,
+            "fontWeightMedium": 500,
+            "fontWeightRegular": 400,
+            "h1": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.375rem",
+              "fontWeight": 800,
+              "letterSpacing": "-0.01562em",
+              "lineHeight": 1.45,
+            },
+            "h2": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.125rem",
+              "fontWeight": 800,
+              "letterSpacing": "-0.00833em",
+              "lineHeight": 1.27,
+            },
+            "h3": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1.05rem",
+              "fontWeight": 800,
+              "letterSpacing": "0em",
+              "lineHeight": 1.2,
+            },
+            "h4": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00735em",
+              "lineHeight": 1.1,
+            },
+            "h5": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0em",
+              "lineHeight": 1,
+            },
+            "h6": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "0.625rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.0075em",
+              "lineHeight": 1,
+            },
+            "heading": Object {
+              "fontFamily": "\\"Raleway-ExtraBold\\"",
+              "fontSize": "1rem",
+              "fontWeight": 800,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.5,
+            },
+            "htmlFontSize": 16,
+            "overline": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.75rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.08333em",
+              "lineHeight": 2.66,
+              "textTransform": "uppercase",
+            },
+            "pxToRem": [Function],
+            "round": [Function],
+            "subtitle1": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "1rem",
+              "fontWeight": 400,
+              "letterSpacing": "0.00938em",
+              "lineHeight": 1.75,
+            },
+            "subtitle2": Object {
+              "fontFamily": "\\"Roboto\\", \\"Helvetica\\", \\"Arial\\", sans-serif",
+              "fontSize": "0.875rem",
+              "fontWeight": 500,
+              "letterSpacing": "0.00714em",
+              "lineHeight": 1.57,
+            },
+          },
+          "zIndex": Object {
+            "appBar": 1100,
+            "drawer": 1200,
+            "mobileStepper": 1000,
+            "modal": 1300,
+            "snackbar": 1400,
+            "speedDial": 1050,
+            "tooltip": 1500,
+          },
+          Symbol(mui.nested): false,
+        }
+      }
+    >
+      <MockedSessionContextProvider>
+        <g
+          session={
+            Object {
+              "fetch": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "/iri%20with%20spaces/",
+                    Object {
+                      "method": "HEAD",
+                    },
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": undefined,
+                  },
+                ],
+              },
+              "handleIncomingRedirect": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "http://localhost/",
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": Promise {},
+                  },
+                ],
+              },
+              "info": Object {
+                "isLoggedIn": true,
+                "sessionId": "some-session-id",
+                "webId": "http://example.com/webId#me",
+              },
+              "on": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "logout",
+                    [Function],
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": undefined,
+                  },
+                ],
+              },
+            }
+          }
+          sessionId="test-session"
+          sessionRequestInProgress={false}
+        >
+          <DetailsContextMenuProvider>
+            <ResourceDrawer
+              onUpdate={[Function]}
+            >
+              <Drawer
+                close={[Function]}
+                open={true}
+              >
+                <section
+                  className="PodBrowser-drawer PodBrowser-drawer--open"
+                >
+                  <div
+                    className="PodBrowser-drawer__content"
+                  >
+                    <div
+                      className="PodBrowser-drawer__article"
+                    >
+                      <Button
+                        onClick={[Function]}
+                        variant="text"
+                      >
+                        <button
+                          className="PodBrowser-button PodBrowser-button--text"
+                          onClick={[Function]}
+                        >
+                          <Icon
+                            name="cancel"
+                          >
+                            <span
+                              className="PodBrowser-icon-cancel"
+                            />
+                          </Icon>
+                           Close
+                        </button>
+                      </Button>
+                    </div>
+                    <DetailsLoading
+                      iri="/iri with spaces/"
+                    >
+                      <section
+                        className="PodBrowser-centeredSection"
+                      >
+                        <h3
+                          className="PodBrowser-content-h3"
+                          title="/iri with spaces/"
+                        >
+                          iri with spaces
+                        </h3>
+                      </section>
+                      <WithStyles(ForwardRef(Divider))>
+                        <ForwardRef(Divider)
+                          classes={
+                            Object {
+                              "absolute": "PodBrowser-absolute",
+                              "flexItem": "PodBrowser-flexItem",
+                              "inset": "PodBrowser-inset",
+                              "light": "PodBrowser-light",
+                              "middle": "PodBrowser-middle",
+                              "root": "PodBrowser-root",
+                              "vertical": "PodBrowser-vertical",
+                            }
+                          }
+                        >
+                          <hr
+                            className="PodBrowser-root"
+                          />
+                        </ForwardRef(Divider)>
+                      </WithStyles(ForwardRef(Divider))>
+                      <WithStyles(ForwardRef(Accordion))
+                        disabled={true}
+                      >
+                        <ForwardRef(Accordion)
+                          classes={
+                            Object {
+                              "disabled": "PodBrowser-disabled",
+                              "expanded": "PodBrowser-expanded",
+                              "root": "PodBrowser-root",
+                              "rounded": "PodBrowser-rounded",
+                            }
+                          }
+                          disabled={true}
+                        >
+                          <WithStyles(ForwardRef(Paper))
+                            className="PodBrowser-root PodBrowser-disabled PodBrowser-rounded"
+                            square={false}
+                          >
+                            <ForwardRef(Paper)
+                              className="PodBrowser-root PodBrowser-disabled PodBrowser-rounded"
+                              classes={
+                                Object {
+                                  "elevation0": "PodBrowser-elevation0",
+                                  "elevation1": "PodBrowser-elevation1",
+                                  "elevation10": "PodBrowser-elevation10",
+                                  "elevation11": "PodBrowser-elevation11",
+                                  "elevation12": "PodBrowser-elevation12",
+                                  "elevation13": "PodBrowser-elevation13",
+                                  "elevation14": "PodBrowser-elevation14",
+                                  "elevation15": "PodBrowser-elevation15",
+                                  "elevation16": "PodBrowser-elevation16",
+                                  "elevation17": "PodBrowser-elevation17",
+                                  "elevation18": "PodBrowser-elevation18",
+                                  "elevation19": "PodBrowser-elevation19",
+                                  "elevation2": "PodBrowser-elevation2",
+                                  "elevation20": "PodBrowser-elevation20",
+                                  "elevation21": "PodBrowser-elevation21",
+                                  "elevation22": "PodBrowser-elevation22",
+                                  "elevation23": "PodBrowser-elevation23",
+                                  "elevation24": "PodBrowser-elevation24",
+                                  "elevation3": "PodBrowser-elevation3",
+                                  "elevation4": "PodBrowser-elevation4",
+                                  "elevation5": "PodBrowser-elevation5",
+                                  "elevation6": "PodBrowser-elevation6",
+                                  "elevation7": "PodBrowser-elevation7",
+                                  "elevation8": "PodBrowser-elevation8",
+                                  "elevation9": "PodBrowser-elevation9",
+                                  "outlined": "PodBrowser-outlined",
+                                  "root": "PodBrowser-root",
+                                  "rounded": "PodBrowser-rounded",
+                                }
+                              }
+                              square={false}
+                            >
+                              <div
+                                className="PodBrowser-root PodBrowser-root PodBrowser-disabled PodBrowser-rounded PodBrowser-elevation1 PodBrowser-rounded"
+                              >
+                                <WithStyles(ForwardRef(AccordionSummary))
+                                  key=".0"
+                                >
+                                  <ForwardRef(AccordionSummary)
+                                    classes={
+                                      Object {
+                                        "content": "PodBrowser-content",
+                                        "disabled": "PodBrowser-disabled",
+                                        "expandIcon": "PodBrowser-expandIcon",
+                                        "expanded": "PodBrowser-expanded",
+                                        "focused": "PodBrowser-focused",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <WithStyles(ForwardRef(ButtonBase))
+                                      aria-expanded={false}
+                                      className="PodBrowser-root PodBrowser-disabled"
+                                      component="div"
+                                      disableRipple={true}
+                                      disabled={true}
+                                      focusRipple={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocusVisible={[Function]}
+                                    >
+                                      <ForwardRef(ButtonBase)
+                                        aria-expanded={false}
+                                        className="PodBrowser-root PodBrowser-disabled"
+                                        classes={
+                                          Object {
+                                            "disabled": "PodBrowser-disabled",
+                                            "focusVisible": "PodBrowser-focusVisible",
+                                            "root": "PodBrowser-root",
+                                          }
+                                        }
+                                        component="div"
+                                        disableRipple={true}
+                                        disabled={true}
+                                        focusRipple={false}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocusVisible={[Function]}
+                                      >
+                                        <div
+                                          aria-disabled={true}
+                                          aria-expanded={false}
+                                          className="PodBrowser-root PodBrowser-root PodBrowser-disabled PodBrowser-disabled"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onDragLeave={[Function]}
+                                          onFocus={[Function]}
+                                          onKeyDown={[Function]}
+                                          onKeyUp={[Function]}
+                                          onMouseDown={[Function]}
+                                          onMouseLeave={[Function]}
+                                          onMouseUp={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
+                                          role="button"
+                                          tabIndex={-1}
+                                        >
+                                          <div
+                                            className="PodBrowser-content"
+                                          >
+                                            Actions
+                                          </div>
+                                        </div>
+                                      </ForwardRef(ButtonBase)>
+                                    </WithStyles(ForwardRef(ButtonBase))>
+                                  </ForwardRef(AccordionSummary)>
+                                </WithStyles(ForwardRef(AccordionSummary))>
+                                <WithStyles(ForwardRef(Collapse))
+                                  in={false}
+                                  timeout="auto"
+                                >
+                                  <ForwardRef(Collapse)
+                                    classes={
+                                      Object {
+                                        "container": "PodBrowser-container",
+                                        "entered": "PodBrowser-entered",
+                                        "hidden": "PodBrowser-hidden",
+                                        "wrapper": "PodBrowser-wrapper",
+                                        "wrapperInner": "PodBrowser-wrapperInner",
+                                      }
+                                    }
+                                    in={false}
+                                    timeout="auto"
+                                  >
+                                    <Transition
+                                      addEndListener={[Function]}
+                                      appear={false}
+                                      enter={true}
+                                      exit={true}
+                                      in={false}
+                                      mountOnEnter={false}
+                                      onEnter={[Function]}
+                                      onEntered={[Function]}
+                                      onEntering={[Function]}
+                                      onExit={[Function]}
+                                      onExited={[Function]}
+                                      onExiting={[Function]}
+                                      timeout={null}
+                                      unmountOnExit={false}
+                                    >
+                                      <div
+                                        className="PodBrowser-container PodBrowser-hidden"
+                                        style={
+                                          Object {
+                                            "minHeight": "0px",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="PodBrowser-wrapper"
+                                        >
+                                          <div
+                                            className="PodBrowser-wrapperInner"
+                                          >
+                                            <div
+                                              role="region"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </Transition>
+                                  </ForwardRef(Collapse)>
+                                </WithStyles(ForwardRef(Collapse))>
+                              </div>
+                            </ForwardRef(Paper)>
+                          </WithStyles(ForwardRef(Paper))>
+                        </ForwardRef(Accordion)>
+                      </WithStyles(ForwardRef(Accordion))>
+                      <WithStyles(ForwardRef(Accordion))
+                        disabled={true}
+                      >
+                        <ForwardRef(Accordion)
+                          classes={
+                            Object {
+                              "disabled": "PodBrowser-disabled",
+                              "expanded": "PodBrowser-expanded",
+                              "root": "PodBrowser-root",
+                              "rounded": "PodBrowser-rounded",
+                            }
+                          }
+                          disabled={true}
+                        >
+                          <WithStyles(ForwardRef(Paper))
+                            className="PodBrowser-root PodBrowser-disabled PodBrowser-rounded"
+                            square={false}
+                          >
+                            <ForwardRef(Paper)
+                              className="PodBrowser-root PodBrowser-disabled PodBrowser-rounded"
+                              classes={
+                                Object {
+                                  "elevation0": "PodBrowser-elevation0",
+                                  "elevation1": "PodBrowser-elevation1",
+                                  "elevation10": "PodBrowser-elevation10",
+                                  "elevation11": "PodBrowser-elevation11",
+                                  "elevation12": "PodBrowser-elevation12",
+                                  "elevation13": "PodBrowser-elevation13",
+                                  "elevation14": "PodBrowser-elevation14",
+                                  "elevation15": "PodBrowser-elevation15",
+                                  "elevation16": "PodBrowser-elevation16",
+                                  "elevation17": "PodBrowser-elevation17",
+                                  "elevation18": "PodBrowser-elevation18",
+                                  "elevation19": "PodBrowser-elevation19",
+                                  "elevation2": "PodBrowser-elevation2",
+                                  "elevation20": "PodBrowser-elevation20",
+                                  "elevation21": "PodBrowser-elevation21",
+                                  "elevation22": "PodBrowser-elevation22",
+                                  "elevation23": "PodBrowser-elevation23",
+                                  "elevation24": "PodBrowser-elevation24",
+                                  "elevation3": "PodBrowser-elevation3",
+                                  "elevation4": "PodBrowser-elevation4",
+                                  "elevation5": "PodBrowser-elevation5",
+                                  "elevation6": "PodBrowser-elevation6",
+                                  "elevation7": "PodBrowser-elevation7",
+                                  "elevation8": "PodBrowser-elevation8",
+                                  "elevation9": "PodBrowser-elevation9",
+                                  "outlined": "PodBrowser-outlined",
+                                  "root": "PodBrowser-root",
+                                  "rounded": "PodBrowser-rounded",
+                                }
+                              }
+                              square={false}
+                            >
+                              <div
+                                className="PodBrowser-root PodBrowser-root PodBrowser-disabled PodBrowser-rounded PodBrowser-elevation1 PodBrowser-rounded"
+                              >
+                                <WithStyles(ForwardRef(AccordionSummary))
+                                  key=".0"
+                                >
+                                  <ForwardRef(AccordionSummary)
+                                    classes={
+                                      Object {
+                                        "content": "PodBrowser-content",
+                                        "disabled": "PodBrowser-disabled",
+                                        "expandIcon": "PodBrowser-expandIcon",
+                                        "expanded": "PodBrowser-expanded",
+                                        "focused": "PodBrowser-focused",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <WithStyles(ForwardRef(ButtonBase))
+                                      aria-expanded={false}
+                                      className="PodBrowser-root PodBrowser-disabled"
+                                      component="div"
+                                      disableRipple={true}
+                                      disabled={true}
+                                      focusRipple={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocusVisible={[Function]}
+                                    >
+                                      <ForwardRef(ButtonBase)
+                                        aria-expanded={false}
+                                        className="PodBrowser-root PodBrowser-disabled"
+                                        classes={
+                                          Object {
+                                            "disabled": "PodBrowser-disabled",
+                                            "focusVisible": "PodBrowser-focusVisible",
+                                            "root": "PodBrowser-root",
+                                          }
+                                        }
+                                        component="div"
+                                        disableRipple={true}
+                                        disabled={true}
+                                        focusRipple={false}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocusVisible={[Function]}
+                                      >
+                                        <div
+                                          aria-disabled={true}
+                                          aria-expanded={false}
+                                          className="PodBrowser-root PodBrowser-root PodBrowser-disabled PodBrowser-disabled"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onDragLeave={[Function]}
+                                          onFocus={[Function]}
+                                          onKeyDown={[Function]}
+                                          onKeyUp={[Function]}
+                                          onMouseDown={[Function]}
+                                          onMouseLeave={[Function]}
+                                          onMouseUp={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
+                                          role="button"
+                                          tabIndex={-1}
+                                        >
+                                          <div
+                                            className="PodBrowser-content"
+                                          >
+                                            Details
+                                          </div>
+                                        </div>
+                                      </ForwardRef(ButtonBase)>
+                                    </WithStyles(ForwardRef(ButtonBase))>
+                                  </ForwardRef(AccordionSummary)>
+                                </WithStyles(ForwardRef(AccordionSummary))>
+                                <WithStyles(ForwardRef(Collapse))
+                                  in={false}
+                                  timeout="auto"
+                                >
+                                  <ForwardRef(Collapse)
+                                    classes={
+                                      Object {
+                                        "container": "PodBrowser-container",
+                                        "entered": "PodBrowser-entered",
+                                        "hidden": "PodBrowser-hidden",
+                                        "wrapper": "PodBrowser-wrapper",
+                                        "wrapperInner": "PodBrowser-wrapperInner",
+                                      }
+                                    }
+                                    in={false}
+                                    timeout="auto"
+                                  >
+                                    <Transition
+                                      addEndListener={[Function]}
+                                      appear={false}
+                                      enter={true}
+                                      exit={true}
+                                      in={false}
+                                      mountOnEnter={false}
+                                      onEnter={[Function]}
+                                      onEntered={[Function]}
+                                      onEntering={[Function]}
+                                      onExit={[Function]}
+                                      onExited={[Function]}
+                                      onExiting={[Function]}
+                                      timeout={null}
+                                      unmountOnExit={false}
+                                    >
+                                      <div
+                                        className="PodBrowser-container PodBrowser-hidden"
+                                        style={
+                                          Object {
+                                            "minHeight": "0px",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="PodBrowser-wrapper"
+                                        >
+                                          <div
+                                            className="PodBrowser-wrapperInner"
+                                          >
+                                            <div
+                                              role="region"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </Transition>
+                                  </ForwardRef(Collapse)>
+                                </WithStyles(ForwardRef(Collapse))>
+                              </div>
+                            </ForwardRef(Paper)>
+                          </WithStyles(ForwardRef(Paper))>
+                        </ForwardRef(Accordion)>
+                      </WithStyles(ForwardRef(Accordion))>
+                      <WithStyles(ForwardRef(Accordion))
+                        disabled={true}
+                      >
+                        <ForwardRef(Accordion)
+                          classes={
+                            Object {
+                              "disabled": "PodBrowser-disabled",
+                              "expanded": "PodBrowser-expanded",
+                              "root": "PodBrowser-root",
+                              "rounded": "PodBrowser-rounded",
+                            }
+                          }
+                          disabled={true}
+                        >
+                          <WithStyles(ForwardRef(Paper))
+                            className="PodBrowser-root PodBrowser-disabled PodBrowser-rounded"
+                            square={false}
+                          >
+                            <ForwardRef(Paper)
+                              className="PodBrowser-root PodBrowser-disabled PodBrowser-rounded"
+                              classes={
+                                Object {
+                                  "elevation0": "PodBrowser-elevation0",
+                                  "elevation1": "PodBrowser-elevation1",
+                                  "elevation10": "PodBrowser-elevation10",
+                                  "elevation11": "PodBrowser-elevation11",
+                                  "elevation12": "PodBrowser-elevation12",
+                                  "elevation13": "PodBrowser-elevation13",
+                                  "elevation14": "PodBrowser-elevation14",
+                                  "elevation15": "PodBrowser-elevation15",
+                                  "elevation16": "PodBrowser-elevation16",
+                                  "elevation17": "PodBrowser-elevation17",
+                                  "elevation18": "PodBrowser-elevation18",
+                                  "elevation19": "PodBrowser-elevation19",
+                                  "elevation2": "PodBrowser-elevation2",
+                                  "elevation20": "PodBrowser-elevation20",
+                                  "elevation21": "PodBrowser-elevation21",
+                                  "elevation22": "PodBrowser-elevation22",
+                                  "elevation23": "PodBrowser-elevation23",
+                                  "elevation24": "PodBrowser-elevation24",
+                                  "elevation3": "PodBrowser-elevation3",
+                                  "elevation4": "PodBrowser-elevation4",
+                                  "elevation5": "PodBrowser-elevation5",
+                                  "elevation6": "PodBrowser-elevation6",
+                                  "elevation7": "PodBrowser-elevation7",
+                                  "elevation8": "PodBrowser-elevation8",
+                                  "elevation9": "PodBrowser-elevation9",
+                                  "outlined": "PodBrowser-outlined",
+                                  "root": "PodBrowser-root",
+                                  "rounded": "PodBrowser-rounded",
+                                }
+                              }
+                              square={false}
+                            >
+                              <div
+                                className="PodBrowser-root PodBrowser-root PodBrowser-disabled PodBrowser-rounded PodBrowser-elevation1 PodBrowser-rounded"
+                              >
+                                <WithStyles(ForwardRef(AccordionSummary))
+                                  key=".0"
+                                >
+                                  <ForwardRef(AccordionSummary)
+                                    classes={
+                                      Object {
+                                        "content": "PodBrowser-content",
+                                        "disabled": "PodBrowser-disabled",
+                                        "expandIcon": "PodBrowser-expandIcon",
+                                        "expanded": "PodBrowser-expanded",
+                                        "focused": "PodBrowser-focused",
+                                        "root": "PodBrowser-root",
+                                      }
+                                    }
+                                  >
+                                    <WithStyles(ForwardRef(ButtonBase))
+                                      aria-expanded={false}
+                                      className="PodBrowser-root PodBrowser-disabled"
+                                      component="div"
+                                      disableRipple={true}
+                                      disabled={true}
+                                      focusRipple={false}
+                                      onBlur={[Function]}
+                                      onClick={[Function]}
+                                      onFocusVisible={[Function]}
+                                    >
+                                      <ForwardRef(ButtonBase)
+                                        aria-expanded={false}
+                                        className="PodBrowser-root PodBrowser-disabled"
+                                        classes={
+                                          Object {
+                                            "disabled": "PodBrowser-disabled",
+                                            "focusVisible": "PodBrowser-focusVisible",
+                                            "root": "PodBrowser-root",
+                                          }
+                                        }
+                                        component="div"
+                                        disableRipple={true}
+                                        disabled={true}
+                                        focusRipple={false}
+                                        onBlur={[Function]}
+                                        onClick={[Function]}
+                                        onFocusVisible={[Function]}
+                                      >
+                                        <div
+                                          aria-disabled={true}
+                                          aria-expanded={false}
+                                          className="PodBrowser-root PodBrowser-root PodBrowser-disabled PodBrowser-disabled"
+                                          onBlur={[Function]}
+                                          onClick={[Function]}
+                                          onDragLeave={[Function]}
+                                          onFocus={[Function]}
+                                          onKeyDown={[Function]}
+                                          onKeyUp={[Function]}
+                                          onMouseDown={[Function]}
+                                          onMouseLeave={[Function]}
+                                          onMouseUp={[Function]}
+                                          onTouchEnd={[Function]}
+                                          onTouchMove={[Function]}
+                                          onTouchStart={[Function]}
+                                          role="button"
+                                          tabIndex={-1}
+                                        >
+                                          <div
+                                            className="PodBrowser-content"
+                                          >
+                                            Permissions
+                                          </div>
+                                        </div>
+                                      </ForwardRef(ButtonBase)>
+                                    </WithStyles(ForwardRef(ButtonBase))>
+                                  </ForwardRef(AccordionSummary)>
+                                </WithStyles(ForwardRef(AccordionSummary))>
+                                <WithStyles(ForwardRef(Collapse))
+                                  in={false}
+                                  timeout="auto"
+                                >
+                                  <ForwardRef(Collapse)
+                                    classes={
+                                      Object {
+                                        "container": "PodBrowser-container",
+                                        "entered": "PodBrowser-entered",
+                                        "hidden": "PodBrowser-hidden",
+                                        "wrapper": "PodBrowser-wrapper",
+                                        "wrapperInner": "PodBrowser-wrapperInner",
+                                      }
+                                    }
+                                    in={false}
+                                    timeout="auto"
+                                  >
+                                    <Transition
+                                      addEndListener={[Function]}
+                                      appear={false}
+                                      enter={true}
+                                      exit={true}
+                                      in={false}
+                                      mountOnEnter={false}
+                                      onEnter={[Function]}
+                                      onEntered={[Function]}
+                                      onEntering={[Function]}
+                                      onExit={[Function]}
+                                      onExited={[Function]}
+                                      onExiting={[Function]}
+                                      timeout={null}
+                                      unmountOnExit={false}
+                                    >
+                                      <div
+                                        className="PodBrowser-container PodBrowser-hidden"
+                                        style={
+                                          Object {
+                                            "minHeight": "0px",
+                                          }
+                                        }
+                                      >
+                                        <div
+                                          className="PodBrowser-wrapper"
+                                        >
+                                          <div
+                                            className="PodBrowser-wrapperInner"
+                                          >
+                                            <div
+                                              role="region"
+                                            />
+                                          </div>
+                                        </div>
+                                      </div>
+                                    </Transition>
+                                  </ForwardRef(Collapse)>
+                                </WithStyles(ForwardRef(Collapse))>
+                              </div>
+                            </ForwardRef(Paper)>
+                          </WithStyles(ForwardRef(Paper))>
+                        </ForwardRef(Accordion)>
+                      </WithStyles(ForwardRef(Accordion))>
+                    </DetailsLoading>
+                  </div>
+                </section>
+              </Drawer>
+            </ResourceDrawer>
+          </DetailsContextMenuProvider>
+        </g>
+      </MockedSessionContextProvider>
+    </ThemeProvider>
+  </StylesProvider>
+</Component>
+`;

--- a/components/resourceDrawer/index.jsx
+++ b/components/resourceDrawer/index.jsx
@@ -58,7 +58,8 @@ export default function ResourceDrawer({ onUpdate }) {
   useEffect(() => {
     if (!resourceIri) return;
     setLoading(true);
-    getResourceInfoWithAcl(resourceIri, { fetch }).then((dataset) => {
+    const encodedResourceIri = encodeURI(resourceIri);
+    getResourceInfoWithAcl(encodedResourceIri, { fetch }).then((dataset) => {
       setDatasetWithAcl(dataset);
       setLoading(false);
     });

--- a/components/resourceDrawer/index.test.jsx
+++ b/components/resourceDrawer/index.test.jsx
@@ -30,6 +30,7 @@ import { mountToJson } from "../../__testUtils/mountWithTheme";
 import mockDetailsContextMenuProvider from "../../__testUtils/mockDetailsContextMenuProvider";
 
 const iri = "/iri/";
+const iriWithSpaces = "/iri with spaces/";
 
 describe("ResourceDrawer view", () => {
   let fetch;
@@ -83,6 +84,25 @@ describe("ResourceDrawer view", () => {
   });
 
   test("it renders a Contents view when the router query has an iri", () => {
+    const tree = mountToJson(
+      <SessionProvider>
+        <DetailsMenuContext>
+          <ResourceDrawer />
+        </DetailsMenuContext>
+      </SessionProvider>
+    );
+    expect(tree).toMatchSnapshot();
+  });
+
+  test("it renders without errors when iri contains spaces", () => {
+    jest.spyOn(RouterFns, "useRouter").mockReturnValue({
+      asPath: "/pathname/",
+      replace: jest.fn(),
+      query: {
+        resourceIri: iriWithSpaces,
+        action: "details",
+      },
+    });
     const tree = mountToJson(
       <SessionProvider>
         <DetailsMenuContext>


### PR DESCRIPTION
This PR fixes errors when trying to access subfolders with spaces by encoding the iri before fetching.

### To test:
- Create a folder and a subfolder within it, both with names that contain spaces.
- Verify that you can navigate into the subfolder without errors.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
