### PR TITLE
Fix: variable header height in Firefox

### DIFF
--- a/components/header/styles.ts
+++ b/components/header/styles.ts
@@ -21,14 +21,21 @@
 
 import { PrismTheme, createStyles } from "@solid/lit-prism-patterns";
 
+const HEADER_HEIGHT = "100px";
+
 const styles = (theme: PrismTheme) =>
   createStyles(theme, ["appLayout", "headerBanner"], {
     logoIndicatorContainer: {
       display: "flex",
+      height: HEADER_HEIGHT,
       flexDirection: "column",
       alignItems: "center",
+      justifyContent: "center",
       marginRight: theme.spacing(2),
-      paddingTop: theme.spacing(2),
+      paddingTop: theme.spacing(1),
+      [theme.breakpoints.up("sm")]: {
+        paddingTop: theme.spacing(2),
+      },
     },
   });
 


### PR DESCRIPTION
This PR fixes height being ignored in Firefox when using flexbox, by setting the `div` container inside the header to a fixed height and thus forcing the height to be 100px.

This issue seems to be due to the app layout container being a flex container, rather than the header container.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

