### PR TITLE
Feature/improve add contact error message

### DIFF
--- a/components/addContact/__snapshots__/index.test.jsx.snap
+++ b/components/addContact/__snapshots__/index.test.jsx.snap
@@ -1839,7 +1839,9 @@ font-display: block;",
               <AgentSearchForm
                 buttonText="Add Contact"
                 heading="Add contact using Web ID"
+                onChange={[Function]}
                 onSubmit={[Function]}
+                value=""
               >
                 <Form
                   onSubmit={[Function]}

--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -45,6 +45,7 @@ export const FETCH_PROFILE_FAILED_ERROR_MESSAGE =
 
 export function handleSubmit({
   addressBook,
+  setAgentId,
   setIsLoading,
   alertError,
   alertSuccess,
@@ -78,11 +79,14 @@ export function handleSubmit({
         );
 
         if (error) alertError(error);
-        if (response) alertSuccess(`${contact.fn} was added to your contacts`);
+        if (response) {
+          alertSuccess(`${contact.fn} was added to your contacts`);
+          setAgentId("");
+        }
       } else {
         alertError(NO_NAME_ERROR_MESSAGE);
       }
-    } catch (error) {
+    } catch {
       alertError(FETCH_PROFILE_FAILED_ERROR_MESSAGE);
     }
     setIsLoading(false);
@@ -105,16 +109,20 @@ export default function AddContact() {
   );
   const [addressBook] = useAddressBook();
   const [isLoading, setIsLoading] = useState(false);
+  const [agentId, setAgentId] = useState("");
   if (!webId || isLoading) return <Spinner />;
 
   const onSubmit = handleSubmit({
     addressBook,
+    setAgentId,
     setIsLoading,
     alertError,
     alertSuccess,
     fetch,
     webId,
   });
+
+  const handleChange = (newValue) => setAgentId(newValue);
 
   return (
     <div className={containerClass}>
@@ -125,8 +133,10 @@ export default function AddContact() {
 
       <AgentSearchForm
         heading="Add contact using Web ID"
+        onChange={handleChange}
         onSubmit={onSubmit}
         buttonText="Add Contact"
+        value={agentId}
       />
     </div>
   );

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -37,6 +37,7 @@ import AddContact, {
   handleSubmit,
   EXISTING_WEBID_ERROR_MESSAGE,
   NO_NAME_ERROR_MESSAGE,
+  FETCH_PROFILE_FAILED_ERROR_MESSAGE,
 } from "./index";
 import * as addressBookFns from "../../src/addressBook";
 import { WithTheme } from "../../__testUtils/mountWithTheme";
@@ -124,6 +125,26 @@ describe("handleSubmit", () => {
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertSuccess).not.toHaveBeenCalled();
     expect(alertError).toHaveBeenCalledWith(NO_NAME_ERROR_MESSAGE);
+  });
+  test("it alerts the user and exits if fetching the profile fails", async () => {
+    const mockProfileError = new Error("error");
+    const setIsLoading = jest.fn();
+    const alertError = jest.fn();
+    const alertSuccess = jest.fn();
+    const handler = handleSubmit({
+      addressBook,
+      setIsLoading,
+      alertError,
+      alertSuccess,
+      fetch,
+    });
+    jest
+      .spyOn(profileHelperFns, "fetchProfile")
+      .mockRejectedValue(mockProfileError);
+    await handler();
+    expect(setIsLoading).toHaveBeenCalledTimes(2);
+    expect(alertSuccess).not.toHaveBeenCalled();
+    expect(alertError).toHaveBeenCalledWith(FETCH_PROFILE_FAILED_ERROR_MESSAGE);
   });
   test("it saves a new contact", async () => {
     const personUri = "http://example.com/alice#me";

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -80,15 +80,20 @@ describe("AddContact", () => {
 });
 describe("handleSubmit", () => {
   const addressBook = mockSolidDatasetFrom("https://example.com/addressBook");
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   test("it alerts the user and exits if the webid already exists", async () => {
     const personDataset = mockPersonDatasetAlice();
     const personProfile = mockProfileAlice();
+    const setAgentId = jest.fn();
     const setIsLoading = jest.fn();
     const alertError = jest.fn();
     const alertSuccess = jest.fn();
     const handler = handleSubmit({
       addressBook,
+      setAgentId,
       setIsLoading,
       alertError,
       alertSuccess,
@@ -101,17 +106,20 @@ describe("handleSubmit", () => {
       .spyOn(addressBookFns, "findContactInAddressBook")
       .mockResolvedValue([personDataset]);
     await handler();
+    expect(setAgentId).toHaveBeenCalledTimes(0);
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertError).toHaveBeenCalledWith(EXISTING_WEBID_ERROR_MESSAGE);
   });
   test("it alerts the user and exits if the webid doesn't have a name", async () => {
     const personUri = "http://example.com/marie#me";
     const mockProfile = { webId: personUri };
+    const setAgentId = jest.fn();
     const setIsLoading = jest.fn();
     const alertError = jest.fn();
     const alertSuccess = jest.fn();
     const handler = handleSubmit({
       addressBook,
+      setAgentId,
       setIsLoading,
       alertError,
       alertSuccess,
@@ -122,17 +130,20 @@ describe("handleSubmit", () => {
       .spyOn(addressBookFns, "findContactInAddressBook")
       .mockResolvedValue([]);
     await handler();
+    expect(setAgentId).toHaveBeenCalledTimes(0);
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertSuccess).not.toHaveBeenCalled();
     expect(alertError).toHaveBeenCalledWith(NO_NAME_ERROR_MESSAGE);
   });
   test("it alerts the user and exits if fetching the profile fails", async () => {
     const mockProfileError = new Error("error");
+    const setAgentId = jest.fn();
     const setIsLoading = jest.fn();
     const alertError = jest.fn();
     const alertSuccess = jest.fn();
     const handler = handleSubmit({
       addressBook,
+      setAgentId,
       setIsLoading,
       alertError,
       alertSuccess,
@@ -140,8 +151,9 @@ describe("handleSubmit", () => {
     });
     jest
       .spyOn(profileHelperFns, "fetchProfile")
-      .mockRejectedValue(mockProfileError);
+      .mockRejectedValueOnce(mockProfileError);
     await handler();
+    expect(setAgentId).toHaveBeenCalledTimes(0);
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertSuccess).not.toHaveBeenCalled();
     expect(alertError).toHaveBeenCalledWith(FETCH_PROFILE_FAILED_ERROR_MESSAGE);
@@ -157,11 +169,13 @@ describe("handleSubmit", () => {
     const peopleDataset = mockSolidDatasetFrom(contactsIri);
     const peopleDatasetWithContact = setThing(peopleDataset, personDataset);
     const mockProfile = mockProfileAlice();
+    const setAgentId = jest.fn();
     const setIsLoading = jest.fn();
     const alertError = jest.fn();
     const alertSuccess = jest.fn();
     const handler = handleSubmit({
       addressBook,
+      setAgentId,
       setIsLoading,
       alertError,
       alertSuccess,
@@ -176,6 +190,7 @@ describe("handleSubmit", () => {
       error: null,
     });
     await handler();
+    expect(setAgentId).toHaveBeenCalledWith("");
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertSuccess).toHaveBeenCalledWith(
       "Alice was added to your contacts"
@@ -184,11 +199,13 @@ describe("handleSubmit", () => {
   });
   test("it alerts the user if there is an error while creating the contact", async () => {
     const mockProfile = mockProfileAlice();
+    const setAgentId = jest.fn();
     const setIsLoading = jest.fn();
     const alertError = jest.fn();
     const alertSuccess = jest.fn();
     const handler = handleSubmit({
       addressBook,
+      setAgentId,
       setIsLoading,
       alertError,
       alertSuccess,
@@ -203,6 +220,7 @@ describe("handleSubmit", () => {
       error: "There was an error saving the resource",
     });
     await handler();
+    expect(setAgentId).toHaveBeenCalledTimes(0);
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertSuccess).not.toHaveBeenCalled();
     expect(alertError).toHaveBeenCalledWith(

--- a/components/addPermissionUsingWebIdButton/index.jsx
+++ b/components/addPermissionUsingWebIdButton/index.jsx
@@ -39,6 +39,12 @@ const POPOVER_ID = "AddPermissionWithWebId";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
+export function changeHandler(setAgentId) {
+  return (newAgentId) => {
+    setAgentId(newAgentId);
+  };
+}
+
 export function clickHandler(setAnchorEl) {
   return (event) => {
     setAnchorEl(event.currentTarget);
@@ -104,6 +110,9 @@ export default function AddPermissionUsingWebIdButton({
   const { dataset, setDataset } = useContext(DatasetContext);
   const [submitted, setSubmitted] = useState(false);
   const [permissionFormError, setPermissionFormError] = useState(false);
+  const [agentId, setAgentId] = useState("");
+
+  const handleChange = changeHandler(setAgentId);
 
   const handleClick = clickHandler(setAnchorEl);
 
@@ -160,7 +169,11 @@ export default function AddPermissionUsingWebIdButton({
           horizontal: "center",
         }}
       >
-        <AgentSearchForm onSubmit={onSubmit}>
+        <AgentSearchForm
+          onChange={handleChange}
+          onSubmit={onSubmit}
+          value={agentId}
+        >
           <InputGroup>
             <Label>Assign permissions</Label>
             <PermissionsForm

--- a/components/addPermissionUsingWebIdButton/index.test.jsx
+++ b/components/addPermissionUsingWebIdButton/index.test.jsx
@@ -24,6 +24,7 @@ import { DatasetProvider } from "@inrupt/solid-ui-react";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import { mountToJson } from "../../__testUtils/mountWithTheme";
 import AddPermissionUsingWebIdButton, {
+  changeHandler,
   clickHandler,
   closeHandler,
   submitHandler,
@@ -43,6 +44,14 @@ describe("AddPermissionUsingWebIdButton", () => {
         </DatasetProvider>
       )
     ).toMatchSnapshot();
+  });
+});
+
+describe("changeHandler", () => {
+  it("triggers setAgentId", () => {
+    const setAgentId = jest.fn();
+    changeHandler(setAgentId)("https://example.com");
+    expect(setAgentId).toHaveBeenCalledWith("https://example.com");
   });
 });
 

--- a/components/agentSearchForm/__snapshots__/index.test.jsx.snap
+++ b/components/agentSearchForm/__snapshots__/index.test.jsx.snap
@@ -842,7 +842,9 @@ font-display: block;",
     >
       <AgentSearchForm
         buttonText="Add"
+        onChange={[Function]}
         onSubmit={[MockFunction]}
+        value=""
       >
         <Form
           onSubmit={[Function]}
@@ -1786,7 +1788,9 @@ font-display: block;",
       <AgentSearchForm
         buttonText="Add"
         heading="Heading"
+        onChange={[MockFunction]}
         onSubmit={[MockFunction]}
+        value=""
       >
         <Form
           onSubmit={[Function]}

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -19,25 +19,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import { useId } from "react-id-generator";
 import T from "prop-types";
 import { Form, Button, Input } from "@inrupt/prism-react-components";
 
-function AgentSearchForm({ children, onSubmit, buttonText }) {
-  const [agentId, setAgentId] = useState("");
+function AgentSearchForm({ children, onSubmit, buttonText, value, onChange }) {
   const inputId = useId();
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    if (agentId === "") {
+    if (value === "") {
       return;
     }
-    onSubmit(agentId);
+    onSubmit(value);
   };
 
   const handleChange = (event) => {
-    setAgentId(event.target.value);
+    onChange(event.target.value);
   };
 
   return (
@@ -46,7 +45,7 @@ function AgentSearchForm({ children, onSubmit, buttonText }) {
         id={inputId}
         label="WebID"
         onChange={handleChange}
-        value={agentId}
+        value={value}
         type="url"
         pattern="https://.+"
         title="Must start with https://"
@@ -62,13 +61,17 @@ function AgentSearchForm({ children, onSubmit, buttonText }) {
 AgentSearchForm.propTypes = {
   buttonText: T.string,
   children: T.node,
+  onChange: T.func,
   onSubmit: T.func,
+  value: T.string,
 };
 
 AgentSearchForm.defaultProps = {
   buttonText: "Add",
   children: null,
+  onChange: () => {},
   onSubmit: () => {},
+  value: "",
 };
 
 export default AgentSearchForm;

--- a/components/agentSearchForm/index.test.jsx
+++ b/components/agentSearchForm/index.test.jsx
@@ -27,9 +27,15 @@ import AgentSearchForm from "./index";
 describe("AgentSearchForm", () => {
   test("it renders an AgentSearchForm", () => {
     const heading = "Heading";
+    const onChange = jest.fn();
     const onSubmit = jest.fn();
     const tree = mountToJson(
-      <AgentSearchForm heading={heading} onSubmit={onSubmit} />
+      <AgentSearchForm
+        heading={heading}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        value=""
+      />
     );
 
     expect(tree).toMatchSnapshot();
@@ -41,11 +47,21 @@ describe("AgentSearchForm", () => {
 
     expect(tree).toMatchSnapshot();
   });
-  test("it calls onSubmit when clicking the submit button", () => {
+  test("it calls onChange when updating the input", () => {
+    const onChange = jest.fn();
     const onSubmit = jest.fn();
-    const wrapper = render(<AgentSearchForm onSubmit={onSubmit} />);
+    const wrapper = render(
+      <AgentSearchForm onSubmit={onSubmit} onChange={onChange} value="" />
+    );
     const input = wrapper.getByRole("textbox");
     fireEvent.change(input, { target: { value: "https://www.example.com" } });
+    expect(onChange).toHaveBeenCalledWith("https://www.example.com");
+  });
+  test("it calls onSubmit when clicking the submit button", () => {
+    const onSubmit = jest.fn();
+    const wrapper = render(
+      <AgentSearchForm onSubmit={onSubmit} value="https://www.example.com" />
+    );
     const button = wrapper.getByRole("button");
     fireEvent.click(button);
     expect(onSubmit).toHaveBeenCalledWith("https://www.example.com");


### PR DESCRIPTION
Improve error message when contact creation with an invalid WebId fails

- Adds a useful error message ("Unable to retrieve a profile from the given WebID")
- Refactor AgentSearchForm to allow `agentId` search term to be persisted, and only cleared on success
