### PR TITLE
Feat: add pod ownership to useOwnerProfile hook

### DIFF
--- a/components/header/__snapshots__/index.test.jsx.snap
+++ b/components/header/__snapshots__/index.test.jsx.snap
@@ -855,6 +855,12 @@ font-display: block;",
                     },
                   ],
                   Array [
+                    "https://mypod.myhost.com",
+                    Object {
+                      "method": "HEAD",
+                    },
+                  ],
+                  Array [
                     "https://mypod.myhost.com/profile/card#me",
                     Object {
                       "headers": Object {
@@ -867,6 +873,10 @@ font-display: block;",
                   Object {
                     "type": "return",
                     "value": Promise {},
+                  },
+                  Object {
+                    "type": "throw",
+                    "value": [Error: URL (https://mypod.myhost.com) not mocked properly],
                   },
                   Object {
                     "type": "throw",

--- a/components/header/__snapshots__/index.test.jsx.snap
+++ b/components/header/__snapshots__/index.test.jsx.snap
@@ -861,11 +861,9 @@ font-display: block;",
                     },
                   ],
                   Array [
-                    "https://mypod.myhost.com/profile/card#me",
+                    "https://mypod.myhost.com",
                     Object {
-                      "headers": Object {
-                        "Accept": "text/turtle",
-                      },
+                      "method": "HEAD",
                     },
                   ],
                 ],
@@ -880,7 +878,7 @@ font-display: block;",
                   },
                   Object {
                     "type": "throw",
-                    "value": [Error: URL (https://mypod.myhost.com/profile/card#me) not mocked properly],
+                    "value": [Error: URL (https://mypod.myhost.com) not mocked properly],
                   },
                 ],
               },

--- a/src/hooks/usePodOwner/index.js
+++ b/src/hooks/usePodOwner/index.js
@@ -23,14 +23,13 @@ import { useState, useEffect } from "react";
 import { getResourceInfo, getPodOwner } from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
 import { joinPath } from "../../stringHelpers";
-import usePodRoot from "../usePodRoot";
+import usePodRootUri from "../usePodRootUri";
 
 export default function usePodOwner({ resourceIri }) {
   const { fetch } = useSession();
   const [podOwnerWebId, setPodOwnerWebId] = useState(null);
   const [error, setError] = useState(null);
-  const decodedResourceUri = decodeURIComponent(resourceIri);
-  const podRoot = usePodRoot(decodedResourceUri, null);
+  const podRoot = usePodRootUri(resourceIri, null);
   const profileIri = podRoot && joinPath(podRoot, "profile/card#me");
 
   useEffect(() => {

--- a/src/hooks/usePodOwner/index.js
+++ b/src/hooks/usePodOwner/index.js
@@ -30,7 +30,6 @@ export default function usePodOwner({ resourceIri }) {
   const [podOwnerWebId, setPodOwnerWebId] = useState(null);
   const [error, setError] = useState(null);
   const podRoot = usePodRootUri(resourceIri, null);
-  const profileIri = podRoot && joinPath(podRoot, "profile/card#me");
 
   useEffect(() => {
     if (!resourceIri) {
@@ -41,12 +40,14 @@ export default function usePodOwner({ resourceIri }) {
     (async () => {
       try {
         const resourceInfo = await getResourceInfo(resourceIri, { fetch });
-        const webId = getPodOwner(resourceInfo, fetch);
+        const webId =
+          getPodOwner(resourceInfo) ||
+          (podRoot && joinPath(podRoot, "profile/card#me"));
         setPodOwnerWebId(webId);
       } catch (e) {
         setError(e);
       }
     })();
-  }, [resourceIri, fetch]);
-  return { podOwnerWebId: podOwnerWebId || profileIri, error };
+  }, [resourceIri, fetch, podRoot]);
+  return { podOwnerWebId, error };
 }

--- a/src/hooks/usePodOwner/index.js
+++ b/src/hooks/usePodOwner/index.js
@@ -41,7 +41,7 @@ export default function usePodOwner({ resourceIri }) {
     (async () => {
       try {
         const resourceInfo = await getResourceInfo(resourceIri, { fetch });
-        const { response: webId } = getPodOwner(resourceInfo, fetch);
+        const webId = getPodOwner(resourceInfo, fetch);
         setPodOwnerWebId(webId);
       } catch (e) {
         setError(e);

--- a/src/hooks/usePodOwner/index.js
+++ b/src/hooks/usePodOwner/index.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { useState, useEffect } from "react";
+import { getResourceInfo, getPodOwner } from "@inrupt/solid-client";
+import { useSession } from "@inrupt/solid-ui-react";
+
+export default function usePodOwner(resourceIri) {
+  const { fetch } = useSession();
+  const [podOwnerWebId, setPodOwnerWebId] = useState(null);
+  const [error, setError] = useState();
+
+  useEffect(() => {
+    if (!resourceIri) return;
+    (async () => {
+      try {
+        const resourceInfo = await getResourceInfo(resourceIri, { fetch });
+        const { response: webId } = await getPodOwner(resourceInfo, fetch);
+        setPodOwnerWebId(webId);
+      } catch (e) {
+        setError(e);
+      }
+    })();
+  }, [resourceIri, fetch]);
+
+  return { podOwnerWebId, error };
+}

--- a/src/hooks/usePodOwner/index.test.js
+++ b/src/hooks/usePodOwner/index.test.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { renderHook } from "@testing-library/react-hooks";
+import * as solidClientFns from "@inrupt/solid-client";
+import usePodOwner from ".";
+
+jest.mock("@inrupt/solid-client");
+
+describe("usePodOwner", () => {
+  test("it returns the pod owner if available", async () => {
+    const resourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://www.example.com",
+        linkedResources: {
+          "http://www.w3.org/ns/solid/terms#podOwner": [
+            "https://www.example.com/profile#WebId",
+          ],
+        },
+      },
+    };
+
+    solidClientFns.getResourceInfo = jest.fn().mockResolvedValue(resourceInfo);
+    solidClientFns.getPodOwner = jest
+      .fn()
+      .mockReturnValue({ response: "https://www.example.com/profile#WebId" });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodOwner({ resourceIri: "https://www.example.com" })
+    );
+    await waitForNextUpdate();
+    expect(result.current.podOwnerWebId).toEqual(
+      "https://www.example.com/profile#WebId"
+    );
+  });
+  test("it returns the fallback profile iri if pod owner is not available", async () => {
+    const resourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://www.example.com",
+        linkedResources: {},
+      },
+    };
+
+    solidClientFns.getResourceInfo = jest.fn().mockResolvedValue(resourceInfo);
+    solidClientFns.getPodOwner = jest.fn().mockReturnValue({ response: null });
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePodOwner({ resourceIri: "https://www.example.com" })
+    );
+    await waitForNextUpdate();
+    expect(result.current.podOwnerWebId).toEqual(
+      "https://www.example.com/profile/card#me"
+    );
+  });
+  test("it sets webId and error to null and exits if resource Iri is undefined", async () => {
+    const resourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://www.example.com",
+        linkedResources: {
+          "http://www.w3.org/ns/solid/terms#podOwner": [
+            "https://www.example.com/profile#WebId",
+          ],
+        },
+      },
+    };
+
+    solidClientFns.getResourceInfo = jest.fn().mockResolvedValue(resourceInfo);
+    solidClientFns.getPodOwner = jest
+      .fn()
+      .mockReturnValue({ response: "https://www.example.com/profile#WebId" });
+
+    const { result, rerender, waitForNextUpdate } = renderHook(
+      ({ resourceIri }) => usePodOwner({ resourceIri }),
+      { initialProps: { resourceIri: "https://www.example.com " } }
+    );
+    await waitForNextUpdate();
+    expect(result.current.podOwnerWebId).not.toBeNull();
+    rerender({ resourceIri: undefined });
+    expect(result.current.podOwnerWebId).toBeNull();
+  });
+});

--- a/src/hooks/usePodOwner/index.test.js
+++ b/src/hooks/usePodOwner/index.test.js
@@ -41,7 +41,7 @@ describe("usePodOwner", () => {
     solidClientFns.getResourceInfo = jest.fn().mockResolvedValue(resourceInfo);
     solidClientFns.getPodOwner = jest
       .fn()
-      .mockReturnValue({ response: "https://www.example.com/profile#WebId" });
+      .mockReturnValue("https://www.example.com/profile#WebId");
 
     const { result, waitForNextUpdate } = renderHook(() =>
       usePodOwner({ resourceIri: "https://www.example.com" })
@@ -60,7 +60,7 @@ describe("usePodOwner", () => {
     };
 
     solidClientFns.getResourceInfo = jest.fn().mockResolvedValue(resourceInfo);
-    solidClientFns.getPodOwner = jest.fn().mockReturnValue({ response: null });
+    solidClientFns.getPodOwner = jest.fn().mockReturnValue(null);
 
     const { result, waitForNextUpdate } = renderHook(() =>
       usePodOwner({ resourceIri: "https://www.example.com" })
@@ -85,7 +85,7 @@ describe("usePodOwner", () => {
     solidClientFns.getResourceInfo = jest.fn().mockResolvedValue(resourceInfo);
     solidClientFns.getPodOwner = jest
       .fn()
-      .mockReturnValue({ response: "https://www.example.com/profile#WebId" });
+      .mockReturnValue("https://www.example.com/profile#WebId");
 
     const { result, rerender, waitForNextUpdate } = renderHook(
       ({ resourceIri }) => usePodOwner({ resourceIri }),

--- a/src/hooks/usePodOwnerProfile/index.js
+++ b/src/hooks/usePodOwnerProfile/index.js
@@ -21,39 +21,22 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import { useSession } from "@inrupt/solid-ui-react";
-import { getResourceInfo, getPodOwner } from "@inrupt/solid-client";
 import { joinPath } from "../../stringHelpers";
 import useAuthenticatedProfile from "../useAuthenticatedProfile";
 import usePodRootUri from "../usePodRootUri";
 import useFetchProfile from "../useFetchProfile";
+import usePodOwner from "../usePodOwner";
 
 export default function usePodOwnerProfile() {
-  const { session } = useSession();
-  const { fetch } = session;
   const [profile, setProfile] = useState();
   const [error, setError] = useState();
   const router = useRouter();
-  // const decodedResourceUri = decodeURIComponent(router.query.iri);
   const podRoot = usePodRootUri(router.query.iri, null);
-  const [podOwnerWebId, setPodOwnerWebId] = useState(null);
+  const { podOwnerWebId } = usePodOwner(router.query.iri);
   const profileIri =
     podOwnerWebId || (podRoot && joinPath(podRoot, "profile/card#me")); // we won't need to do this once ownership is available
   const { data: authProfile, error: authError } = useAuthenticatedProfile();
   const { data: ownerProfile, error: ownerError } = useFetchProfile(profileIri);
-
-  useEffect(() => {
-    if (!router.query.iri) return;
-    (async () => {
-      try {
-        const resourceInfo = await getResourceInfo(router.query.iri, { fetch });
-        const { response: webId } = await getPodOwner(resourceInfo, fetch);
-        setPodOwnerWebId(webId);
-      } catch (e) {
-        setError(e);
-      }
-    })();
-  }, [router.query.iri, fetch, session]);
 
   useEffect(() => {
     if (!router.query.iri && authProfile) {

--- a/src/hooks/usePodOwnerProfile/index.js
+++ b/src/hooks/usePodOwnerProfile/index.js
@@ -32,7 +32,7 @@ export default function usePodOwnerProfile() {
   const [error, setError] = useState();
   const router = useRouter();
   const podRoot = usePodRootUri(router.query.iri, null);
-  const { podOwnerWebId } = usePodOwner(router.query.iri);
+  const { podOwnerWebId } = usePodOwner({ resourceIri: router.query.iri }); // passing in an object for testing purposes
   const profileIri =
     podOwnerWebId || (podRoot && joinPath(podRoot, "profile/card#me")); // we won't need to do this once ownership is available
   const { data: authProfile, error: authError } = useAuthenticatedProfile();

--- a/src/hooks/usePodOwnerProfile/index.js
+++ b/src/hooks/usePodOwnerProfile/index.js
@@ -21,9 +21,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
-import { joinPath } from "../../stringHelpers";
 import useAuthenticatedProfile from "../useAuthenticatedProfile";
-import usePodRootUri from "../usePodRootUri";
 import useFetchProfile from "../useFetchProfile";
 import usePodOwner from "../usePodOwner";
 
@@ -31,14 +29,20 @@ export default function usePodOwnerProfile() {
   const [profile, setProfile] = useState();
   const [error, setError] = useState();
   const router = useRouter();
-  const podRoot = usePodRootUri(router.query.iri, null);
-  const { podOwnerWebId } = usePodOwner({ resourceIri: router.query.iri }); // passing in an object for testing purposes
-  const profileIri =
-    podOwnerWebId || (podRoot && joinPath(podRoot, "profile/card#me")); // we won't need to do this once ownership is available
+  const { podOwnerWebId, error: podOwnerError } = usePodOwner({
+    resourceIri: router.query.iri,
+  }); // passing in an object for testing purposes
   const { data: authProfile, error: authError } = useAuthenticatedProfile();
-  const { data: ownerProfile, error: ownerError } = useFetchProfile(profileIri);
+  const { data: ownerProfile, error: ownerError } = useFetchProfile(
+    podOwnerWebId
+  );
 
   useEffect(() => {
+    if (podOwnerError) {
+      setProfile(null);
+      setError(podOwnerError);
+      return;
+    }
     if (!router.query.iri && authProfile) {
       // we're not using the Navigator, so we'll use the authenticated user's profile
       setProfile(authProfile);
@@ -64,7 +68,14 @@ export default function usePodOwnerProfile() {
     }
     setProfile(ownerProfile);
     setError(ownerError);
-  }, [router.query.iri, authProfile, authError, ownerProfile, ownerError]);
+  }, [
+    router.query.iri,
+    authProfile,
+    authError,
+    ownerProfile,
+    ownerError,
+    podOwnerError,
+  ]);
 
   return { profile, error };
 }

--- a/src/hooks/usePodOwnerProfile/index.test.jsx
+++ b/src/hooks/usePodOwnerProfile/index.test.jsx
@@ -24,6 +24,7 @@ import * as RouterFns from "next/router";
 import { addUrl } from "@inrupt/solid-client";
 import { space } from "rdf-namespaces/dist/index";
 import usePodOwnerProfile from "./index";
+import usePodOwner from "../usePodOwner/index";
 import {
   mockPersonDatasetAlice,
   mockPersonDatasetBob,
@@ -36,6 +37,7 @@ import { packageProfile } from "../../solidClientHelpers/profile";
 
 jest.mock("../useFetchProfile");
 jest.mock("../useAuthenticatedProfile");
+jest.mock("../usePodOwner");
 
 describe("usePodOwnerProfile", () => {
   const podUrl = "http://example.com";
@@ -49,6 +51,7 @@ describe("usePodOwnerProfile", () => {
   beforeEach(() => {
     useAuthenticatedProfile.mockReturnValue({ data: authProfile });
     useFetchProfile.mockReturnValue({ data: userProfile });
+    usePodOwner.mockReturnValue({ podOwnerWebId: userProfileUri });
     jest.spyOn(RouterFns, "useRouter").mockReturnValue({ query: {} });
   });
 


### PR DESCRIPTION
# Add pod ownership to useOwnerProfile hook
This enables the pod indicator to use pod owner when available, or fall back to fetching the profile from the constructed profile iri. 

## To test
- Log in with an ESS and check that the owner name is displayed properly
- Do the same with an NSS account to check that the fallback works

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
