### PR TITLE
Fix/agent search form validation

### DIFF
--- a/components/addContact/__snapshots__/index.test.jsx.snap
+++ b/components/addContact/__snapshots__/index.test.jsx.snap
@@ -1840,7 +1840,6 @@ font-display: block;",
                       label="WebID"
                       onChange={[Function]}
                       pattern="https://.+"
-                      required={true}
                       title="Must start with https://"
                       type="url"
                       value=""
@@ -1880,7 +1879,6 @@ font-display: block;",
                             }
                             onChange={[Function]}
                             pattern="https://.+"
-                            required={true}
                             title="Must start with https://"
                             type="url"
                             value=""
@@ -1900,7 +1898,6 @@ font-display: block;",
                               }
                               onChange={[Function]}
                               pattern="https://.+"
-                              required={true}
                               title="Must start with https://"
                               type="url"
                             />

--- a/components/addContact/__snapshots__/index.test.jsx.snap
+++ b/components/addContact/__snapshots__/index.test.jsx.snap
@@ -1824,82 +1824,102 @@ font-display: block;",
                 heading="Add contact using Web ID"
                 onSubmit={[Function]}
               >
-                <Input
-                  id={
-                    Array [
-                      "id1",
-                    ]
-                  }
-                  label="WebID"
-                  onChange={[Function]}
-                  value=""
+                <Form
+                  onSubmit={[Function]}
                 >
-                  <InputGroup>
-                    <div
-                      className="PodBrowser-input-group"
-                    >
-                      <Label
-                        htmlFor={
-                          Array [
-                            "id1",
-                          ]
-                        }
-                      >
-                        <label
-                          className="PodBrowser-label"
-                          htmlFor={
-                            Array [
-                              "id1",
-                            ]
-                          }
-                        >
-                          WebID
-                        </label>
-                      </Label>
-                      <SimpleInput
-                        id={
-                          Array [
-                            "id1",
-                          ]
-                        }
-                        name={
-                          Array [
-                            "id1",
-                          ]
-                        }
-                        onChange={[Function]}
-                        value=""
-                      >
-                        <input
-                          className="PodBrowser-input"
-                          defaultValue=""
-                          id={
-                            Array [
-                              "id1",
-                            ]
-                          }
-                          name={
-                            Array [
-                              "id1",
-                            ]
-                          }
-                          onChange={[Function]}
-                          type="text"
-                        />
-                      </SimpleInput>
-                    </div>
-                  </InputGroup>
-                </Input>
-                <Button
-                  onClick={[Function]}
-                >
-                  <button
-                    className="PodBrowser-button"
-                    onClick={[Function]}
+                  <form
+                    className="PodBrowser-form"
+                    onSubmit={[Function]}
                   >
-                    Add Contact
-                  </button>
-                </Button>
+                    <Input
+                      id={
+                        Array [
+                          "id1",
+                        ]
+                      }
+                      label="WebID"
+                      onChange={[Function]}
+                      pattern="https://.+"
+                      required={true}
+                      title="Must start with https://"
+                      type="url"
+                      value=""
+                    >
+                      <InputGroup>
+                        <div
+                          className="PodBrowser-input-group"
+                        >
+                          <Label
+                            htmlFor={
+                              Array [
+                                "id1",
+                              ]
+                            }
+                          >
+                            <label
+                              className="PodBrowser-label"
+                              htmlFor={
+                                Array [
+                                  "id1",
+                                ]
+                              }
+                            >
+                              WebID
+                            </label>
+                          </Label>
+                          <SimpleInput
+                            id={
+                              Array [
+                                "id1",
+                              ]
+                            }
+                            name={
+                              Array [
+                                "id1",
+                              ]
+                            }
+                            onChange={[Function]}
+                            pattern="https://.+"
+                            required={true}
+                            title="Must start with https://"
+                            type="url"
+                            value=""
+                          >
+                            <input
+                              className="PodBrowser-input"
+                              defaultValue=""
+                              id={
+                                Array [
+                                  "id1",
+                                ]
+                              }
+                              name={
+                                Array [
+                                  "id1",
+                                ]
+                              }
+                              onChange={[Function]}
+                              pattern="https://.+"
+                              required={true}
+                              title="Must start with https://"
+                              type="url"
+                            />
+                          </SimpleInput>
+                        </div>
+                      </InputGroup>
+                    </Input>
+                    <Button
+                      type="submit"
+                    >
+                      <button
+                        className="PodBrowser-button"
+                        type="submit"
+                      >
+                        Add Contact
+                      </button>
+                    </Button>
+                  </form>
+                </Form>
               </AgentSearchForm>
             </div>
           </AddContact>

--- a/components/agentSearchForm/__snapshots__/index.test.jsx.snap
+++ b/components/agentSearchForm/__snapshots__/index.test.jsx.snap
@@ -860,7 +860,6 @@ font-display: block;",
               label="WebID"
               onChange={[Function]}
               pattern="https://.+"
-              required={true}
               title="Must start with https://"
               type="url"
               value=""
@@ -900,7 +899,6 @@ font-display: block;",
                     }
                     onChange={[Function]}
                     pattern="https://.+"
-                    required={true}
                     title="Must start with https://"
                     type="url"
                     value=""
@@ -920,7 +918,6 @@ font-display: block;",
                       }
                       onChange={[Function]}
                       pattern="https://.+"
-                      required={true}
                       title="Must start with https://"
                       type="url"
                     />
@@ -1807,7 +1804,6 @@ font-display: block;",
               label="WebID"
               onChange={[Function]}
               pattern="https://.+"
-              required={true}
               title="Must start with https://"
               type="url"
               value=""
@@ -1847,7 +1843,6 @@ font-display: block;",
                     }
                     onChange={[Function]}
                     pattern="https://.+"
-                    required={true}
                     title="Must start with https://"
                     type="url"
                     value=""
@@ -1867,7 +1862,6 @@ font-display: block;",
                       }
                       onChange={[Function]}
                       pattern="https://.+"
-                      required={true}
                       title="Must start with https://"
                       type="url"
                     />

--- a/components/agentSearchForm/__snapshots__/index.test.jsx.snap
+++ b/components/agentSearchForm/__snapshots__/index.test.jsx.snap
@@ -844,82 +844,102 @@ font-display: block;",
         buttonText="Add"
         onSubmit={[MockFunction]}
       >
-        <Input
-          id={
-            Array [
-              "id2",
-            ]
-          }
-          label="WebID"
-          onChange={[Function]}
-          value=""
+        <Form
+          onSubmit={[Function]}
         >
-          <InputGroup>
-            <div
-              className="PodBrowser-input-group"
-            >
-              <Label
-                htmlFor={
-                  Array [
-                    "id2",
-                  ]
-                }
-              >
-                <label
-                  className="PodBrowser-label"
-                  htmlFor={
-                    Array [
-                      "id2",
-                    ]
-                  }
-                >
-                  WebID
-                </label>
-              </Label>
-              <SimpleInput
-                id={
-                  Array [
-                    "id2",
-                  ]
-                }
-                name={
-                  Array [
-                    "id2",
-                  ]
-                }
-                onChange={[Function]}
-                value=""
-              >
-                <input
-                  className="PodBrowser-input"
-                  defaultValue=""
-                  id={
-                    Array [
-                      "id2",
-                    ]
-                  }
-                  name={
-                    Array [
-                      "id2",
-                    ]
-                  }
-                  onChange={[Function]}
-                  type="text"
-                />
-              </SimpleInput>
-            </div>
-          </InputGroup>
-        </Input>
-        <Button
-          onClick={[Function]}
-        >
-          <button
-            className="PodBrowser-button"
-            onClick={[Function]}
+          <form
+            className="PodBrowser-form"
+            onSubmit={[Function]}
           >
-            Add
-          </button>
-        </Button>
+            <Input
+              id={
+                Array [
+                  "id2",
+                ]
+              }
+              label="WebID"
+              onChange={[Function]}
+              pattern="https://.+"
+              required={true}
+              title="Must start with https://"
+              type="url"
+              value=""
+            >
+              <InputGroup>
+                <div
+                  className="PodBrowser-input-group"
+                >
+                  <Label
+                    htmlFor={
+                      Array [
+                        "id2",
+                      ]
+                    }
+                  >
+                    <label
+                      className="PodBrowser-label"
+                      htmlFor={
+                        Array [
+                          "id2",
+                        ]
+                      }
+                    >
+                      WebID
+                    </label>
+                  </Label>
+                  <SimpleInput
+                    id={
+                      Array [
+                        "id2",
+                      ]
+                    }
+                    name={
+                      Array [
+                        "id2",
+                      ]
+                    }
+                    onChange={[Function]}
+                    pattern="https://.+"
+                    required={true}
+                    title="Must start with https://"
+                    type="url"
+                    value=""
+                  >
+                    <input
+                      className="PodBrowser-input"
+                      defaultValue=""
+                      id={
+                        Array [
+                          "id2",
+                        ]
+                      }
+                      name={
+                        Array [
+                          "id2",
+                        ]
+                      }
+                      onChange={[Function]}
+                      pattern="https://.+"
+                      required={true}
+                      title="Must start with https://"
+                      type="url"
+                    />
+                  </SimpleInput>
+                </div>
+              </InputGroup>
+            </Input>
+            <Button
+              type="submit"
+            >
+              <button
+                className="PodBrowser-button"
+                type="submit"
+              >
+                Add
+              </button>
+            </Button>
+          </form>
+        </Form>
       </AgentSearchForm>
     </ThemeProvider>
   </StylesProvider>
@@ -1771,82 +1791,102 @@ font-display: block;",
         heading="Heading"
         onSubmit={[MockFunction]}
       >
-        <Input
-          id={
-            Array [
-              "id1",
-            ]
-          }
-          label="WebID"
-          onChange={[Function]}
-          value=""
+        <Form
+          onSubmit={[Function]}
         >
-          <InputGroup>
-            <div
-              className="PodBrowser-input-group"
-            >
-              <Label
-                htmlFor={
-                  Array [
-                    "id1",
-                  ]
-                }
-              >
-                <label
-                  className="PodBrowser-label"
-                  htmlFor={
-                    Array [
-                      "id1",
-                    ]
-                  }
-                >
-                  WebID
-                </label>
-              </Label>
-              <SimpleInput
-                id={
-                  Array [
-                    "id1",
-                  ]
-                }
-                name={
-                  Array [
-                    "id1",
-                  ]
-                }
-                onChange={[Function]}
-                value=""
-              >
-                <input
-                  className="PodBrowser-input"
-                  defaultValue=""
-                  id={
-                    Array [
-                      "id1",
-                    ]
-                  }
-                  name={
-                    Array [
-                      "id1",
-                    ]
-                  }
-                  onChange={[Function]}
-                  type="text"
-                />
-              </SimpleInput>
-            </div>
-          </InputGroup>
-        </Input>
-        <Button
-          onClick={[Function]}
-        >
-          <button
-            className="PodBrowser-button"
-            onClick={[Function]}
+          <form
+            className="PodBrowser-form"
+            onSubmit={[Function]}
           >
-            Add
-          </button>
-        </Button>
+            <Input
+              id={
+                Array [
+                  "id1",
+                ]
+              }
+              label="WebID"
+              onChange={[Function]}
+              pattern="https://.+"
+              required={true}
+              title="Must start with https://"
+              type="url"
+              value=""
+            >
+              <InputGroup>
+                <div
+                  className="PodBrowser-input-group"
+                >
+                  <Label
+                    htmlFor={
+                      Array [
+                        "id1",
+                      ]
+                    }
+                  >
+                    <label
+                      className="PodBrowser-label"
+                      htmlFor={
+                        Array [
+                          "id1",
+                        ]
+                      }
+                    >
+                      WebID
+                    </label>
+                  </Label>
+                  <SimpleInput
+                    id={
+                      Array [
+                        "id1",
+                      ]
+                    }
+                    name={
+                      Array [
+                        "id1",
+                      ]
+                    }
+                    onChange={[Function]}
+                    pattern="https://.+"
+                    required={true}
+                    title="Must start with https://"
+                    type="url"
+                    value=""
+                  >
+                    <input
+                      className="PodBrowser-input"
+                      defaultValue=""
+                      id={
+                        Array [
+                          "id1",
+                        ]
+                      }
+                      name={
+                        Array [
+                          "id1",
+                        ]
+                      }
+                      onChange={[Function]}
+                      pattern="https://.+"
+                      required={true}
+                      title="Must start with https://"
+                      type="url"
+                    />
+                  </SimpleInput>
+                </div>
+              </InputGroup>
+            </Input>
+            <Button
+              type="submit"
+            >
+              <button
+                className="PodBrowser-button"
+                type="submit"
+              >
+                Add
+              </button>
+            </Button>
+          </form>
+        </Form>
       </AgentSearchForm>
     </ThemeProvider>
   </StylesProvider>

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -22,34 +22,39 @@
 import React, { useState } from "react";
 import { useId } from "react-id-generator";
 import T from "prop-types";
-import { Button, Input } from "@inrupt/prism-react-components";
-
-export function handleClick({ setAgentId, onSubmit }) {
-  return (agentId) => {
-    setAgentId("");
-    onSubmit(agentId);
-  };
-}
-
-export function handleChange(setAgentId) {
-  return ({ target: { value } }) => {
-    setAgentId(value);
-  };
-}
+import { Form, Button, Input } from "@inrupt/prism-react-components";
 
 function AgentSearchForm({ children, onSubmit, buttonText }) {
   const [agentId, setAgentId] = useState("");
-  const onClick = handleClick({ setAgentId, onSubmit });
-  const onChange = handleChange(setAgentId);
   const inputId = useId();
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    onSubmit(agentId);
+    setAgentId("");
+  };
+
+  const handleChange = (event) => {
+    setAgentId(event.target.value);
+  };
+
   return (
-    <>
-      <Input id={inputId} label="WebID" onChange={onChange} value={agentId} />
+    <Form onSubmit={handleSubmit}>
+      <Input
+        id={inputId}
+        label="WebID"
+        onChange={handleChange}
+        value={agentId}
+        required
+        type="url"
+        pattern="https://.+"
+        title="Must start with https://"
+      />
 
       {children}
 
-      <Button onClick={() => onClick(agentId)}>{buttonText}</Button>
-    </>
+      <Button type="submit">{buttonText}</Button>
+    </Form>
   );
 }
 

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -28,9 +28,12 @@ function AgentSearchForm({ children, onSubmit, buttonText }) {
   const [agentId, setAgentId] = useState("");
   const inputId = useId();
 
-  const handleSubmit = () => {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (agentId === "") {
+      return;
+    }
     onSubmit(agentId);
-    setAgentId("");
   };
 
   const handleChange = (event) => {
@@ -44,7 +47,6 @@ function AgentSearchForm({ children, onSubmit, buttonText }) {
         label="WebID"
         onChange={handleChange}
         value={agentId}
-        required
         type="url"
         pattern="https://.+"
         title="Must start with https://"

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -28,8 +28,7 @@ function AgentSearchForm({ children, onSubmit, buttonText }) {
   const [agentId, setAgentId] = useState("");
   const inputId = useId();
 
-  const handleSubmit = (event) => {
-    event.preventDefault();
+  const handleSubmit = () => {
     onSubmit(agentId);
     setAgentId("");
   };

--- a/components/agentSearchForm/index.test.jsx
+++ b/components/agentSearchForm/index.test.jsx
@@ -19,9 +19,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { render, fireEvent } from "@testing-library/react";
 import React from "react";
 import { mountToJson } from "../../__testUtils/mountWithTheme";
-import AgentSearchForm, { handleClick, handleChange } from "./index";
+import AgentSearchForm from "./index";
 
 describe("AgentSearchForm", () => {
   test("it renders an AgentSearchForm", () => {
@@ -40,28 +41,25 @@ describe("AgentSearchForm", () => {
 
     expect(tree).toMatchSnapshot();
   });
-});
-
-describe("handleClick", () => {
-  test("it returns a handler that clears the agentId input and calls onSubmit", () => {
-    const setAgentId = jest.fn();
+  test("it calls onSubmit when clicking the submit button", () => {
     const onSubmit = jest.fn();
-    const onClick = handleClick({ setAgentId, onSubmit });
-
-    onClick("agentId");
-
-    expect(setAgentId).toHaveBeenCalledWith("");
-    expect(onSubmit).toHaveBeenCalledWith("agentId");
+    const wrapper = render(<AgentSearchForm onSubmit={onSubmit} />);
+    const input = wrapper.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "https://www.example.com" } });
+    const button = wrapper.getByRole("button");
+    fireEvent.click(button);
+    expect(onSubmit).toHaveBeenCalledWith("https://www.example.com");
   });
-});
-
-describe("handleChange", () => {
-  test("it returns a handler that sets the agentId", () => {
+  test("it clears the input box before calling onSubmit", () => {
+    const onSubmit = jest.fn();
     const setAgentId = jest.fn();
-    const onChange = handleChange(setAgentId);
-
-    onChange({ target: { value: "test" } });
-
-    expect(setAgentId).toHaveBeenCalledWith("test");
+    const useStateSpy = jest.spyOn(React, "useState");
+    useStateSpy.mockImplementation((agentId) => [agentId, setAgentId]);
+    const wrapper = render(<AgentSearchForm onSubmit={onSubmit} />);
+    const input = wrapper.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "https://www.example.com" } });
+    const button = wrapper.getByRole("button");
+    fireEvent.click(button);
+    expect(setAgentId).toHaveBeenCalledWith("");
   });
 });

--- a/components/agentSearchForm/index.test.jsx
+++ b/components/agentSearchForm/index.test.jsx
@@ -50,4 +50,11 @@ describe("AgentSearchForm", () => {
     fireEvent.click(button);
     expect(onSubmit).toHaveBeenCalledWith("https://www.example.com");
   });
+  test("it does not call onSubmit with an empty string", () => {
+    const onSubmit = jest.fn();
+    const wrapper = render(<AgentSearchForm onSubmit={onSubmit} />);
+    const button = wrapper.getByRole("button");
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/components/agentSearchForm/index.test.jsx
+++ b/components/agentSearchForm/index.test.jsx
@@ -50,16 +50,4 @@ describe("AgentSearchForm", () => {
     fireEvent.click(button);
     expect(onSubmit).toHaveBeenCalledWith("https://www.example.com");
   });
-  test("it clears the input box before calling onSubmit", () => {
-    const onSubmit = jest.fn();
-    const setAgentId = jest.fn();
-    const useStateSpy = jest.spyOn(React, "useState");
-    useStateSpy.mockImplementation((agentId) => [agentId, setAgentId]);
-    const wrapper = render(<AgentSearchForm onSubmit={onSubmit} />);
-    const input = wrapper.getByRole("textbox");
-    fireEvent.change(input, { target: { value: "https://www.example.com" } });
-    const button = wrapper.getByRole("button");
-    fireEvent.click(button);
-    expect(setAgentId).toHaveBeenCalledWith("");
-  });
 });


### PR DESCRIPTION
This PR fixes:
- Uncaught promise if "Add Contact" button clicked without WebId
- "Insecure Resource Requested" when trying to add a WebId with `http`

## To test
- This component can be tested in Add Contact and in Permissions for an individual resource
- Verify that the form cannot be submitted without a valid url that doesn't start with `https`

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

