### PR TITLE
Fix: user menu flickering

### DIFF
--- a/components/header/userMenu/index.jsx
+++ b/components/header/userMenu/index.jsx
@@ -19,22 +19,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { ReactElement, useState } from "react";
-import { createStyles, makeStyles, StyleRules } from "@material-ui/styles";
-import { PrismTheme, useBem } from "@solid/lit-prism-patterns";
+import React, { useState } from "react";
+import { createStyles, makeStyles } from "@material-ui/styles";
+import { useBem } from "@solid/lit-prism-patterns";
 import Link from "next/link";
 import clsx from "clsx";
 import LogOutButton from "../../logout";
 import styles from "./styles";
 
-const useStyles = makeStyles<PrismTheme>((theme) =>
-  createStyles(styles(theme) as StyleRules)
-);
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 const TESTCAFE_ID_USER_MENU_BUTTON = "user-menu-button";
 
-export default function UserMenu(): ReactElement {
-  const [userMenuOpen, setUserMenuOpen] = useState<boolean>(false);
+export default function UserMenu() {
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
   const bem = useBem(useStyles());
 
   const toggleMenu = () => setUserMenuOpen(!userMenuOpen);

--- a/components/header/userMenu/index.tsx
+++ b/components/header/userMenu/index.tsx
@@ -38,6 +38,8 @@ export default function UserMenu(): ReactElement {
   const bem = useBem(useStyles());
 
   const toggleMenu = () => setUserMenuOpen(!userMenuOpen);
+  const handleMenuOpen = () => setUserMenuOpen(true);
+  const handleMenuClose = () => setUserMenuOpen(false);
 
   return (
     <>
@@ -99,8 +101,8 @@ export default function UserMenu(): ReactElement {
 
       <div
         className={bem("header-banner__aside-menu", "popup")}
-        onMouseEnter={toggleMenu}
-        onMouseLeave={toggleMenu}
+        onMouseEnter={handleMenuOpen}
+        onMouseLeave={handleMenuClose}
       >
         <button
           data-testid={TESTCAFE_ID_USER_MENU_BUTTON}

--- a/components/header/userMenu/styles.js
+++ b/components/header/userMenu/styles.js
@@ -19,9 +19,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { PrismTheme, createStyles } from "@solid/lit-prism-patterns";
+import { createStyles } from "@solid/lit-prism-patterns";
 
-const styles = (theme: PrismTheme) =>
+const styles = (theme) =>
   createStyles(theme, ["headerBanner", "icons", "mainNav"]);
 
 export default styles;


### PR DESCRIPTION
This PR fixes the user menu flickering when hovering on log out button after having clicked the user menu button.

This is fixed by separating the open and close actions for the hover, and toggling only on click. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
