### PR TITLE
Adds onSubmit to forms that are missing it

### DIFF
--- a/components/addFolderFlyout/__snapshots__/index.test.jsx.snap
+++ b/components/addFolderFlyout/__snapshots__/index.test.jsx.snap
@@ -50,6 +50,11 @@ exports[`AddFolderFlyout Renders an Add Folder button 1`] = `
               "vertical": "bottom",
             }
           }
+          classes={
+            Object {
+              "paper": "makeStyles-paper-1",
+            }
+          }
           onClose={[Function]}
           open={false}
           transformOrigin={
@@ -69,7 +74,7 @@ exports[`AddFolderFlyout Renders an Add Folder button 1`] = `
             }
             classes={
               Object {
-                "paper": "MuiPopover-paper",
+                "paper": "MuiPopover-paper makeStyles-paper-1",
                 "root": "MuiPopover-root",
               }
             }

--- a/components/addFolderFlyout/index.jsx
+++ b/components/addFolderFlyout/index.jsx
@@ -21,7 +21,7 @@
 
 import React, { useContext, useState } from "react";
 import PropTypes from "prop-types";
-import { createContainerAt } from "@inrupt/solid-client";
+import { createContainerAt, getSourceUrl } from "@inrupt/solid-client";
 import { makeStyles } from "@material-ui/core/styles";
 import { useSession } from "@inrupt/solid-ui-react";
 import {
@@ -32,6 +32,7 @@ import {
   Input,
   InputLabel,
 } from "@material-ui/core";
+import { Form } from "@inrupt/prism-react-components";
 import PodLocationContext from "../../src/contexts/podLocationContext";
 import AlertContext from "../../src/contexts/alertContext";
 
@@ -82,8 +83,13 @@ export function handleFolderSubmit({
   setMessage,
   setAlertOpen,
   handleClose,
+  setFolderName,
 }) {
-  return async () => {
+  return async (event) => {
+    event.preventDefault();
+    if (!name) {
+      return;
+    }
     try {
       const url = determineFinalUrl(folders, currentUri, name);
       const response = await createContainerAt(url, options);
@@ -92,23 +98,17 @@ export function handleFolderSubmit({
       setSeverity("success");
       setMessage(
         `Your folder has been created at ${decodeURIComponent(
-          response.internal_resourceInfo.sourceIri
+          getSourceUrl(response)
         )}`
       );
       setAlertOpen(true);
+      setFolderName("");
       handleClose();
     } catch (error) {
       setSeverity("error");
       setMessage(error.toString());
       setAlertOpen(true);
     }
-  };
-}
-
-export function handleCreateFolderClick({ setFolderName, onSubmit }) {
-  return () => {
-    setFolderName("");
-    onSubmit();
   };
 }
 
@@ -153,9 +153,9 @@ export default function AddFolderFlyout({ onSave, className, resourceList }) {
     setMessage,
     setAlertOpen,
     handleClose,
+    setFolderName,
   });
 
-  const onClick = handleCreateFolderClick({ setFolderName, onSubmit });
   const onChange = handleChange(setFolderName);
 
   return (
@@ -183,24 +183,24 @@ export default function AddFolderFlyout({ onSave, className, resourceList }) {
           horizontal: "center",
         }}
       >
-        <Typography className={classes.typography}>
-          <FormControl className={classes.folderInput}>
-            <InputLabel htmlFor="folder-input">Folder name</InputLabel>
-            <Input
-              data-testid={TESTCAFE_ID_FOLDER_NAME_INPUT}
-              onChange={onChange}
-              value={folderName}
-            />
-          </FormControl>
-          <Button
-            data-testid={TESTCAFE_ID_CREATE_FOLDER_FLYOUT_BUTTON}
-            variant="contained"
-            onClick={onClick}
-            disabled={folderName === ""}
-          >
-            Create Folder
-          </Button>
-        </Typography>
+        <Form onSubmit={(event) => onSubmit(event)}>
+          <Typography className={classes.typography}>
+            <FormControl className={classes.folderInput}>
+              <InputLabel htmlFor="folder-input">Folder name</InputLabel>
+              <Input
+                data-testid={TESTCAFE_ID_FOLDER_NAME_INPUT}
+                onChange={onChange}
+                value={folderName}
+              />
+            </FormControl>
+            <Button
+              data-testid={TESTCAFE_ID_CREATE_FOLDER_FLYOUT_BUTTON}
+              variant="contained"
+            >
+              Create Folder
+            </Button>
+          </Typography>
+        </Form>
       </Popover>
     </>
   );

--- a/components/addFolderFlyout/index.jsx
+++ b/components/addFolderFlyout/index.jsx
@@ -177,7 +177,7 @@ export default function AddFolderFlyout({ onSave, className, resourceList }) {
           />
           <Button
             data-testid={TESTCAFE_ID_CREATE_FOLDER_FLYOUT_BUTTON}
-            type="button"
+            type="submit"
           >
             Create Folder
           </Button>

--- a/components/addFolderFlyout/index.jsx
+++ b/components/addFolderFlyout/index.jsx
@@ -24,34 +24,17 @@ import PropTypes from "prop-types";
 import { createContainerAt, getSourceUrl } from "@inrupt/solid-client";
 import { makeStyles } from "@material-ui/core/styles";
 import { useSession } from "@inrupt/solid-ui-react";
-import {
-  Popover,
-  Button,
-  Typography,
-  FormControl,
-  Input,
-  InputLabel,
-} from "@material-ui/core";
-import { Form } from "@inrupt/prism-react-components";
+import { createStyles, Popover } from "@material-ui/core";
+import { Button, Form, Input } from "@inrupt/prism-react-components";
 import PodLocationContext from "../../src/contexts/podLocationContext";
 import AlertContext from "../../src/contexts/alertContext";
+import styles from "../addPermissionUsingWebIdButton/styles";
 
 const TESTCAFE_ID_ADD_FOLDER_BUTTON = "add-folder-button";
 const TESTCAFE_ID_FOLDER_NAME_INPUT = "folder-name-input";
 const TESTCAFE_ID_CREATE_FOLDER_FLYOUT_BUTTON = "create-folder-flyout-button";
 
-const useStyles = makeStyles((theme) => {
-  return {
-    typography: {
-      padding: theme.spacing(2),
-      display: "flex",
-      flexDirection: "column",
-    },
-    folderInput: {
-      padding: theme.spacing(2, 0),
-    },
-  };
-});
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 export function determineFinalUrl(folders, currentUri, name) {
   let currentName = name;
@@ -173,6 +156,7 @@ export default function AddFolderFlyout({ onSave, className, resourceList }) {
         data-testid={id}
         open={open}
         anchorEl={anchorEl}
+        classes={classes}
         onClose={handleClose}
         anchorOrigin={{
           vertical: "bottom",
@@ -184,22 +168,19 @@ export default function AddFolderFlyout({ onSave, className, resourceList }) {
         }}
       >
         <Form onSubmit={(event) => onSubmit(event)}>
-          <Typography className={classes.typography}>
-            <FormControl className={classes.folderInput}>
-              <InputLabel htmlFor="folder-input">Folder name</InputLabel>
-              <Input
-                data-testid={TESTCAFE_ID_FOLDER_NAME_INPUT}
-                onChange={onChange}
-                value={folderName}
-              />
-            </FormControl>
-            <Button
-              data-testid={TESTCAFE_ID_CREATE_FOLDER_FLYOUT_BUTTON}
-              variant="contained"
-            >
-              Create Folder
-            </Button>
-          </Typography>
+          <Input
+            data-testid={TESTCAFE_ID_FOLDER_NAME_INPUT}
+            id="folder-input"
+            label="Folder name"
+            onChange={onChange}
+            value={folderName}
+          />
+          <Button
+            data-testid={TESTCAFE_ID_CREATE_FOLDER_FLYOUT_BUTTON}
+            type="button"
+          >
+            Create Folder
+          </Button>
         </Form>
       </Popover>
     </>

--- a/components/addFolderFlyout/index.test.jsx
+++ b/components/addFolderFlyout/index.test.jsx
@@ -31,7 +31,6 @@ import AlertContext from "../../src/contexts/alertContext";
 import AddFolderFlyout, {
   determineFinalUrl,
   handleFolderSubmit,
-  handleCreateFolderClick,
 } from "./index";
 
 jest.mock("@inrupt/solid-client");
@@ -106,18 +105,32 @@ describe("determineFinalUrl", () => {
 });
 
 describe("handleFolderSubmit", () => {
-  test("it returns a handler that creates a new folder at a given location", async () => {
-    const fetch = jest.fn();
-    const options = { fetch };
-    const onSave = jest.fn();
+  let fetch;
+  let options;
+  let onSave;
+  let setSeverity;
+  let setMessage;
+  let setAlertOpen;
+  let setFolderName;
+  let event;
+
+  beforeEach(() => {
+    fetch = jest.fn();
+    options = { fetch };
+    onSave = jest.fn();
+    setSeverity = jest.fn();
+    setMessage = jest.fn();
+    setAlertOpen = jest.fn();
+    setFolderName = jest.fn();
+    event = { preventDefault: jest.fn() };
+  });
+
+  it("returns a handler that creates a new folder at a given location", async () => {
     const currentUri = "https://www.mypodbrowser.com/";
     const folders = [
       { iri: "https://www.mypodbrowser.com/SomeFolder", name: "SomeFolder" },
     ];
     const name = "SomeFolder";
-    const setSeverity = jest.fn();
-    const setMessage = jest.fn();
-    const setAlertOpen = jest.fn();
 
     const handler = handleFolderSubmit({
       options,
@@ -128,9 +141,10 @@ describe("handleFolderSubmit", () => {
       setSeverity,
       setMessage,
       setAlertOpen,
+      setFolderName,
     });
 
-    await handler();
+    await handler(event);
 
     expect(createContainerAt).toHaveBeenCalledWith(
       "https://www.mypodbrowser.com/SomeFolder(1)",
@@ -141,17 +155,14 @@ describe("handleFolderSubmit", () => {
     expect(setSeverity).toHaveBeenCalledWith("success");
     expect(setMessage).toHaveBeenCalled();
     expect(setAlertOpen).toHaveBeenCalledWith(true);
+    expect(setFolderName).toHaveBeenCalledWith("");
+    expect(event.preventDefault).toHaveBeenCalledWith();
   });
-  test("it returns a handler that creates a new folder within a folder which has spaces in its name", async () => {
-    const fetch = jest.fn();
-    const options = { fetch };
-    const onSave = jest.fn();
+
+  it("returns a handler that creates a new folder within a folder which has spaces in its name", async () => {
     const currentUri = "https://www.mypodbrowser.com/First Folder/";
     const folders = [];
     const name = "Second Folder";
-    const setSeverity = jest.fn();
-    const setMessage = jest.fn();
-    const setAlertOpen = jest.fn();
 
     const handler = handleFolderSubmit({
       options,
@@ -162,9 +173,10 @@ describe("handleFolderSubmit", () => {
       setSeverity,
       setMessage,
       setAlertOpen,
+      setFolderName,
     });
 
-    await handler();
+    await handler(event);
 
     expect(createContainerAt).toHaveBeenCalledWith(
       "https://www.mypodbrowser.com/First%20Folder/Second%20Folder",
@@ -175,21 +187,7 @@ describe("handleFolderSubmit", () => {
     expect(setSeverity).toHaveBeenCalledWith("success");
     expect(setMessage).toHaveBeenCalled();
     expect(setAlertOpen).toHaveBeenCalledWith(true);
-  });
-});
-describe("handleCreateFolderClick", () => {
-  test("it returns a handler that submits the current folder and calls a function to clear the current folder name from state", () => {
-    const setFolderName = jest.fn();
-    const onSubmit = jest.fn();
-
-    const handler = handleCreateFolderClick({
-      setFolderName,
-      onSubmit,
-    });
-
-    handler(setFolderName, onSubmit);
-
     expect(setFolderName).toHaveBeenCalledWith("");
-    expect(onSubmit).toHaveBeenCalled();
+    expect(event.preventDefault).toHaveBeenCalledWith();
   });
 });

--- a/components/addFolderFlyout/styles.js
+++ b/components/addFolderFlyout/styles.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export default (theme) => ({
+  paper: {
+    padding: theme.spacing(2),
+  },
+});

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -1823,6 +1823,11 @@ font-display: block;",
                           "vertical": "bottom",
                         }
                       }
+                      classes={
+                        Object {
+                          "paper": "PodBrowser-paper",
+                        }
+                      }
                       onClose={[Function]}
                       open={false}
                       transformOrigin={
@@ -1842,7 +1847,7 @@ font-display: block;",
                         }
                         classes={
                           Object {
-                            "paper": "PodBrowser-paper",
+                            "paper": "PodBrowser-paper PodBrowser-paper",
                             "root": "PodBrowser-root",
                           }
                         }
@@ -6062,6 +6067,11 @@ font-display: block;",
                           "vertical": "bottom",
                         }
                       }
+                      classes={
+                        Object {
+                          "paper": "PodBrowser-paper",
+                        }
+                      }
                       onClose={[Function]}
                       open={false}
                       transformOrigin={
@@ -6081,7 +6091,7 @@ font-display: block;",
                         }
                         classes={
                           Object {
-                            "paper": "PodBrowser-paper",
+                            "paper": "PodBrowser-paper PodBrowser-paper",
                             "root": "PodBrowser-root",
                           }
                         }

--- a/components/containerPageHeader/__snapshots__/index.test.jsx.snap
+++ b/components/containerPageHeader/__snapshots__/index.test.jsx.snap
@@ -104,6 +104,11 @@ exports[`ContainerPageHeader Renders view 1`] = `
                 "vertical": "bottom",
               }
             }
+            classes={
+              Object {
+                "paper": "makeStyles-paper-6",
+              }
+            }
             onClose={[Function]}
             open={false}
             transformOrigin={
@@ -123,7 +128,7 @@ exports[`ContainerPageHeader Renders view 1`] = `
               }
               classes={
                 Object {
-                  "paper": "MuiPopover-paper",
+                  "paper": "MuiPopover-paper makeStyles-paper-6",
                   "root": "MuiPopover-root",
                 }
               }

--- a/components/permissionsForm/styles.js
+++ b/components/permissionsForm/styles.js
@@ -47,7 +47,6 @@ export default (theme) => ({
     textTransform: "inherit",
     fontSize: theme.typography.body.fontSize,
     maxWidth: "95%",
-    margin: theme.spacing(0.5, 0),
     padding: theme.spacing(1.5, 2),
   },
   label: smallFontSize,

--- a/components/resourceDetails/resourceSharing/agentAccess/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/__snapshots__/index.test.jsx.snap
@@ -947,1717 +947,1728 @@ font-display: block;",
               </p>
             </ForwardRef(Typography)>
           </WithStyles(ForwardRef(Typography))>
-          <PermissionsForm
-            acl={
-              Object {
-                "append": false,
-                "control": false,
-                "read": false,
-                "write": false,
-              }
-            }
-            disabled={false}
-            onChange={[Function]}
+          <Form
+            onSubmit={[Function]}
           >
-            <div
-              className="PodBrowser-container"
+            <form
+              className="PodBrowser-form"
+              onSubmit={[Function]}
             >
-              <WithStyles(ForwardRef(Button))
-                className="PodBrowser-summary"
-                data-testid="permissions-dropdown-button"
-                endIcon={<Memo(KeyboardArrowDownIcon) />}
-                onClick={[Function]}
-              >
-                <ForwardRef(Button)
-                  className="PodBrowser-summary"
-                  classes={
-                    Object {
-                      "colorInherit": "PodBrowser-colorInherit",
-                      "contained": "PodBrowser-contained",
-                      "containedPrimary": "PodBrowser-containedPrimary",
-                      "containedSecondary": "PodBrowser-containedSecondary",
-                      "containedSizeLarge": "PodBrowser-containedSizeLarge",
-                      "containedSizeSmall": "PodBrowser-containedSizeSmall",
-                      "disableElevation": "PodBrowser-disableElevation",
-                      "disabled": "PodBrowser-disabled",
-                      "endIcon": "PodBrowser-endIcon",
-                      "focusVisible": "PodBrowser-focusVisible",
-                      "fullWidth": "PodBrowser-fullWidth",
-                      "iconSizeLarge": "PodBrowser-iconSizeLarge",
-                      "iconSizeMedium": "PodBrowser-iconSizeMedium",
-                      "iconSizeSmall": "PodBrowser-iconSizeSmall",
-                      "label": "PodBrowser-label",
-                      "outlined": "PodBrowser-outlined",
-                      "outlinedPrimary": "PodBrowser-outlinedPrimary",
-                      "outlinedSecondary": "PodBrowser-outlinedSecondary",
-                      "outlinedSizeLarge": "PodBrowser-outlinedSizeLarge",
-                      "outlinedSizeSmall": "PodBrowser-outlinedSizeSmall",
-                      "root": "PodBrowser-root",
-                      "sizeLarge": "PodBrowser-sizeLarge",
-                      "sizeSmall": "PodBrowser-sizeSmall",
-                      "startIcon": "PodBrowser-startIcon",
-                      "text": "PodBrowser-text",
-                      "textPrimary": "PodBrowser-textPrimary",
-                      "textSecondary": "PodBrowser-textSecondary",
-                      "textSizeLarge": "PodBrowser-textSizeLarge",
-                      "textSizeSmall": "PodBrowser-textSizeSmall",
-                    }
+              <PermissionsForm
+                acl={
+                  Object {
+                    "append": false,
+                    "control": false,
+                    "read": false,
+                    "write": false,
                   }
-                  data-testid="permissions-dropdown-button"
-                  endIcon={<Memo(KeyboardArrowDownIcon) />}
-                  onClick={[Function]}
+                }
+                disabled={false}
+                onChange={[Function]}
+              >
+                <div
+                  className="PodBrowser-container"
                 >
-                  <WithStyles(ForwardRef(ButtonBase))
-                    className="PodBrowser-root PodBrowser-text PodBrowser-summary"
-                    component="button"
+                  <WithStyles(ForwardRef(Button))
+                    className="PodBrowser-summary"
                     data-testid="permissions-dropdown-button"
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="PodBrowser-focusVisible"
+                    endIcon={<Memo(KeyboardArrowDownIcon) />}
                     onClick={[Function]}
-                    type="button"
                   >
-                    <ForwardRef(ButtonBase)
-                      className="PodBrowser-root PodBrowser-text PodBrowser-summary"
+                    <ForwardRef(Button)
+                      className="PodBrowser-summary"
                       classes={
                         Object {
+                          "colorInherit": "PodBrowser-colorInherit",
+                          "contained": "PodBrowser-contained",
+                          "containedPrimary": "PodBrowser-containedPrimary",
+                          "containedSecondary": "PodBrowser-containedSecondary",
+                          "containedSizeLarge": "PodBrowser-containedSizeLarge",
+                          "containedSizeSmall": "PodBrowser-containedSizeSmall",
+                          "disableElevation": "PodBrowser-disableElevation",
                           "disabled": "PodBrowser-disabled",
+                          "endIcon": "PodBrowser-endIcon",
                           "focusVisible": "PodBrowser-focusVisible",
+                          "fullWidth": "PodBrowser-fullWidth",
+                          "iconSizeLarge": "PodBrowser-iconSizeLarge",
+                          "iconSizeMedium": "PodBrowser-iconSizeMedium",
+                          "iconSizeSmall": "PodBrowser-iconSizeSmall",
+                          "label": "PodBrowser-label",
+                          "outlined": "PodBrowser-outlined",
+                          "outlinedPrimary": "PodBrowser-outlinedPrimary",
+                          "outlinedSecondary": "PodBrowser-outlinedSecondary",
+                          "outlinedSizeLarge": "PodBrowser-outlinedSizeLarge",
+                          "outlinedSizeSmall": "PodBrowser-outlinedSizeSmall",
                           "root": "PodBrowser-root",
+                          "sizeLarge": "PodBrowser-sizeLarge",
+                          "sizeSmall": "PodBrowser-sizeSmall",
+                          "startIcon": "PodBrowser-startIcon",
+                          "text": "PodBrowser-text",
+                          "textPrimary": "PodBrowser-textPrimary",
+                          "textSecondary": "PodBrowser-textSecondary",
+                          "textSizeLarge": "PodBrowser-textSizeLarge",
+                          "textSizeSmall": "PodBrowser-textSizeSmall",
                         }
                       }
-                      component="button"
                       data-testid="permissions-dropdown-button"
-                      disabled={false}
-                      focusRipple={true}
-                      focusVisibleClassName="PodBrowser-focusVisible"
+                      endIcon={<Memo(KeyboardArrowDownIcon) />}
                       onClick={[Function]}
-                      type="button"
                     >
-                      <button
-                        className="PodBrowser-root PodBrowser-root PodBrowser-text PodBrowser-summary"
+                      <WithStyles(ForwardRef(ButtonBase))
+                        className="PodBrowser-root PodBrowser-text PodBrowser-summary"
+                        component="button"
                         data-testid="permissions-dropdown-button"
                         disabled={false}
-                        onBlur={[Function]}
+                        focusRipple={true}
+                        focusVisibleClassName="PodBrowser-focusVisible"
                         onClick={[Function]}
-                        onDragLeave={[Function]}
-                        onFocus={[Function]}
-                        onKeyDown={[Function]}
-                        onKeyUp={[Function]}
-                        onMouseDown={[Function]}
-                        onMouseLeave={[Function]}
-                        onMouseUp={[Function]}
-                        onTouchEnd={[Function]}
-                        onTouchMove={[Function]}
-                        onTouchStart={[Function]}
-                        tabIndex={0}
                         type="button"
                       >
-                        <span
-                          className="PodBrowser-label"
-                        >
-                          <span />
-                          <span
-                            className="PodBrowser-endIcon PodBrowser-iconSizeMedium"
-                          >
-                            <ForwardRef>
-                              <WithStyles(ForwardRef(SvgIcon))>
-                                <ForwardRef(SvgIcon)
-                                  classes={
-                                    Object {
-                                      "colorAction": "PodBrowser-colorAction",
-                                      "colorDisabled": "PodBrowser-colorDisabled",
-                                      "colorError": "PodBrowser-colorError",
-                                      "colorPrimary": "PodBrowser-colorPrimary",
-                                      "colorSecondary": "PodBrowser-colorSecondary",
-                                      "fontSizeInherit": "PodBrowser-fontSizeInherit",
-                                      "fontSizeLarge": "PodBrowser-fontSizeLarge",
-                                      "fontSizeSmall": "PodBrowser-fontSizeSmall",
-                                      "root": "PodBrowser-root",
-                                    }
-                                  }
-                                >
-                                  <svg
-                                    aria-hidden={true}
-                                    className="PodBrowser-root"
-                                    focusable="false"
-                                    viewBox="0 0 24 24"
-                                  >
-                                    <path
-                                      d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
-                                    />
-                                  </svg>
-                                </ForwardRef(SvgIcon)>
-                              </WithStyles(ForwardRef(SvgIcon))>
-                            </ForwardRef>
-                          </span>
-                        </span>
-                        <WithStyles(memo)
-                          center={false}
-                        >
-                          <ForwardRef(TouchRipple)
-                            center={false}
-                            classes={
-                              Object {
-                                "child": "PodBrowser-child",
-                                "childLeaving": "PodBrowser-childLeaving",
-                                "childPulsate": "PodBrowser-childPulsate",
-                                "ripple": "PodBrowser-ripple",
-                                "ripplePulsate": "PodBrowser-ripplePulsate",
-                                "rippleVisible": "PodBrowser-rippleVisible",
-                                "root": "PodBrowser-root",
-                              }
+                        <ForwardRef(ButtonBase)
+                          className="PodBrowser-root PodBrowser-text PodBrowser-summary"
+                          classes={
+                            Object {
+                              "disabled": "PodBrowser-disabled",
+                              "focusVisible": "PodBrowser-focusVisible",
+                              "root": "PodBrowser-root",
                             }
+                          }
+                          component="button"
+                          data-testid="permissions-dropdown-button"
+                          disabled={false}
+                          focusRipple={true}
+                          focusVisibleClassName="PodBrowser-focusVisible"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <button
+                            className="PodBrowser-root PodBrowser-root PodBrowser-text PodBrowser-summary"
+                            data-testid="permissions-dropdown-button"
+                            disabled={false}
+                            onBlur={[Function]}
+                            onClick={[Function]}
+                            onDragLeave={[Function]}
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onKeyUp={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseUp={[Function]}
+                            onTouchEnd={[Function]}
+                            onTouchMove={[Function]}
+                            onTouchStart={[Function]}
+                            tabIndex={0}
+                            type="button"
                           >
                             <span
-                              className="PodBrowser-root"
+                              className="PodBrowser-label"
                             >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                component={null}
-                                exit={true}
-                              />
+                              <span />
+                              <span
+                                className="PodBrowser-endIcon PodBrowser-iconSizeMedium"
+                              >
+                                <ForwardRef>
+                                  <WithStyles(ForwardRef(SvgIcon))>
+                                    <ForwardRef(SvgIcon)
+                                      classes={
+                                        Object {
+                                          "colorAction": "PodBrowser-colorAction",
+                                          "colorDisabled": "PodBrowser-colorDisabled",
+                                          "colorError": "PodBrowser-colorError",
+                                          "colorPrimary": "PodBrowser-colorPrimary",
+                                          "colorSecondary": "PodBrowser-colorSecondary",
+                                          "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                          "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                          "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                          "root": "PodBrowser-root",
+                                        }
+                                      }
+                                    >
+                                      <svg
+                                        aria-hidden={true}
+                                        className="PodBrowser-root"
+                                        focusable="false"
+                                        viewBox="0 0 24 24"
+                                      >
+                                        <path
+                                          d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"
+                                        />
+                                      </svg>
+                                    </ForwardRef(SvgIcon)>
+                                  </WithStyles(ForwardRef(SvgIcon))>
+                                </ForwardRef>
+                              </span>
                             </span>
-                          </ForwardRef(TouchRipple)>
-                        </WithStyles(memo)>
-                      </button>
-                    </ForwardRef(ButtonBase)>
-                  </WithStyles(ForwardRef(ButtonBase))>
-                </ForwardRef(Button)>
-              </WithStyles(ForwardRef(Button))>
-              <section
-                className="PodBrowser-selectionClosed"
-              >
-                <WithStyles(ForwardRef(List))>
-                  <ForwardRef(List)
-                    classes={
-                      Object {
-                        "dense": "PodBrowser-dense",
-                        "padding": "PodBrowser-padding",
-                        "root": "PodBrowser-root",
-                        "subheader": "PodBrowser-subheader",
-                      }
-                    }
-                  >
-                    <ul
-                      className="PodBrowser-root PodBrowser-padding"
-                    >
-                      <PermissionCheckbox
-                        classes={
-                          Object {
-                            "checkbox": "PodBrowser-checkbox",
-                            "container": "PodBrowser-container",
-                            "label": "PodBrowser-label",
-                            "listItem": "PodBrowser-listItem",
-                            "selectionClosed": "PodBrowser-selectionClosed",
-                            "selectionOpen": "PodBrowser-selectionOpen",
-                            "summary": "PodBrowser-summary",
-                          }
-                        }
-                        disabled={false}
-                        label="View"
-                        onChange={[Function]}
-                        value={false}
-                      >
-                        <WithStyles(ForwardRef(ListItem))
-                          className="PodBrowser-listItem"
-                        >
-                          <ForwardRef(ListItem)
-                            className="PodBrowser-listItem"
-                            classes={
-                              Object {
-                                "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
-                                "button": "PodBrowser-button",
-                                "container": "PodBrowser-container",
-                                "dense": "PodBrowser-dense",
-                                "disabled": "PodBrowser-disabled",
-                                "divider": "PodBrowser-divider",
-                                "focusVisible": "PodBrowser-focusVisible",
-                                "gutters": "PodBrowser-gutters",
-                                "root": "PodBrowser-root",
-                                "secondaryAction": "PodBrowser-secondaryAction",
-                                "selected": "PodBrowser-selected",
-                              }
-                            }
-                          >
-                            <li
-                              className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
-                              disabled={false}
+                            <WithStyles(memo)
+                              center={false}
                             >
-                              <WithStyles(ForwardRef(FormControlLabel))
+                              <ForwardRef(TouchRipple)
+                                center={false}
                                 classes={
                                   Object {
-                                    "label": "PodBrowser-label",
+                                    "child": "PodBrowser-child",
+                                    "childLeaving": "PodBrowser-childLeaving",
+                                    "childPulsate": "PodBrowser-childPulsate",
+                                    "ripple": "PodBrowser-ripple",
+                                    "ripplePulsate": "PodBrowser-ripplePulsate",
+                                    "rippleVisible": "PodBrowser-rippleVisible",
+                                    "root": "PodBrowser-root",
                                   }
                                 }
-                                control={
-                                  <WithStyles(ForwardRef(Checkbox))
-                                    checked={false}
+                              >
+                                <span
+                                  className="PodBrowser-root"
+                                >
+                                  <TransitionGroup
+                                    childFactory={[Function]}
+                                    component={null}
+                                    exit={true}
+                                  />
+                                </span>
+                              </ForwardRef(TouchRipple)>
+                            </WithStyles(memo)>
+                          </button>
+                        </ForwardRef(ButtonBase)>
+                      </WithStyles(ForwardRef(ButtonBase))>
+                    </ForwardRef(Button)>
+                  </WithStyles(ForwardRef(Button))>
+                  <section
+                    className="PodBrowser-selectionClosed"
+                  >
+                    <WithStyles(ForwardRef(List))>
+                      <ForwardRef(List)
+                        classes={
+                          Object {
+                            "dense": "PodBrowser-dense",
+                            "padding": "PodBrowser-padding",
+                            "root": "PodBrowser-root",
+                            "subheader": "PodBrowser-subheader",
+                          }
+                        }
+                      >
+                        <ul
+                          className="PodBrowser-root PodBrowser-padding"
+                        >
+                          <PermissionCheckbox
+                            classes={
+                              Object {
+                                "checkbox": "PodBrowser-checkbox",
+                                "container": "PodBrowser-container",
+                                "label": "PodBrowser-label",
+                                "listItem": "PodBrowser-listItem",
+                                "selectionClosed": "PodBrowser-selectionClosed",
+                                "selectionOpen": "PodBrowser-selectionOpen",
+                                "summary": "PodBrowser-summary",
+                              }
+                            }
+                            disabled={false}
+                            label="View"
+                            onChange={[Function]}
+                            value={false}
+                          >
+                            <WithStyles(ForwardRef(ListItem))
+                              className="PodBrowser-listItem"
+                            >
+                              <ForwardRef(ListItem)
+                                className="PodBrowser-listItem"
+                                classes={
+                                  Object {
+                                    "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                    "button": "PodBrowser-button",
+                                    "container": "PodBrowser-container",
+                                    "dense": "PodBrowser-dense",
+                                    "disabled": "PodBrowser-disabled",
+                                    "divider": "PodBrowser-divider",
+                                    "focusVisible": "PodBrowser-focusVisible",
+                                    "gutters": "PodBrowser-gutters",
+                                    "root": "PodBrowser-root",
+                                    "secondaryAction": "PodBrowser-secondaryAction",
+                                    "selected": "PodBrowser-selected",
+                                  }
+                                }
+                              >
+                                <li
+                                  className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
+                                  disabled={false}
+                                >
+                                  <WithStyles(ForwardRef(FormControlLabel))
                                     classes={
                                       Object {
-                                        "root": "PodBrowser-checkbox",
+                                        "label": "PodBrowser-label",
                                       }
                                     }
-                                    disabled={false}
-                                    name="view"
-                                    onChange={[Function]}
-                                  />
-                                }
-                                key=".0"
-                                label="View"
-                              >
-                                <ForwardRef(FormControlLabel)
-                                  classes={
-                                    Object {
-                                      "disabled": "PodBrowser-disabled",
-                                      "label": "PodBrowser-label PodBrowser-label",
-                                      "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
-                                      "labelPlacementStart": "PodBrowser-labelPlacementStart",
-                                      "labelPlacementTop": "PodBrowser-labelPlacementTop",
-                                      "root": "PodBrowser-root",
-                                    }
-                                  }
-                                  control={
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="view"
-                                      onChange={[Function]}
-                                    />
-                                  }
-                                  label="View"
-                                >
-                                  <label
-                                    className="PodBrowser-root"
-                                  >
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="view"
-                                      onChange={[Function]}
-                                    >
-                                      <ForwardRef(Checkbox)
+                                    control={
+                                      <WithStyles(ForwardRef(Checkbox))
                                         checked={false}
                                         classes={
                                           Object {
-                                            "checked": "PodBrowser-checked",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "disabled": "PodBrowser-disabled",
-                                            "indeterminate": "PodBrowser-indeterminate",
-                                            "root": "PodBrowser-root PodBrowser-checkbox",
+                                            "root": "PodBrowser-checkbox",
                                           }
                                         }
                                         disabled={false}
                                         name="view"
                                         onChange={[Function]}
-                                      >
-                                        <WithStyles(ForwardRef(SwitchBase))
+                                      />
+                                    }
+                                    key=".0"
+                                    label="View"
+                                  >
+                                    <ForwardRef(FormControlLabel)
+                                      classes={
+                                        Object {
+                                          "disabled": "PodBrowser-disabled",
+                                          "label": "PodBrowser-label PodBrowser-label",
+                                          "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
+                                          "labelPlacementStart": "PodBrowser-labelPlacementStart",
+                                          "labelPlacementTop": "PodBrowser-labelPlacementTop",
+                                          "root": "PodBrowser-root",
+                                        }
+                                      }
+                                      control={
+                                        <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
-                                          checkedIcon={<Memo />}
                                           classes={
                                             Object {
-                                              "checked": "PodBrowser-checked",
-                                              "disabled": "PodBrowser-disabled",
-                                              "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                              "root": "PodBrowser-checkbox",
                                             }
                                           }
-                                          color="secondary"
                                           disabled={false}
-                                          icon={<Memo />}
-                                          inputProps={
-                                            Object {
-                                              "data-indeterminate": false,
-                                            }
-                                          }
                                           name="view"
                                           onChange={[Function]}
-                                          type="checkbox"
+                                        />
+                                      }
+                                      label="View"
+                                    >
+                                      <label
+                                        className="PodBrowser-root"
+                                      >
+                                        <WithStyles(ForwardRef(Checkbox))
+                                          checked={false}
+                                          classes={
+                                            Object {
+                                              "root": "PodBrowser-checkbox",
+                                            }
+                                          }
+                                          disabled={false}
+                                          name="view"
+                                          onChange={[Function]}
                                         >
-                                          <ForwardRef(SwitchBase)
+                                          <ForwardRef(Checkbox)
                                             checked={false}
-                                            checkedIcon={<Memo />}
                                             classes={
                                               Object {
-                                                "checked": "PodBrowser-checked PodBrowser-checked",
-                                                "disabled": "PodBrowser-disabled PodBrowser-disabled",
-                                                "input": "PodBrowser-input",
-                                                "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                "checked": "PodBrowser-checked",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "disabled": "PodBrowser-disabled",
+                                                "indeterminate": "PodBrowser-indeterminate",
+                                                "root": "PodBrowser-root PodBrowser-checkbox",
                                               }
                                             }
-                                            color="secondary"
                                             disabled={false}
-                                            icon={<Memo />}
-                                            inputProps={
-                                              Object {
-                                                "data-indeterminate": false,
-                                              }
-                                            }
                                             name="view"
                                             onChange={[Function]}
-                                            type="checkbox"
                                           >
-                                            <WithStyles(ForwardRef(IconButton))
-                                              className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                            <WithStyles(ForwardRef(SwitchBase))
+                                              checked={false}
+                                              checkedIcon={<Memo />}
+                                              classes={
+                                                Object {
+                                                  "checked": "PodBrowser-checked",
+                                                  "disabled": "PodBrowser-disabled",
+                                                  "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                }
+                                              }
                                               color="secondary"
-                                              component="span"
                                               disabled={false}
-                                              onBlur={[Function]}
-                                              onFocus={[Function]}
-                                              tabIndex={null}
+                                              icon={<Memo />}
+                                              inputProps={
+                                                Object {
+                                                  "data-indeterminate": false,
+                                                }
+                                              }
+                                              name="view"
+                                              onChange={[Function]}
+                                              type="checkbox"
                                             >
-                                              <ForwardRef(IconButton)
-                                                className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                              <ForwardRef(SwitchBase)
+                                                checked={false}
+                                                checkedIcon={<Memo />}
                                                 classes={
                                                   Object {
-                                                    "colorInherit": "PodBrowser-colorInherit",
-                                                    "colorPrimary": "PodBrowser-colorPrimary",
-                                                    "colorSecondary": "PodBrowser-colorSecondary",
-                                                    "disabled": "PodBrowser-disabled",
-                                                    "edgeEnd": "PodBrowser-edgeEnd",
-                                                    "edgeStart": "PodBrowser-edgeStart",
-                                                    "label": "PodBrowser-label",
-                                                    "root": "PodBrowser-root",
-                                                    "sizeSmall": "PodBrowser-sizeSmall",
+                                                    "checked": "PodBrowser-checked PodBrowser-checked",
+                                                    "disabled": "PodBrowser-disabled PodBrowser-disabled",
+                                                    "input": "PodBrowser-input",
+                                                    "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
                                                   }
                                                 }
                                                 color="secondary"
-                                                component="span"
                                                 disabled={false}
-                                                onBlur={[Function]}
-                                                onFocus={[Function]}
-                                                tabIndex={null}
+                                                icon={<Memo />}
+                                                inputProps={
+                                                  Object {
+                                                    "data-indeterminate": false,
+                                                  }
+                                                }
+                                                name="view"
+                                                onChange={[Function]}
+                                                type="checkbox"
                                               >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  centerRipple={true}
-                                                  className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                <WithStyles(ForwardRef(IconButton))
+                                                  className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                                  color="secondary"
                                                   component="span"
                                                   disabled={false}
-                                                  focusRipple={true}
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   tabIndex={null}
                                                 >
-                                                  <ForwardRef(ButtonBase)
-                                                    centerRipple={true}
-                                                    className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                  <ForwardRef(IconButton)
+                                                    className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
                                                     classes={
                                                       Object {
+                                                        "colorInherit": "PodBrowser-colorInherit",
+                                                        "colorPrimary": "PodBrowser-colorPrimary",
+                                                        "colorSecondary": "PodBrowser-colorSecondary",
                                                         "disabled": "PodBrowser-disabled",
-                                                        "focusVisible": "PodBrowser-focusVisible",
+                                                        "edgeEnd": "PodBrowser-edgeEnd",
+                                                        "edgeStart": "PodBrowser-edgeStart",
+                                                        "label": "PodBrowser-label",
                                                         "root": "PodBrowser-root",
+                                                        "sizeSmall": "PodBrowser-sizeSmall",
                                                       }
                                                     }
+                                                    color="secondary"
                                                     component="span"
                                                     disabled={false}
-                                                    focusRipple={true}
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     tabIndex={null}
                                                   >
-                                                    <span
-                                                      aria-disabled={false}
-                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                    <WithStyles(ForwardRef(ButtonBase))
+                                                      centerRipple={true}
+                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                      component="span"
+                                                      disabled={false}
+                                                      focusRipple={true}
                                                       onBlur={[Function]}
-                                                      onDragLeave={[Function]}
                                                       onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
                                                       tabIndex={null}
                                                     >
-                                                      <span
-                                                        className="PodBrowser-label"
+                                                      <ForwardRef(ButtonBase)
+                                                        centerRipple={true}
+                                                        className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                        classes={
+                                                          Object {
+                                                            "disabled": "PodBrowser-disabled",
+                                                            "focusVisible": "PodBrowser-focusVisible",
+                                                            "root": "PodBrowser-root",
+                                                          }
+                                                        }
+                                                        component="span"
+                                                        disabled={false}
+                                                        focusRipple={true}
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        tabIndex={null}
                                                       >
-                                                        <input
-                                                          checked={false}
-                                                          className="PodBrowser-input"
-                                                          data-indeterminate={false}
-                                                          disabled={false}
-                                                          name="view"
-                                                          onChange={[Function]}
-                                                          type="checkbox"
-                                                        />
-                                                        <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                          <WithStyles(ForwardRef(SvgIcon))>
-                                                            <ForwardRef(SvgIcon)
+                                                        <span
+                                                          aria-disabled={false}
+                                                          className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                          onBlur={[Function]}
+                                                          onDragLeave={[Function]}
+                                                          onFocus={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          onMouseDown={[Function]}
+                                                          onMouseLeave={[Function]}
+                                                          onMouseUp={[Function]}
+                                                          onTouchEnd={[Function]}
+                                                          onTouchMove={[Function]}
+                                                          onTouchStart={[Function]}
+                                                          tabIndex={null}
+                                                        >
+                                                          <span
+                                                            className="PodBrowser-label"
+                                                          >
+                                                            <input
+                                                              checked={false}
+                                                              className="PodBrowser-input"
+                                                              data-indeterminate={false}
+                                                              disabled={false}
+                                                              name="view"
+                                                              onChange={[Function]}
+                                                              type="checkbox"
+                                                            />
+                                                            <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                              <WithStyles(ForwardRef(SvgIcon))>
+                                                                <ForwardRef(SvgIcon)
+                                                                  classes={
+                                                                    Object {
+                                                                      "colorAction": "PodBrowser-colorAction",
+                                                                      "colorDisabled": "PodBrowser-colorDisabled",
+                                                                      "colorError": "PodBrowser-colorError",
+                                                                      "colorPrimary": "PodBrowser-colorPrimary",
+                                                                      "colorSecondary": "PodBrowser-colorSecondary",
+                                                                      "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                                                      "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                                                      "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                      "root": "PodBrowser-root",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="PodBrowser-root"
+                                                                    focusable="false"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <path
+                                                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                    />
+                                                                  </svg>
+                                                                </ForwardRef(SvgIcon)>
+                                                              </WithStyles(ForwardRef(SvgIcon))>
+                                                            </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                          </span>
+                                                          <WithStyles(memo)
+                                                            center={true}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={true}
                                                               classes={
                                                                 Object {
-                                                                  "colorAction": "PodBrowser-colorAction",
-                                                                  "colorDisabled": "PodBrowser-colorDisabled",
-                                                                  "colorError": "PodBrowser-colorError",
-                                                                  "colorPrimary": "PodBrowser-colorPrimary",
-                                                                  "colorSecondary": "PodBrowser-colorSecondary",
-                                                                  "fontSizeInherit": "PodBrowser-fontSizeInherit",
-                                                                  "fontSizeLarge": "PodBrowser-fontSizeLarge",
-                                                                  "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                  "child": "PodBrowser-child",
+                                                                  "childLeaving": "PodBrowser-childLeaving",
+                                                                  "childPulsate": "PodBrowser-childPulsate",
+                                                                  "ripple": "PodBrowser-ripple",
+                                                                  "ripplePulsate": "PodBrowser-ripplePulsate",
+                                                                  "rippleVisible": "PodBrowser-rippleVisible",
                                                                   "root": "PodBrowser-root",
                                                                 }
                                                               }
                                                             >
-                                                              <svg
-                                                                aria-hidden={true}
+                                                              <span
                                                                 className="PodBrowser-root"
-                                                                focusable="false"
-                                                                viewBox="0 0 24 24"
                                                               >
-                                                                <path
-                                                                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
                                                                 />
-                                                              </svg>
-                                                            </ForwardRef(SvgIcon)>
-                                                          </WithStyles(ForwardRef(SvgIcon))>
-                                                        </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                      </span>
-                                                      <WithStyles(memo)
-                                                        center={true}
-                                                      >
-                                                        <ForwardRef(TouchRipple)
-                                                          center={true}
-                                                          classes={
-                                                            Object {
-                                                              "child": "PodBrowser-child",
-                                                              "childLeaving": "PodBrowser-childLeaving",
-                                                              "childPulsate": "PodBrowser-childPulsate",
-                                                              "ripple": "PodBrowser-ripple",
-                                                              "ripplePulsate": "PodBrowser-ripplePulsate",
-                                                              "rippleVisible": "PodBrowser-rippleVisible",
-                                                              "root": "PodBrowser-root",
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            className="PodBrowser-root"
-                                                          >
-                                                            <TransitionGroup
-                                                              childFactory={[Function]}
-                                                              component={null}
-                                                              exit={true}
-                                                            />
-                                                          </span>
-                                                        </ForwardRef(TouchRipple)>
-                                                      </WithStyles(memo)>
-                                                    </span>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(IconButton)>
-                                            </WithStyles(ForwardRef(IconButton))>
-                                          </ForwardRef(SwitchBase)>
-                                        </WithStyles(ForwardRef(SwitchBase))>
-                                      </ForwardRef(Checkbox)>
-                                    </WithStyles(ForwardRef(Checkbox))>
-                                    <WithStyles(ForwardRef(Typography))
-                                      className="PodBrowser-label PodBrowser-label"
-                                      component="span"
-                                    >
-                                      <ForwardRef(Typography)
-                                        className="PodBrowser-label PodBrowser-label"
-                                        classes={
-                                          Object {
-                                            "alignCenter": "PodBrowser-alignCenter",
-                                            "alignJustify": "PodBrowser-alignJustify",
-                                            "alignLeft": "PodBrowser-alignLeft",
-                                            "alignRight": "PodBrowser-alignRight",
-                                            "body1": "PodBrowser-body1",
-                                            "body2": "PodBrowser-body2",
-                                            "button": "PodBrowser-button",
-                                            "caption": "PodBrowser-caption",
-                                            "colorError": "PodBrowser-colorError",
-                                            "colorInherit": "PodBrowser-colorInherit",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "colorTextPrimary": "PodBrowser-colorTextPrimary",
-                                            "colorTextSecondary": "PodBrowser-colorTextSecondary",
-                                            "displayBlock": "PodBrowser-displayBlock",
-                                            "displayInline": "PodBrowser-displayInline",
-                                            "gutterBottom": "PodBrowser-gutterBottom",
-                                            "h1": "PodBrowser-h1",
-                                            "h2": "PodBrowser-h2",
-                                            "h3": "PodBrowser-h3",
-                                            "h4": "PodBrowser-h4",
-                                            "h5": "PodBrowser-h5",
-                                            "h6": "PodBrowser-h6",
-                                            "noWrap": "PodBrowser-noWrap",
-                                            "overline": "PodBrowser-overline",
-                                            "paragraph": "PodBrowser-paragraph",
-                                            "root": "PodBrowser-root",
-                                            "srOnly": "PodBrowser-srOnly",
-                                            "subtitle1": "PodBrowser-subtitle1",
-                                            "subtitle2": "PodBrowser-subtitle2",
-                                          }
-                                        }
-                                        component="span"
-                                      >
-                                        <span
-                                          className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </span>
+                                                      </ForwardRef(ButtonBase)>
+                                                    </WithStyles(ForwardRef(ButtonBase))>
+                                                  </ForwardRef(IconButton)>
+                                                </WithStyles(ForwardRef(IconButton))>
+                                              </ForwardRef(SwitchBase)>
+                                            </WithStyles(ForwardRef(SwitchBase))>
+                                          </ForwardRef(Checkbox)>
+                                        </WithStyles(ForwardRef(Checkbox))>
+                                        <WithStyles(ForwardRef(Typography))
+                                          className="PodBrowser-label PodBrowser-label"
+                                          component="span"
                                         >
-                                          View
-                                        </span>
-                                      </ForwardRef(Typography)>
-                                    </WithStyles(ForwardRef(Typography))>
-                                  </label>
-                                </ForwardRef(FormControlLabel)>
-                              </WithStyles(ForwardRef(FormControlLabel))>
-                            </li>
-                          </ForwardRef(ListItem)>
-                        </WithStyles(ForwardRef(ListItem))>
-                      </PermissionCheckbox>
-                      <PermissionCheckbox
-                        classes={
-                          Object {
-                            "checkbox": "PodBrowser-checkbox",
-                            "container": "PodBrowser-container",
-                            "label": "PodBrowser-label",
-                            "listItem": "PodBrowser-listItem",
-                            "selectionClosed": "PodBrowser-selectionClosed",
-                            "selectionOpen": "PodBrowser-selectionOpen",
-                            "summary": "PodBrowser-summary",
-                          }
-                        }
-                        disabled={false}
-                        label="Edit"
-                        onChange={[Function]}
-                        value={false}
-                      >
-                        <WithStyles(ForwardRef(ListItem))
-                          className="PodBrowser-listItem"
-                        >
-                          <ForwardRef(ListItem)
-                            className="PodBrowser-listItem"
+                                          <ForwardRef(Typography)
+                                            className="PodBrowser-label PodBrowser-label"
+                                            classes={
+                                              Object {
+                                                "alignCenter": "PodBrowser-alignCenter",
+                                                "alignJustify": "PodBrowser-alignJustify",
+                                                "alignLeft": "PodBrowser-alignLeft",
+                                                "alignRight": "PodBrowser-alignRight",
+                                                "body1": "PodBrowser-body1",
+                                                "body2": "PodBrowser-body2",
+                                                "button": "PodBrowser-button",
+                                                "caption": "PodBrowser-caption",
+                                                "colorError": "PodBrowser-colorError",
+                                                "colorInherit": "PodBrowser-colorInherit",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                                "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                                "displayBlock": "PodBrowser-displayBlock",
+                                                "displayInline": "PodBrowser-displayInline",
+                                                "gutterBottom": "PodBrowser-gutterBottom",
+                                                "h1": "PodBrowser-h1",
+                                                "h2": "PodBrowser-h2",
+                                                "h3": "PodBrowser-h3",
+                                                "h4": "PodBrowser-h4",
+                                                "h5": "PodBrowser-h5",
+                                                "h6": "PodBrowser-h6",
+                                                "noWrap": "PodBrowser-noWrap",
+                                                "overline": "PodBrowser-overline",
+                                                "paragraph": "PodBrowser-paragraph",
+                                                "root": "PodBrowser-root",
+                                                "srOnly": "PodBrowser-srOnly",
+                                                "subtitle1": "PodBrowser-subtitle1",
+                                                "subtitle2": "PodBrowser-subtitle2",
+                                              }
+                                            }
+                                            component="span"
+                                          >
+                                            <span
+                                              className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                            >
+                                              View
+                                            </span>
+                                          </ForwardRef(Typography)>
+                                        </WithStyles(ForwardRef(Typography))>
+                                      </label>
+                                    </ForwardRef(FormControlLabel)>
+                                  </WithStyles(ForwardRef(FormControlLabel))>
+                                </li>
+                              </ForwardRef(ListItem)>
+                            </WithStyles(ForwardRef(ListItem))>
+                          </PermissionCheckbox>
+                          <PermissionCheckbox
                             classes={
                               Object {
-                                "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
-                                "button": "PodBrowser-button",
+                                "checkbox": "PodBrowser-checkbox",
                                 "container": "PodBrowser-container",
-                                "dense": "PodBrowser-dense",
-                                "disabled": "PodBrowser-disabled",
-                                "divider": "PodBrowser-divider",
-                                "focusVisible": "PodBrowser-focusVisible",
-                                "gutters": "PodBrowser-gutters",
-                                "root": "PodBrowser-root",
-                                "secondaryAction": "PodBrowser-secondaryAction",
-                                "selected": "PodBrowser-selected",
+                                "label": "PodBrowser-label",
+                                "listItem": "PodBrowser-listItem",
+                                "selectionClosed": "PodBrowser-selectionClosed",
+                                "selectionOpen": "PodBrowser-selectionOpen",
+                                "summary": "PodBrowser-summary",
                               }
                             }
+                            disabled={false}
+                            label="Edit"
+                            onChange={[Function]}
+                            value={false}
                           >
-                            <li
-                              className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
-                              disabled={false}
+                            <WithStyles(ForwardRef(ListItem))
+                              className="PodBrowser-listItem"
                             >
-                              <WithStyles(ForwardRef(FormControlLabel))
+                              <ForwardRef(ListItem)
+                                className="PodBrowser-listItem"
                                 classes={
                                   Object {
-                                    "label": "PodBrowser-label",
+                                    "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                    "button": "PodBrowser-button",
+                                    "container": "PodBrowser-container",
+                                    "dense": "PodBrowser-dense",
+                                    "disabled": "PodBrowser-disabled",
+                                    "divider": "PodBrowser-divider",
+                                    "focusVisible": "PodBrowser-focusVisible",
+                                    "gutters": "PodBrowser-gutters",
+                                    "root": "PodBrowser-root",
+                                    "secondaryAction": "PodBrowser-secondaryAction",
+                                    "selected": "PodBrowser-selected",
                                   }
                                 }
-                                control={
-                                  <WithStyles(ForwardRef(Checkbox))
-                                    checked={false}
+                              >
+                                <li
+                                  className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
+                                  disabled={false}
+                                >
+                                  <WithStyles(ForwardRef(FormControlLabel))
                                     classes={
                                       Object {
-                                        "root": "PodBrowser-checkbox",
+                                        "label": "PodBrowser-label",
                                       }
                                     }
-                                    disabled={false}
-                                    name="edit"
-                                    onChange={[Function]}
-                                  />
-                                }
-                                key=".0"
-                                label="Edit"
-                              >
-                                <ForwardRef(FormControlLabel)
-                                  classes={
-                                    Object {
-                                      "disabled": "PodBrowser-disabled",
-                                      "label": "PodBrowser-label PodBrowser-label",
-                                      "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
-                                      "labelPlacementStart": "PodBrowser-labelPlacementStart",
-                                      "labelPlacementTop": "PodBrowser-labelPlacementTop",
-                                      "root": "PodBrowser-root",
-                                    }
-                                  }
-                                  control={
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="edit"
-                                      onChange={[Function]}
-                                    />
-                                  }
-                                  label="Edit"
-                                >
-                                  <label
-                                    className="PodBrowser-root"
-                                  >
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="edit"
-                                      onChange={[Function]}
-                                    >
-                                      <ForwardRef(Checkbox)
+                                    control={
+                                      <WithStyles(ForwardRef(Checkbox))
                                         checked={false}
                                         classes={
                                           Object {
-                                            "checked": "PodBrowser-checked",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "disabled": "PodBrowser-disabled",
-                                            "indeterminate": "PodBrowser-indeterminate",
-                                            "root": "PodBrowser-root PodBrowser-checkbox",
+                                            "root": "PodBrowser-checkbox",
                                           }
                                         }
                                         disabled={false}
                                         name="edit"
                                         onChange={[Function]}
-                                      >
-                                        <WithStyles(ForwardRef(SwitchBase))
+                                      />
+                                    }
+                                    key=".0"
+                                    label="Edit"
+                                  >
+                                    <ForwardRef(FormControlLabel)
+                                      classes={
+                                        Object {
+                                          "disabled": "PodBrowser-disabled",
+                                          "label": "PodBrowser-label PodBrowser-label",
+                                          "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
+                                          "labelPlacementStart": "PodBrowser-labelPlacementStart",
+                                          "labelPlacementTop": "PodBrowser-labelPlacementTop",
+                                          "root": "PodBrowser-root",
+                                        }
+                                      }
+                                      control={
+                                        <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
-                                          checkedIcon={<Memo />}
                                           classes={
                                             Object {
-                                              "checked": "PodBrowser-checked",
-                                              "disabled": "PodBrowser-disabled",
-                                              "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                              "root": "PodBrowser-checkbox",
                                             }
                                           }
-                                          color="secondary"
                                           disabled={false}
-                                          icon={<Memo />}
-                                          inputProps={
-                                            Object {
-                                              "data-indeterminate": false,
-                                            }
-                                          }
                                           name="edit"
                                           onChange={[Function]}
-                                          type="checkbox"
+                                        />
+                                      }
+                                      label="Edit"
+                                    >
+                                      <label
+                                        className="PodBrowser-root"
+                                      >
+                                        <WithStyles(ForwardRef(Checkbox))
+                                          checked={false}
+                                          classes={
+                                            Object {
+                                              "root": "PodBrowser-checkbox",
+                                            }
+                                          }
+                                          disabled={false}
+                                          name="edit"
+                                          onChange={[Function]}
                                         >
-                                          <ForwardRef(SwitchBase)
+                                          <ForwardRef(Checkbox)
                                             checked={false}
-                                            checkedIcon={<Memo />}
                                             classes={
                                               Object {
-                                                "checked": "PodBrowser-checked PodBrowser-checked",
-                                                "disabled": "PodBrowser-disabled PodBrowser-disabled",
-                                                "input": "PodBrowser-input",
-                                                "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                "checked": "PodBrowser-checked",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "disabled": "PodBrowser-disabled",
+                                                "indeterminate": "PodBrowser-indeterminate",
+                                                "root": "PodBrowser-root PodBrowser-checkbox",
                                               }
                                             }
-                                            color="secondary"
                                             disabled={false}
-                                            icon={<Memo />}
-                                            inputProps={
-                                              Object {
-                                                "data-indeterminate": false,
-                                              }
-                                            }
                                             name="edit"
                                             onChange={[Function]}
-                                            type="checkbox"
                                           >
-                                            <WithStyles(ForwardRef(IconButton))
-                                              className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                            <WithStyles(ForwardRef(SwitchBase))
+                                              checked={false}
+                                              checkedIcon={<Memo />}
+                                              classes={
+                                                Object {
+                                                  "checked": "PodBrowser-checked",
+                                                  "disabled": "PodBrowser-disabled",
+                                                  "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                }
+                                              }
                                               color="secondary"
-                                              component="span"
                                               disabled={false}
-                                              onBlur={[Function]}
-                                              onFocus={[Function]}
-                                              tabIndex={null}
+                                              icon={<Memo />}
+                                              inputProps={
+                                                Object {
+                                                  "data-indeterminate": false,
+                                                }
+                                              }
+                                              name="edit"
+                                              onChange={[Function]}
+                                              type="checkbox"
                                             >
-                                              <ForwardRef(IconButton)
-                                                className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                              <ForwardRef(SwitchBase)
+                                                checked={false}
+                                                checkedIcon={<Memo />}
                                                 classes={
                                                   Object {
-                                                    "colorInherit": "PodBrowser-colorInherit",
-                                                    "colorPrimary": "PodBrowser-colorPrimary",
-                                                    "colorSecondary": "PodBrowser-colorSecondary",
-                                                    "disabled": "PodBrowser-disabled",
-                                                    "edgeEnd": "PodBrowser-edgeEnd",
-                                                    "edgeStart": "PodBrowser-edgeStart",
-                                                    "label": "PodBrowser-label",
-                                                    "root": "PodBrowser-root",
-                                                    "sizeSmall": "PodBrowser-sizeSmall",
+                                                    "checked": "PodBrowser-checked PodBrowser-checked",
+                                                    "disabled": "PodBrowser-disabled PodBrowser-disabled",
+                                                    "input": "PodBrowser-input",
+                                                    "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
                                                   }
                                                 }
                                                 color="secondary"
-                                                component="span"
                                                 disabled={false}
-                                                onBlur={[Function]}
-                                                onFocus={[Function]}
-                                                tabIndex={null}
+                                                icon={<Memo />}
+                                                inputProps={
+                                                  Object {
+                                                    "data-indeterminate": false,
+                                                  }
+                                                }
+                                                name="edit"
+                                                onChange={[Function]}
+                                                type="checkbox"
                                               >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  centerRipple={true}
-                                                  className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                <WithStyles(ForwardRef(IconButton))
+                                                  className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                                  color="secondary"
                                                   component="span"
                                                   disabled={false}
-                                                  focusRipple={true}
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   tabIndex={null}
                                                 >
-                                                  <ForwardRef(ButtonBase)
-                                                    centerRipple={true}
-                                                    className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                  <ForwardRef(IconButton)
+                                                    className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
                                                     classes={
                                                       Object {
+                                                        "colorInherit": "PodBrowser-colorInherit",
+                                                        "colorPrimary": "PodBrowser-colorPrimary",
+                                                        "colorSecondary": "PodBrowser-colorSecondary",
                                                         "disabled": "PodBrowser-disabled",
-                                                        "focusVisible": "PodBrowser-focusVisible",
+                                                        "edgeEnd": "PodBrowser-edgeEnd",
+                                                        "edgeStart": "PodBrowser-edgeStart",
+                                                        "label": "PodBrowser-label",
                                                         "root": "PodBrowser-root",
+                                                        "sizeSmall": "PodBrowser-sizeSmall",
                                                       }
                                                     }
+                                                    color="secondary"
                                                     component="span"
                                                     disabled={false}
-                                                    focusRipple={true}
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     tabIndex={null}
                                                   >
-                                                    <span
-                                                      aria-disabled={false}
-                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                    <WithStyles(ForwardRef(ButtonBase))
+                                                      centerRipple={true}
+                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                      component="span"
+                                                      disabled={false}
+                                                      focusRipple={true}
                                                       onBlur={[Function]}
-                                                      onDragLeave={[Function]}
                                                       onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
                                                       tabIndex={null}
                                                     >
-                                                      <span
-                                                        className="PodBrowser-label"
+                                                      <ForwardRef(ButtonBase)
+                                                        centerRipple={true}
+                                                        className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                        classes={
+                                                          Object {
+                                                            "disabled": "PodBrowser-disabled",
+                                                            "focusVisible": "PodBrowser-focusVisible",
+                                                            "root": "PodBrowser-root",
+                                                          }
+                                                        }
+                                                        component="span"
+                                                        disabled={false}
+                                                        focusRipple={true}
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        tabIndex={null}
                                                       >
-                                                        <input
-                                                          checked={false}
-                                                          className="PodBrowser-input"
-                                                          data-indeterminate={false}
-                                                          disabled={false}
-                                                          name="edit"
-                                                          onChange={[Function]}
-                                                          type="checkbox"
-                                                        />
-                                                        <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                          <WithStyles(ForwardRef(SvgIcon))>
-                                                            <ForwardRef(SvgIcon)
+                                                        <span
+                                                          aria-disabled={false}
+                                                          className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                          onBlur={[Function]}
+                                                          onDragLeave={[Function]}
+                                                          onFocus={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          onMouseDown={[Function]}
+                                                          onMouseLeave={[Function]}
+                                                          onMouseUp={[Function]}
+                                                          onTouchEnd={[Function]}
+                                                          onTouchMove={[Function]}
+                                                          onTouchStart={[Function]}
+                                                          tabIndex={null}
+                                                        >
+                                                          <span
+                                                            className="PodBrowser-label"
+                                                          >
+                                                            <input
+                                                              checked={false}
+                                                              className="PodBrowser-input"
+                                                              data-indeterminate={false}
+                                                              disabled={false}
+                                                              name="edit"
+                                                              onChange={[Function]}
+                                                              type="checkbox"
+                                                            />
+                                                            <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                              <WithStyles(ForwardRef(SvgIcon))>
+                                                                <ForwardRef(SvgIcon)
+                                                                  classes={
+                                                                    Object {
+                                                                      "colorAction": "PodBrowser-colorAction",
+                                                                      "colorDisabled": "PodBrowser-colorDisabled",
+                                                                      "colorError": "PodBrowser-colorError",
+                                                                      "colorPrimary": "PodBrowser-colorPrimary",
+                                                                      "colorSecondary": "PodBrowser-colorSecondary",
+                                                                      "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                                                      "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                                                      "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                      "root": "PodBrowser-root",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="PodBrowser-root"
+                                                                    focusable="false"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <path
+                                                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                    />
+                                                                  </svg>
+                                                                </ForwardRef(SvgIcon)>
+                                                              </WithStyles(ForwardRef(SvgIcon))>
+                                                            </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                          </span>
+                                                          <WithStyles(memo)
+                                                            center={true}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={true}
                                                               classes={
                                                                 Object {
-                                                                  "colorAction": "PodBrowser-colorAction",
-                                                                  "colorDisabled": "PodBrowser-colorDisabled",
-                                                                  "colorError": "PodBrowser-colorError",
-                                                                  "colorPrimary": "PodBrowser-colorPrimary",
-                                                                  "colorSecondary": "PodBrowser-colorSecondary",
-                                                                  "fontSizeInherit": "PodBrowser-fontSizeInherit",
-                                                                  "fontSizeLarge": "PodBrowser-fontSizeLarge",
-                                                                  "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                  "child": "PodBrowser-child",
+                                                                  "childLeaving": "PodBrowser-childLeaving",
+                                                                  "childPulsate": "PodBrowser-childPulsate",
+                                                                  "ripple": "PodBrowser-ripple",
+                                                                  "ripplePulsate": "PodBrowser-ripplePulsate",
+                                                                  "rippleVisible": "PodBrowser-rippleVisible",
                                                                   "root": "PodBrowser-root",
                                                                 }
                                                               }
                                                             >
-                                                              <svg
-                                                                aria-hidden={true}
+                                                              <span
                                                                 className="PodBrowser-root"
-                                                                focusable="false"
-                                                                viewBox="0 0 24 24"
                                                               >
-                                                                <path
-                                                                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
                                                                 />
-                                                              </svg>
-                                                            </ForwardRef(SvgIcon)>
-                                                          </WithStyles(ForwardRef(SvgIcon))>
-                                                        </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                      </span>
-                                                      <WithStyles(memo)
-                                                        center={true}
-                                                      >
-                                                        <ForwardRef(TouchRipple)
-                                                          center={true}
-                                                          classes={
-                                                            Object {
-                                                              "child": "PodBrowser-child",
-                                                              "childLeaving": "PodBrowser-childLeaving",
-                                                              "childPulsate": "PodBrowser-childPulsate",
-                                                              "ripple": "PodBrowser-ripple",
-                                                              "ripplePulsate": "PodBrowser-ripplePulsate",
-                                                              "rippleVisible": "PodBrowser-rippleVisible",
-                                                              "root": "PodBrowser-root",
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            className="PodBrowser-root"
-                                                          >
-                                                            <TransitionGroup
-                                                              childFactory={[Function]}
-                                                              component={null}
-                                                              exit={true}
-                                                            />
-                                                          </span>
-                                                        </ForwardRef(TouchRipple)>
-                                                      </WithStyles(memo)>
-                                                    </span>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(IconButton)>
-                                            </WithStyles(ForwardRef(IconButton))>
-                                          </ForwardRef(SwitchBase)>
-                                        </WithStyles(ForwardRef(SwitchBase))>
-                                      </ForwardRef(Checkbox)>
-                                    </WithStyles(ForwardRef(Checkbox))>
-                                    <WithStyles(ForwardRef(Typography))
-                                      className="PodBrowser-label PodBrowser-label"
-                                      component="span"
-                                    >
-                                      <ForwardRef(Typography)
-                                        className="PodBrowser-label PodBrowser-label"
-                                        classes={
-                                          Object {
-                                            "alignCenter": "PodBrowser-alignCenter",
-                                            "alignJustify": "PodBrowser-alignJustify",
-                                            "alignLeft": "PodBrowser-alignLeft",
-                                            "alignRight": "PodBrowser-alignRight",
-                                            "body1": "PodBrowser-body1",
-                                            "body2": "PodBrowser-body2",
-                                            "button": "PodBrowser-button",
-                                            "caption": "PodBrowser-caption",
-                                            "colorError": "PodBrowser-colorError",
-                                            "colorInherit": "PodBrowser-colorInherit",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "colorTextPrimary": "PodBrowser-colorTextPrimary",
-                                            "colorTextSecondary": "PodBrowser-colorTextSecondary",
-                                            "displayBlock": "PodBrowser-displayBlock",
-                                            "displayInline": "PodBrowser-displayInline",
-                                            "gutterBottom": "PodBrowser-gutterBottom",
-                                            "h1": "PodBrowser-h1",
-                                            "h2": "PodBrowser-h2",
-                                            "h3": "PodBrowser-h3",
-                                            "h4": "PodBrowser-h4",
-                                            "h5": "PodBrowser-h5",
-                                            "h6": "PodBrowser-h6",
-                                            "noWrap": "PodBrowser-noWrap",
-                                            "overline": "PodBrowser-overline",
-                                            "paragraph": "PodBrowser-paragraph",
-                                            "root": "PodBrowser-root",
-                                            "srOnly": "PodBrowser-srOnly",
-                                            "subtitle1": "PodBrowser-subtitle1",
-                                            "subtitle2": "PodBrowser-subtitle2",
-                                          }
-                                        }
-                                        component="span"
-                                      >
-                                        <span
-                                          className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </span>
+                                                      </ForwardRef(ButtonBase)>
+                                                    </WithStyles(ForwardRef(ButtonBase))>
+                                                  </ForwardRef(IconButton)>
+                                                </WithStyles(ForwardRef(IconButton))>
+                                              </ForwardRef(SwitchBase)>
+                                            </WithStyles(ForwardRef(SwitchBase))>
+                                          </ForwardRef(Checkbox)>
+                                        </WithStyles(ForwardRef(Checkbox))>
+                                        <WithStyles(ForwardRef(Typography))
+                                          className="PodBrowser-label PodBrowser-label"
+                                          component="span"
                                         >
-                                          Edit
-                                        </span>
-                                      </ForwardRef(Typography)>
-                                    </WithStyles(ForwardRef(Typography))>
-                                  </label>
-                                </ForwardRef(FormControlLabel)>
-                              </WithStyles(ForwardRef(FormControlLabel))>
-                            </li>
-                          </ForwardRef(ListItem)>
-                        </WithStyles(ForwardRef(ListItem))>
-                      </PermissionCheckbox>
-                      <PermissionCheckbox
-                        classes={
-                          Object {
-                            "checkbox": "PodBrowser-checkbox",
-                            "container": "PodBrowser-container",
-                            "label": "PodBrowser-label",
-                            "listItem": "PodBrowser-listItem",
-                            "selectionClosed": "PodBrowser-selectionClosed",
-                            "selectionOpen": "PodBrowser-selectionOpen",
-                            "summary": "PodBrowser-summary",
-                          }
-                        }
-                        disabled={false}
-                        label="Append"
-                        onChange={[Function]}
-                        value={false}
-                      >
-                        <WithStyles(ForwardRef(ListItem))
-                          className="PodBrowser-listItem"
-                        >
-                          <ForwardRef(ListItem)
-                            className="PodBrowser-listItem"
+                                          <ForwardRef(Typography)
+                                            className="PodBrowser-label PodBrowser-label"
+                                            classes={
+                                              Object {
+                                                "alignCenter": "PodBrowser-alignCenter",
+                                                "alignJustify": "PodBrowser-alignJustify",
+                                                "alignLeft": "PodBrowser-alignLeft",
+                                                "alignRight": "PodBrowser-alignRight",
+                                                "body1": "PodBrowser-body1",
+                                                "body2": "PodBrowser-body2",
+                                                "button": "PodBrowser-button",
+                                                "caption": "PodBrowser-caption",
+                                                "colorError": "PodBrowser-colorError",
+                                                "colorInherit": "PodBrowser-colorInherit",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                                "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                                "displayBlock": "PodBrowser-displayBlock",
+                                                "displayInline": "PodBrowser-displayInline",
+                                                "gutterBottom": "PodBrowser-gutterBottom",
+                                                "h1": "PodBrowser-h1",
+                                                "h2": "PodBrowser-h2",
+                                                "h3": "PodBrowser-h3",
+                                                "h4": "PodBrowser-h4",
+                                                "h5": "PodBrowser-h5",
+                                                "h6": "PodBrowser-h6",
+                                                "noWrap": "PodBrowser-noWrap",
+                                                "overline": "PodBrowser-overline",
+                                                "paragraph": "PodBrowser-paragraph",
+                                                "root": "PodBrowser-root",
+                                                "srOnly": "PodBrowser-srOnly",
+                                                "subtitle1": "PodBrowser-subtitle1",
+                                                "subtitle2": "PodBrowser-subtitle2",
+                                              }
+                                            }
+                                            component="span"
+                                          >
+                                            <span
+                                              className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                            >
+                                              Edit
+                                            </span>
+                                          </ForwardRef(Typography)>
+                                        </WithStyles(ForwardRef(Typography))>
+                                      </label>
+                                    </ForwardRef(FormControlLabel)>
+                                  </WithStyles(ForwardRef(FormControlLabel))>
+                                </li>
+                              </ForwardRef(ListItem)>
+                            </WithStyles(ForwardRef(ListItem))>
+                          </PermissionCheckbox>
+                          <PermissionCheckbox
                             classes={
                               Object {
-                                "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
-                                "button": "PodBrowser-button",
+                                "checkbox": "PodBrowser-checkbox",
                                 "container": "PodBrowser-container",
-                                "dense": "PodBrowser-dense",
-                                "disabled": "PodBrowser-disabled",
-                                "divider": "PodBrowser-divider",
-                                "focusVisible": "PodBrowser-focusVisible",
-                                "gutters": "PodBrowser-gutters",
-                                "root": "PodBrowser-root",
-                                "secondaryAction": "PodBrowser-secondaryAction",
-                                "selected": "PodBrowser-selected",
+                                "label": "PodBrowser-label",
+                                "listItem": "PodBrowser-listItem",
+                                "selectionClosed": "PodBrowser-selectionClosed",
+                                "selectionOpen": "PodBrowser-selectionOpen",
+                                "summary": "PodBrowser-summary",
                               }
                             }
+                            disabled={false}
+                            label="Append"
+                            onChange={[Function]}
+                            value={false}
                           >
-                            <li
-                              className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
-                              disabled={false}
+                            <WithStyles(ForwardRef(ListItem))
+                              className="PodBrowser-listItem"
                             >
-                              <WithStyles(ForwardRef(FormControlLabel))
+                              <ForwardRef(ListItem)
+                                className="PodBrowser-listItem"
                                 classes={
                                   Object {
-                                    "label": "PodBrowser-label",
+                                    "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                    "button": "PodBrowser-button",
+                                    "container": "PodBrowser-container",
+                                    "dense": "PodBrowser-dense",
+                                    "disabled": "PodBrowser-disabled",
+                                    "divider": "PodBrowser-divider",
+                                    "focusVisible": "PodBrowser-focusVisible",
+                                    "gutters": "PodBrowser-gutters",
+                                    "root": "PodBrowser-root",
+                                    "secondaryAction": "PodBrowser-secondaryAction",
+                                    "selected": "PodBrowser-selected",
                                   }
                                 }
-                                control={
-                                  <WithStyles(ForwardRef(Checkbox))
-                                    checked={false}
+                              >
+                                <li
+                                  className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
+                                  disabled={false}
+                                >
+                                  <WithStyles(ForwardRef(FormControlLabel))
                                     classes={
                                       Object {
-                                        "root": "PodBrowser-checkbox",
+                                        "label": "PodBrowser-label",
                                       }
                                     }
-                                    disabled={false}
-                                    name="append"
-                                    onChange={[Function]}
-                                  />
-                                }
-                                key=".0"
-                                label="Append"
-                              >
-                                <ForwardRef(FormControlLabel)
-                                  classes={
-                                    Object {
-                                      "disabled": "PodBrowser-disabled",
-                                      "label": "PodBrowser-label PodBrowser-label",
-                                      "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
-                                      "labelPlacementStart": "PodBrowser-labelPlacementStart",
-                                      "labelPlacementTop": "PodBrowser-labelPlacementTop",
-                                      "root": "PodBrowser-root",
-                                    }
-                                  }
-                                  control={
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="append"
-                                      onChange={[Function]}
-                                    />
-                                  }
-                                  label="Append"
-                                >
-                                  <label
-                                    className="PodBrowser-root"
-                                  >
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="append"
-                                      onChange={[Function]}
-                                    >
-                                      <ForwardRef(Checkbox)
+                                    control={
+                                      <WithStyles(ForwardRef(Checkbox))
                                         checked={false}
                                         classes={
                                           Object {
-                                            "checked": "PodBrowser-checked",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "disabled": "PodBrowser-disabled",
-                                            "indeterminate": "PodBrowser-indeterminate",
-                                            "root": "PodBrowser-root PodBrowser-checkbox",
+                                            "root": "PodBrowser-checkbox",
                                           }
                                         }
                                         disabled={false}
                                         name="append"
                                         onChange={[Function]}
-                                      >
-                                        <WithStyles(ForwardRef(SwitchBase))
+                                      />
+                                    }
+                                    key=".0"
+                                    label="Append"
+                                  >
+                                    <ForwardRef(FormControlLabel)
+                                      classes={
+                                        Object {
+                                          "disabled": "PodBrowser-disabled",
+                                          "label": "PodBrowser-label PodBrowser-label",
+                                          "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
+                                          "labelPlacementStart": "PodBrowser-labelPlacementStart",
+                                          "labelPlacementTop": "PodBrowser-labelPlacementTop",
+                                          "root": "PodBrowser-root",
+                                        }
+                                      }
+                                      control={
+                                        <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
-                                          checkedIcon={<Memo />}
                                           classes={
                                             Object {
-                                              "checked": "PodBrowser-checked",
-                                              "disabled": "PodBrowser-disabled",
-                                              "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                              "root": "PodBrowser-checkbox",
                                             }
                                           }
-                                          color="secondary"
                                           disabled={false}
-                                          icon={<Memo />}
-                                          inputProps={
-                                            Object {
-                                              "data-indeterminate": false,
-                                            }
-                                          }
                                           name="append"
                                           onChange={[Function]}
-                                          type="checkbox"
+                                        />
+                                      }
+                                      label="Append"
+                                    >
+                                      <label
+                                        className="PodBrowser-root"
+                                      >
+                                        <WithStyles(ForwardRef(Checkbox))
+                                          checked={false}
+                                          classes={
+                                            Object {
+                                              "root": "PodBrowser-checkbox",
+                                            }
+                                          }
+                                          disabled={false}
+                                          name="append"
+                                          onChange={[Function]}
                                         >
-                                          <ForwardRef(SwitchBase)
+                                          <ForwardRef(Checkbox)
                                             checked={false}
-                                            checkedIcon={<Memo />}
                                             classes={
                                               Object {
-                                                "checked": "PodBrowser-checked PodBrowser-checked",
-                                                "disabled": "PodBrowser-disabled PodBrowser-disabled",
-                                                "input": "PodBrowser-input",
-                                                "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                "checked": "PodBrowser-checked",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "disabled": "PodBrowser-disabled",
+                                                "indeterminate": "PodBrowser-indeterminate",
+                                                "root": "PodBrowser-root PodBrowser-checkbox",
                                               }
                                             }
-                                            color="secondary"
                                             disabled={false}
-                                            icon={<Memo />}
-                                            inputProps={
-                                              Object {
-                                                "data-indeterminate": false,
-                                              }
-                                            }
                                             name="append"
                                             onChange={[Function]}
-                                            type="checkbox"
                                           >
-                                            <WithStyles(ForwardRef(IconButton))
-                                              className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                            <WithStyles(ForwardRef(SwitchBase))
+                                              checked={false}
+                                              checkedIcon={<Memo />}
+                                              classes={
+                                                Object {
+                                                  "checked": "PodBrowser-checked",
+                                                  "disabled": "PodBrowser-disabled",
+                                                  "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                }
+                                              }
                                               color="secondary"
-                                              component="span"
                                               disabled={false}
-                                              onBlur={[Function]}
-                                              onFocus={[Function]}
-                                              tabIndex={null}
+                                              icon={<Memo />}
+                                              inputProps={
+                                                Object {
+                                                  "data-indeterminate": false,
+                                                }
+                                              }
+                                              name="append"
+                                              onChange={[Function]}
+                                              type="checkbox"
                                             >
-                                              <ForwardRef(IconButton)
-                                                className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                              <ForwardRef(SwitchBase)
+                                                checked={false}
+                                                checkedIcon={<Memo />}
                                                 classes={
                                                   Object {
-                                                    "colorInherit": "PodBrowser-colorInherit",
-                                                    "colorPrimary": "PodBrowser-colorPrimary",
-                                                    "colorSecondary": "PodBrowser-colorSecondary",
-                                                    "disabled": "PodBrowser-disabled",
-                                                    "edgeEnd": "PodBrowser-edgeEnd",
-                                                    "edgeStart": "PodBrowser-edgeStart",
-                                                    "label": "PodBrowser-label",
-                                                    "root": "PodBrowser-root",
-                                                    "sizeSmall": "PodBrowser-sizeSmall",
+                                                    "checked": "PodBrowser-checked PodBrowser-checked",
+                                                    "disabled": "PodBrowser-disabled PodBrowser-disabled",
+                                                    "input": "PodBrowser-input",
+                                                    "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
                                                   }
                                                 }
                                                 color="secondary"
-                                                component="span"
                                                 disabled={false}
-                                                onBlur={[Function]}
-                                                onFocus={[Function]}
-                                                tabIndex={null}
+                                                icon={<Memo />}
+                                                inputProps={
+                                                  Object {
+                                                    "data-indeterminate": false,
+                                                  }
+                                                }
+                                                name="append"
+                                                onChange={[Function]}
+                                                type="checkbox"
                                               >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  centerRipple={true}
-                                                  className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                <WithStyles(ForwardRef(IconButton))
+                                                  className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                                  color="secondary"
                                                   component="span"
                                                   disabled={false}
-                                                  focusRipple={true}
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   tabIndex={null}
                                                 >
-                                                  <ForwardRef(ButtonBase)
-                                                    centerRipple={true}
-                                                    className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                  <ForwardRef(IconButton)
+                                                    className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
                                                     classes={
                                                       Object {
+                                                        "colorInherit": "PodBrowser-colorInherit",
+                                                        "colorPrimary": "PodBrowser-colorPrimary",
+                                                        "colorSecondary": "PodBrowser-colorSecondary",
                                                         "disabled": "PodBrowser-disabled",
-                                                        "focusVisible": "PodBrowser-focusVisible",
+                                                        "edgeEnd": "PodBrowser-edgeEnd",
+                                                        "edgeStart": "PodBrowser-edgeStart",
+                                                        "label": "PodBrowser-label",
                                                         "root": "PodBrowser-root",
+                                                        "sizeSmall": "PodBrowser-sizeSmall",
                                                       }
                                                     }
+                                                    color="secondary"
                                                     component="span"
                                                     disabled={false}
-                                                    focusRipple={true}
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     tabIndex={null}
                                                   >
-                                                    <span
-                                                      aria-disabled={false}
-                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                    <WithStyles(ForwardRef(ButtonBase))
+                                                      centerRipple={true}
+                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                      component="span"
+                                                      disabled={false}
+                                                      focusRipple={true}
                                                       onBlur={[Function]}
-                                                      onDragLeave={[Function]}
                                                       onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
                                                       tabIndex={null}
                                                     >
-                                                      <span
-                                                        className="PodBrowser-label"
+                                                      <ForwardRef(ButtonBase)
+                                                        centerRipple={true}
+                                                        className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                        classes={
+                                                          Object {
+                                                            "disabled": "PodBrowser-disabled",
+                                                            "focusVisible": "PodBrowser-focusVisible",
+                                                            "root": "PodBrowser-root",
+                                                          }
+                                                        }
+                                                        component="span"
+                                                        disabled={false}
+                                                        focusRipple={true}
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        tabIndex={null}
                                                       >
-                                                        <input
-                                                          checked={false}
-                                                          className="PodBrowser-input"
-                                                          data-indeterminate={false}
-                                                          disabled={false}
-                                                          name="append"
-                                                          onChange={[Function]}
-                                                          type="checkbox"
-                                                        />
-                                                        <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                          <WithStyles(ForwardRef(SvgIcon))>
-                                                            <ForwardRef(SvgIcon)
+                                                        <span
+                                                          aria-disabled={false}
+                                                          className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                          onBlur={[Function]}
+                                                          onDragLeave={[Function]}
+                                                          onFocus={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          onMouseDown={[Function]}
+                                                          onMouseLeave={[Function]}
+                                                          onMouseUp={[Function]}
+                                                          onTouchEnd={[Function]}
+                                                          onTouchMove={[Function]}
+                                                          onTouchStart={[Function]}
+                                                          tabIndex={null}
+                                                        >
+                                                          <span
+                                                            className="PodBrowser-label"
+                                                          >
+                                                            <input
+                                                              checked={false}
+                                                              className="PodBrowser-input"
+                                                              data-indeterminate={false}
+                                                              disabled={false}
+                                                              name="append"
+                                                              onChange={[Function]}
+                                                              type="checkbox"
+                                                            />
+                                                            <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                              <WithStyles(ForwardRef(SvgIcon))>
+                                                                <ForwardRef(SvgIcon)
+                                                                  classes={
+                                                                    Object {
+                                                                      "colorAction": "PodBrowser-colorAction",
+                                                                      "colorDisabled": "PodBrowser-colorDisabled",
+                                                                      "colorError": "PodBrowser-colorError",
+                                                                      "colorPrimary": "PodBrowser-colorPrimary",
+                                                                      "colorSecondary": "PodBrowser-colorSecondary",
+                                                                      "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                                                      "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                                                      "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                      "root": "PodBrowser-root",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="PodBrowser-root"
+                                                                    focusable="false"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <path
+                                                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                    />
+                                                                  </svg>
+                                                                </ForwardRef(SvgIcon)>
+                                                              </WithStyles(ForwardRef(SvgIcon))>
+                                                            </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                          </span>
+                                                          <WithStyles(memo)
+                                                            center={true}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={true}
                                                               classes={
                                                                 Object {
-                                                                  "colorAction": "PodBrowser-colorAction",
-                                                                  "colorDisabled": "PodBrowser-colorDisabled",
-                                                                  "colorError": "PodBrowser-colorError",
-                                                                  "colorPrimary": "PodBrowser-colorPrimary",
-                                                                  "colorSecondary": "PodBrowser-colorSecondary",
-                                                                  "fontSizeInherit": "PodBrowser-fontSizeInherit",
-                                                                  "fontSizeLarge": "PodBrowser-fontSizeLarge",
-                                                                  "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                  "child": "PodBrowser-child",
+                                                                  "childLeaving": "PodBrowser-childLeaving",
+                                                                  "childPulsate": "PodBrowser-childPulsate",
+                                                                  "ripple": "PodBrowser-ripple",
+                                                                  "ripplePulsate": "PodBrowser-ripplePulsate",
+                                                                  "rippleVisible": "PodBrowser-rippleVisible",
                                                                   "root": "PodBrowser-root",
                                                                 }
                                                               }
                                                             >
-                                                              <svg
-                                                                aria-hidden={true}
+                                                              <span
                                                                 className="PodBrowser-root"
-                                                                focusable="false"
-                                                                viewBox="0 0 24 24"
                                                               >
-                                                                <path
-                                                                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
                                                                 />
-                                                              </svg>
-                                                            </ForwardRef(SvgIcon)>
-                                                          </WithStyles(ForwardRef(SvgIcon))>
-                                                        </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                      </span>
-                                                      <WithStyles(memo)
-                                                        center={true}
-                                                      >
-                                                        <ForwardRef(TouchRipple)
-                                                          center={true}
-                                                          classes={
-                                                            Object {
-                                                              "child": "PodBrowser-child",
-                                                              "childLeaving": "PodBrowser-childLeaving",
-                                                              "childPulsate": "PodBrowser-childPulsate",
-                                                              "ripple": "PodBrowser-ripple",
-                                                              "ripplePulsate": "PodBrowser-ripplePulsate",
-                                                              "rippleVisible": "PodBrowser-rippleVisible",
-                                                              "root": "PodBrowser-root",
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            className="PodBrowser-root"
-                                                          >
-                                                            <TransitionGroup
-                                                              childFactory={[Function]}
-                                                              component={null}
-                                                              exit={true}
-                                                            />
-                                                          </span>
-                                                        </ForwardRef(TouchRipple)>
-                                                      </WithStyles(memo)>
-                                                    </span>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(IconButton)>
-                                            </WithStyles(ForwardRef(IconButton))>
-                                          </ForwardRef(SwitchBase)>
-                                        </WithStyles(ForwardRef(SwitchBase))>
-                                      </ForwardRef(Checkbox)>
-                                    </WithStyles(ForwardRef(Checkbox))>
-                                    <WithStyles(ForwardRef(Typography))
-                                      className="PodBrowser-label PodBrowser-label"
-                                      component="span"
-                                    >
-                                      <ForwardRef(Typography)
-                                        className="PodBrowser-label PodBrowser-label"
-                                        classes={
-                                          Object {
-                                            "alignCenter": "PodBrowser-alignCenter",
-                                            "alignJustify": "PodBrowser-alignJustify",
-                                            "alignLeft": "PodBrowser-alignLeft",
-                                            "alignRight": "PodBrowser-alignRight",
-                                            "body1": "PodBrowser-body1",
-                                            "body2": "PodBrowser-body2",
-                                            "button": "PodBrowser-button",
-                                            "caption": "PodBrowser-caption",
-                                            "colorError": "PodBrowser-colorError",
-                                            "colorInherit": "PodBrowser-colorInherit",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "colorTextPrimary": "PodBrowser-colorTextPrimary",
-                                            "colorTextSecondary": "PodBrowser-colorTextSecondary",
-                                            "displayBlock": "PodBrowser-displayBlock",
-                                            "displayInline": "PodBrowser-displayInline",
-                                            "gutterBottom": "PodBrowser-gutterBottom",
-                                            "h1": "PodBrowser-h1",
-                                            "h2": "PodBrowser-h2",
-                                            "h3": "PodBrowser-h3",
-                                            "h4": "PodBrowser-h4",
-                                            "h5": "PodBrowser-h5",
-                                            "h6": "PodBrowser-h6",
-                                            "noWrap": "PodBrowser-noWrap",
-                                            "overline": "PodBrowser-overline",
-                                            "paragraph": "PodBrowser-paragraph",
-                                            "root": "PodBrowser-root",
-                                            "srOnly": "PodBrowser-srOnly",
-                                            "subtitle1": "PodBrowser-subtitle1",
-                                            "subtitle2": "PodBrowser-subtitle2",
-                                          }
-                                        }
-                                        component="span"
-                                      >
-                                        <span
-                                          className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </span>
+                                                      </ForwardRef(ButtonBase)>
+                                                    </WithStyles(ForwardRef(ButtonBase))>
+                                                  </ForwardRef(IconButton)>
+                                                </WithStyles(ForwardRef(IconButton))>
+                                              </ForwardRef(SwitchBase)>
+                                            </WithStyles(ForwardRef(SwitchBase))>
+                                          </ForwardRef(Checkbox)>
+                                        </WithStyles(ForwardRef(Checkbox))>
+                                        <WithStyles(ForwardRef(Typography))
+                                          className="PodBrowser-label PodBrowser-label"
+                                          component="span"
                                         >
-                                          Append
-                                        </span>
-                                      </ForwardRef(Typography)>
-                                    </WithStyles(ForwardRef(Typography))>
-                                  </label>
-                                </ForwardRef(FormControlLabel)>
-                              </WithStyles(ForwardRef(FormControlLabel))>
-                            </li>
-                          </ForwardRef(ListItem)>
-                        </WithStyles(ForwardRef(ListItem))>
-                      </PermissionCheckbox>
-                      <PermissionCheckbox
-                        classes={
-                          Object {
-                            "checkbox": "PodBrowser-checkbox",
-                            "container": "PodBrowser-container",
-                            "label": "PodBrowser-label",
-                            "listItem": "PodBrowser-listItem",
-                            "selectionClosed": "PodBrowser-selectionClosed",
-                            "selectionOpen": "PodBrowser-selectionOpen",
-                            "summary": "PodBrowser-summary",
-                          }
-                        }
-                        disabled={false}
-                        label="Control"
-                        onChange={[Function]}
-                        value={false}
-                      >
-                        <WithStyles(ForwardRef(ListItem))
-                          className="PodBrowser-listItem"
-                        >
-                          <ForwardRef(ListItem)
-                            className="PodBrowser-listItem"
+                                          <ForwardRef(Typography)
+                                            className="PodBrowser-label PodBrowser-label"
+                                            classes={
+                                              Object {
+                                                "alignCenter": "PodBrowser-alignCenter",
+                                                "alignJustify": "PodBrowser-alignJustify",
+                                                "alignLeft": "PodBrowser-alignLeft",
+                                                "alignRight": "PodBrowser-alignRight",
+                                                "body1": "PodBrowser-body1",
+                                                "body2": "PodBrowser-body2",
+                                                "button": "PodBrowser-button",
+                                                "caption": "PodBrowser-caption",
+                                                "colorError": "PodBrowser-colorError",
+                                                "colorInherit": "PodBrowser-colorInherit",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                                "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                                "displayBlock": "PodBrowser-displayBlock",
+                                                "displayInline": "PodBrowser-displayInline",
+                                                "gutterBottom": "PodBrowser-gutterBottom",
+                                                "h1": "PodBrowser-h1",
+                                                "h2": "PodBrowser-h2",
+                                                "h3": "PodBrowser-h3",
+                                                "h4": "PodBrowser-h4",
+                                                "h5": "PodBrowser-h5",
+                                                "h6": "PodBrowser-h6",
+                                                "noWrap": "PodBrowser-noWrap",
+                                                "overline": "PodBrowser-overline",
+                                                "paragraph": "PodBrowser-paragraph",
+                                                "root": "PodBrowser-root",
+                                                "srOnly": "PodBrowser-srOnly",
+                                                "subtitle1": "PodBrowser-subtitle1",
+                                                "subtitle2": "PodBrowser-subtitle2",
+                                              }
+                                            }
+                                            component="span"
+                                          >
+                                            <span
+                                              className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                            >
+                                              Append
+                                            </span>
+                                          </ForwardRef(Typography)>
+                                        </WithStyles(ForwardRef(Typography))>
+                                      </label>
+                                    </ForwardRef(FormControlLabel)>
+                                  </WithStyles(ForwardRef(FormControlLabel))>
+                                </li>
+                              </ForwardRef(ListItem)>
+                            </WithStyles(ForwardRef(ListItem))>
+                          </PermissionCheckbox>
+                          <PermissionCheckbox
                             classes={
                               Object {
-                                "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
-                                "button": "PodBrowser-button",
+                                "checkbox": "PodBrowser-checkbox",
                                 "container": "PodBrowser-container",
-                                "dense": "PodBrowser-dense",
-                                "disabled": "PodBrowser-disabled",
-                                "divider": "PodBrowser-divider",
-                                "focusVisible": "PodBrowser-focusVisible",
-                                "gutters": "PodBrowser-gutters",
-                                "root": "PodBrowser-root",
-                                "secondaryAction": "PodBrowser-secondaryAction",
-                                "selected": "PodBrowser-selected",
+                                "label": "PodBrowser-label",
+                                "listItem": "PodBrowser-listItem",
+                                "selectionClosed": "PodBrowser-selectionClosed",
+                                "selectionOpen": "PodBrowser-selectionOpen",
+                                "summary": "PodBrowser-summary",
                               }
                             }
+                            disabled={false}
+                            label="Control"
+                            onChange={[Function]}
+                            value={false}
                           >
-                            <li
-                              className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
-                              disabled={false}
+                            <WithStyles(ForwardRef(ListItem))
+                              className="PodBrowser-listItem"
                             >
-                              <WithStyles(ForwardRef(FormControlLabel))
+                              <ForwardRef(ListItem)
+                                className="PodBrowser-listItem"
                                 classes={
                                   Object {
-                                    "label": "PodBrowser-label",
+                                    "alignItemsFlexStart": "PodBrowser-alignItemsFlexStart",
+                                    "button": "PodBrowser-button",
+                                    "container": "PodBrowser-container",
+                                    "dense": "PodBrowser-dense",
+                                    "disabled": "PodBrowser-disabled",
+                                    "divider": "PodBrowser-divider",
+                                    "focusVisible": "PodBrowser-focusVisible",
+                                    "gutters": "PodBrowser-gutters",
+                                    "root": "PodBrowser-root",
+                                    "secondaryAction": "PodBrowser-secondaryAction",
+                                    "selected": "PodBrowser-selected",
                                   }
                                 }
-                                control={
-                                  <WithStyles(ForwardRef(Checkbox))
-                                    checked={false}
+                              >
+                                <li
+                                  className="PodBrowser-root PodBrowser-listItem PodBrowser-gutters"
+                                  disabled={false}
+                                >
+                                  <WithStyles(ForwardRef(FormControlLabel))
                                     classes={
                                       Object {
-                                        "root": "PodBrowser-checkbox",
+                                        "label": "PodBrowser-label",
                                       }
                                     }
-                                    disabled={false}
-                                    name="control"
-                                    onChange={[Function]}
-                                  />
-                                }
-                                key=".0"
-                                label="Control"
-                              >
-                                <ForwardRef(FormControlLabel)
-                                  classes={
-                                    Object {
-                                      "disabled": "PodBrowser-disabled",
-                                      "label": "PodBrowser-label PodBrowser-label",
-                                      "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
-                                      "labelPlacementStart": "PodBrowser-labelPlacementStart",
-                                      "labelPlacementTop": "PodBrowser-labelPlacementTop",
-                                      "root": "PodBrowser-root",
-                                    }
-                                  }
-                                  control={
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="control"
-                                      onChange={[Function]}
-                                    />
-                                  }
-                                  label="Control"
-                                >
-                                  <label
-                                    className="PodBrowser-root"
-                                  >
-                                    <WithStyles(ForwardRef(Checkbox))
-                                      checked={false}
-                                      classes={
-                                        Object {
-                                          "root": "PodBrowser-checkbox",
-                                        }
-                                      }
-                                      disabled={false}
-                                      name="control"
-                                      onChange={[Function]}
-                                    >
-                                      <ForwardRef(Checkbox)
+                                    control={
+                                      <WithStyles(ForwardRef(Checkbox))
                                         checked={false}
                                         classes={
                                           Object {
-                                            "checked": "PodBrowser-checked",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "disabled": "PodBrowser-disabled",
-                                            "indeterminate": "PodBrowser-indeterminate",
-                                            "root": "PodBrowser-root PodBrowser-checkbox",
+                                            "root": "PodBrowser-checkbox",
                                           }
                                         }
                                         disabled={false}
                                         name="control"
                                         onChange={[Function]}
-                                      >
-                                        <WithStyles(ForwardRef(SwitchBase))
+                                      />
+                                    }
+                                    key=".0"
+                                    label="Control"
+                                  >
+                                    <ForwardRef(FormControlLabel)
+                                      classes={
+                                        Object {
+                                          "disabled": "PodBrowser-disabled",
+                                          "label": "PodBrowser-label PodBrowser-label",
+                                          "labelPlacementBottom": "PodBrowser-labelPlacementBottom",
+                                          "labelPlacementStart": "PodBrowser-labelPlacementStart",
+                                          "labelPlacementTop": "PodBrowser-labelPlacementTop",
+                                          "root": "PodBrowser-root",
+                                        }
+                                      }
+                                      control={
+                                        <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
-                                          checkedIcon={<Memo />}
                                           classes={
                                             Object {
-                                              "checked": "PodBrowser-checked",
-                                              "disabled": "PodBrowser-disabled",
-                                              "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                              "root": "PodBrowser-checkbox",
                                             }
                                           }
-                                          color="secondary"
                                           disabled={false}
-                                          icon={<Memo />}
-                                          inputProps={
-                                            Object {
-                                              "data-indeterminate": false,
-                                            }
-                                          }
                                           name="control"
                                           onChange={[Function]}
-                                          type="checkbox"
+                                        />
+                                      }
+                                      label="Control"
+                                    >
+                                      <label
+                                        className="PodBrowser-root"
+                                      >
+                                        <WithStyles(ForwardRef(Checkbox))
+                                          checked={false}
+                                          classes={
+                                            Object {
+                                              "root": "PodBrowser-checkbox",
+                                            }
+                                          }
+                                          disabled={false}
+                                          name="control"
+                                          onChange={[Function]}
                                         >
-                                          <ForwardRef(SwitchBase)
+                                          <ForwardRef(Checkbox)
                                             checked={false}
-                                            checkedIcon={<Memo />}
                                             classes={
                                               Object {
-                                                "checked": "PodBrowser-checked PodBrowser-checked",
-                                                "disabled": "PodBrowser-disabled PodBrowser-disabled",
-                                                "input": "PodBrowser-input",
-                                                "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                "checked": "PodBrowser-checked",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "disabled": "PodBrowser-disabled",
+                                                "indeterminate": "PodBrowser-indeterminate",
+                                                "root": "PodBrowser-root PodBrowser-checkbox",
                                               }
                                             }
-                                            color="secondary"
                                             disabled={false}
-                                            icon={<Memo />}
-                                            inputProps={
-                                              Object {
-                                                "data-indeterminate": false,
-                                              }
-                                            }
                                             name="control"
                                             onChange={[Function]}
-                                            type="checkbox"
                                           >
-                                            <WithStyles(ForwardRef(IconButton))
-                                              className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                            <WithStyles(ForwardRef(SwitchBase))
+                                              checked={false}
+                                              checkedIcon={<Memo />}
+                                              classes={
+                                                Object {
+                                                  "checked": "PodBrowser-checked",
+                                                  "disabled": "PodBrowser-disabled",
+                                                  "root": "PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
+                                                }
+                                              }
                                               color="secondary"
-                                              component="span"
                                               disabled={false}
-                                              onBlur={[Function]}
-                                              onFocus={[Function]}
-                                              tabIndex={null}
+                                              icon={<Memo />}
+                                              inputProps={
+                                                Object {
+                                                  "data-indeterminate": false,
+                                                }
+                                              }
+                                              name="control"
+                                              onChange={[Function]}
+                                              type="checkbox"
                                             >
-                                              <ForwardRef(IconButton)
-                                                className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                              <ForwardRef(SwitchBase)
+                                                checked={false}
+                                                checkedIcon={<Memo />}
                                                 classes={
                                                   Object {
-                                                    "colorInherit": "PodBrowser-colorInherit",
-                                                    "colorPrimary": "PodBrowser-colorPrimary",
-                                                    "colorSecondary": "PodBrowser-colorSecondary",
-                                                    "disabled": "PodBrowser-disabled",
-                                                    "edgeEnd": "PodBrowser-edgeEnd",
-                                                    "edgeStart": "PodBrowser-edgeStart",
-                                                    "label": "PodBrowser-label",
-                                                    "root": "PodBrowser-root",
-                                                    "sizeSmall": "PodBrowser-sizeSmall",
+                                                    "checked": "PodBrowser-checked PodBrowser-checked",
+                                                    "disabled": "PodBrowser-disabled PodBrowser-disabled",
+                                                    "input": "PodBrowser-input",
+                                                    "root": "PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary",
                                                   }
                                                 }
                                                 color="secondary"
-                                                component="span"
                                                 disabled={false}
-                                                onBlur={[Function]}
-                                                onFocus={[Function]}
-                                                tabIndex={null}
+                                                icon={<Memo />}
+                                                inputProps={
+                                                  Object {
+                                                    "data-indeterminate": false,
+                                                  }
+                                                }
+                                                name="control"
+                                                onChange={[Function]}
+                                                type="checkbox"
                                               >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  centerRipple={true}
-                                                  className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                <WithStyles(ForwardRef(IconButton))
+                                                  className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
+                                                  color="secondary"
                                                   component="span"
                                                   disabled={false}
-                                                  focusRipple={true}
                                                   onBlur={[Function]}
                                                   onFocus={[Function]}
                                                   tabIndex={null}
                                                 >
-                                                  <ForwardRef(ButtonBase)
-                                                    centerRipple={true}
-                                                    className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                  <ForwardRef(IconButton)
+                                                    className="PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary"
                                                     classes={
                                                       Object {
+                                                        "colorInherit": "PodBrowser-colorInherit",
+                                                        "colorPrimary": "PodBrowser-colorPrimary",
+                                                        "colorSecondary": "PodBrowser-colorSecondary",
                                                         "disabled": "PodBrowser-disabled",
-                                                        "focusVisible": "PodBrowser-focusVisible",
+                                                        "edgeEnd": "PodBrowser-edgeEnd",
+                                                        "edgeStart": "PodBrowser-edgeStart",
+                                                        "label": "PodBrowser-label",
                                                         "root": "PodBrowser-root",
+                                                        "sizeSmall": "PodBrowser-sizeSmall",
                                                       }
                                                     }
+                                                    color="secondary"
                                                     component="span"
                                                     disabled={false}
-                                                    focusRipple={true}
                                                     onBlur={[Function]}
                                                     onFocus={[Function]}
                                                     tabIndex={null}
                                                   >
-                                                    <span
-                                                      aria-disabled={false}
-                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                    <WithStyles(ForwardRef(ButtonBase))
+                                                      centerRipple={true}
+                                                      className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                      component="span"
+                                                      disabled={false}
+                                                      focusRipple={true}
                                                       onBlur={[Function]}
-                                                      onDragLeave={[Function]}
                                                       onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
                                                       tabIndex={null}
                                                     >
-                                                      <span
-                                                        className="PodBrowser-label"
+                                                      <ForwardRef(ButtonBase)
+                                                        centerRipple={true}
+                                                        className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                        classes={
+                                                          Object {
+                                                            "disabled": "PodBrowser-disabled",
+                                                            "focusVisible": "PodBrowser-focusVisible",
+                                                            "root": "PodBrowser-root",
+                                                          }
+                                                        }
+                                                        component="span"
+                                                        disabled={false}
+                                                        focusRipple={true}
+                                                        onBlur={[Function]}
+                                                        onFocus={[Function]}
+                                                        tabIndex={null}
                                                       >
-                                                        <input
-                                                          checked={false}
-                                                          className="PodBrowser-input"
-                                                          data-indeterminate={false}
-                                                          disabled={false}
-                                                          name="control"
-                                                          onChange={[Function]}
-                                                          type="checkbox"
-                                                        />
-                                                        <ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                          <WithStyles(ForwardRef(SvgIcon))>
-                                                            <ForwardRef(SvgIcon)
+                                                        <span
+                                                          aria-disabled={false}
+                                                          className="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-checkbox PodBrowser-colorSecondary PodBrowser-colorSecondary"
+                                                          onBlur={[Function]}
+                                                          onDragLeave={[Function]}
+                                                          onFocus={[Function]}
+                                                          onKeyDown={[Function]}
+                                                          onKeyUp={[Function]}
+                                                          onMouseDown={[Function]}
+                                                          onMouseLeave={[Function]}
+                                                          onMouseUp={[Function]}
+                                                          onTouchEnd={[Function]}
+                                                          onTouchMove={[Function]}
+                                                          onTouchStart={[Function]}
+                                                          tabIndex={null}
+                                                        >
+                                                          <span
+                                                            className="PodBrowser-label"
+                                                          >
+                                                            <input
+                                                              checked={false}
+                                                              className="PodBrowser-input"
+                                                              data-indeterminate={false}
+                                                              disabled={false}
+                                                              name="control"
+                                                              onChange={[Function]}
+                                                              type="checkbox"
+                                                            />
+                                                            <ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                              <WithStyles(ForwardRef(SvgIcon))>
+                                                                <ForwardRef(SvgIcon)
+                                                                  classes={
+                                                                    Object {
+                                                                      "colorAction": "PodBrowser-colorAction",
+                                                                      "colorDisabled": "PodBrowser-colorDisabled",
+                                                                      "colorError": "PodBrowser-colorError",
+                                                                      "colorPrimary": "PodBrowser-colorPrimary",
+                                                                      "colorSecondary": "PodBrowser-colorSecondary",
+                                                                      "fontSizeInherit": "PodBrowser-fontSizeInherit",
+                                                                      "fontSizeLarge": "PodBrowser-fontSizeLarge",
+                                                                      "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                      "root": "PodBrowser-root",
+                                                                    }
+                                                                  }
+                                                                >
+                                                                  <svg
+                                                                    aria-hidden={true}
+                                                                    className="PodBrowser-root"
+                                                                    focusable="false"
+                                                                    viewBox="0 0 24 24"
+                                                                  >
+                                                                    <path
+                                                                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                    />
+                                                                  </svg>
+                                                                </ForwardRef(SvgIcon)>
+                                                              </WithStyles(ForwardRef(SvgIcon))>
+                                                            </ForwardRef(CheckBoxOutlineBlankIcon)>
+                                                          </span>
+                                                          <WithStyles(memo)
+                                                            center={true}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={true}
                                                               classes={
                                                                 Object {
-                                                                  "colorAction": "PodBrowser-colorAction",
-                                                                  "colorDisabled": "PodBrowser-colorDisabled",
-                                                                  "colorError": "PodBrowser-colorError",
-                                                                  "colorPrimary": "PodBrowser-colorPrimary",
-                                                                  "colorSecondary": "PodBrowser-colorSecondary",
-                                                                  "fontSizeInherit": "PodBrowser-fontSizeInherit",
-                                                                  "fontSizeLarge": "PodBrowser-fontSizeLarge",
-                                                                  "fontSizeSmall": "PodBrowser-fontSizeSmall",
+                                                                  "child": "PodBrowser-child",
+                                                                  "childLeaving": "PodBrowser-childLeaving",
+                                                                  "childPulsate": "PodBrowser-childPulsate",
+                                                                  "ripple": "PodBrowser-ripple",
+                                                                  "ripplePulsate": "PodBrowser-ripplePulsate",
+                                                                  "rippleVisible": "PodBrowser-rippleVisible",
                                                                   "root": "PodBrowser-root",
                                                                 }
                                                               }
                                                             >
-                                                              <svg
-                                                                aria-hidden={true}
+                                                              <span
                                                                 className="PodBrowser-root"
-                                                                focusable="false"
-                                                                viewBox="0 0 24 24"
                                                               >
-                                                                <path
-                                                                  d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
                                                                 />
-                                                              </svg>
-                                                            </ForwardRef(SvgIcon)>
-                                                          </WithStyles(ForwardRef(SvgIcon))>
-                                                        </ForwardRef(CheckBoxOutlineBlankIcon)>
-                                                      </span>
-                                                      <WithStyles(memo)
-                                                        center={true}
-                                                      >
-                                                        <ForwardRef(TouchRipple)
-                                                          center={true}
-                                                          classes={
-                                                            Object {
-                                                              "child": "PodBrowser-child",
-                                                              "childLeaving": "PodBrowser-childLeaving",
-                                                              "childPulsate": "PodBrowser-childPulsate",
-                                                              "ripple": "PodBrowser-ripple",
-                                                              "ripplePulsate": "PodBrowser-ripplePulsate",
-                                                              "rippleVisible": "PodBrowser-rippleVisible",
-                                                              "root": "PodBrowser-root",
-                                                            }
-                                                          }
-                                                        >
-                                                          <span
-                                                            className="PodBrowser-root"
-                                                          >
-                                                            <TransitionGroup
-                                                              childFactory={[Function]}
-                                                              component={null}
-                                                              exit={true}
-                                                            />
-                                                          </span>
-                                                        </ForwardRef(TouchRipple)>
-                                                      </WithStyles(memo)>
-                                                    </span>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(IconButton)>
-                                            </WithStyles(ForwardRef(IconButton))>
-                                          </ForwardRef(SwitchBase)>
-                                        </WithStyles(ForwardRef(SwitchBase))>
-                                      </ForwardRef(Checkbox)>
-                                    </WithStyles(ForwardRef(Checkbox))>
-                                    <WithStyles(ForwardRef(Typography))
-                                      className="PodBrowser-label PodBrowser-label"
-                                      component="span"
-                                    >
-                                      <ForwardRef(Typography)
-                                        className="PodBrowser-label PodBrowser-label"
-                                        classes={
-                                          Object {
-                                            "alignCenter": "PodBrowser-alignCenter",
-                                            "alignJustify": "PodBrowser-alignJustify",
-                                            "alignLeft": "PodBrowser-alignLeft",
-                                            "alignRight": "PodBrowser-alignRight",
-                                            "body1": "PodBrowser-body1",
-                                            "body2": "PodBrowser-body2",
-                                            "button": "PodBrowser-button",
-                                            "caption": "PodBrowser-caption",
-                                            "colorError": "PodBrowser-colorError",
-                                            "colorInherit": "PodBrowser-colorInherit",
-                                            "colorPrimary": "PodBrowser-colorPrimary",
-                                            "colorSecondary": "PodBrowser-colorSecondary",
-                                            "colorTextPrimary": "PodBrowser-colorTextPrimary",
-                                            "colorTextSecondary": "PodBrowser-colorTextSecondary",
-                                            "displayBlock": "PodBrowser-displayBlock",
-                                            "displayInline": "PodBrowser-displayInline",
-                                            "gutterBottom": "PodBrowser-gutterBottom",
-                                            "h1": "PodBrowser-h1",
-                                            "h2": "PodBrowser-h2",
-                                            "h3": "PodBrowser-h3",
-                                            "h4": "PodBrowser-h4",
-                                            "h5": "PodBrowser-h5",
-                                            "h6": "PodBrowser-h6",
-                                            "noWrap": "PodBrowser-noWrap",
-                                            "overline": "PodBrowser-overline",
-                                            "paragraph": "PodBrowser-paragraph",
-                                            "root": "PodBrowser-root",
-                                            "srOnly": "PodBrowser-srOnly",
-                                            "subtitle1": "PodBrowser-subtitle1",
-                                            "subtitle2": "PodBrowser-subtitle2",
-                                          }
-                                        }
-                                        component="span"
-                                      >
-                                        <span
-                                          className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </span>
+                                                      </ForwardRef(ButtonBase)>
+                                                    </WithStyles(ForwardRef(ButtonBase))>
+                                                  </ForwardRef(IconButton)>
+                                                </WithStyles(ForwardRef(IconButton))>
+                                              </ForwardRef(SwitchBase)>
+                                            </WithStyles(ForwardRef(SwitchBase))>
+                                          </ForwardRef(Checkbox)>
+                                        </WithStyles(ForwardRef(Checkbox))>
+                                        <WithStyles(ForwardRef(Typography))
+                                          className="PodBrowser-label PodBrowser-label"
+                                          component="span"
                                         >
-                                          Control
-                                        </span>
-                                      </ForwardRef(Typography)>
-                                    </WithStyles(ForwardRef(Typography))>
-                                  </label>
-                                </ForwardRef(FormControlLabel)>
-                              </WithStyles(ForwardRef(FormControlLabel))>
-                            </li>
-                          </ForwardRef(ListItem)>
-                        </WithStyles(ForwardRef(ListItem))>
-                      </PermissionCheckbox>
-                    </ul>
-                  </ForwardRef(List)>
-                </WithStyles(ForwardRef(List))>
-                <Button
-                  onClick={[Function]}
-                >
-                  <button
-                    className="PodBrowser-button"
-                    onClick={[Function]}
-                  >
-                    Save
-                  </button>
-                </Button>
-              </section>
-            </div>
-          </PermissionsForm>
+                                          <ForwardRef(Typography)
+                                            className="PodBrowser-label PodBrowser-label"
+                                            classes={
+                                              Object {
+                                                "alignCenter": "PodBrowser-alignCenter",
+                                                "alignJustify": "PodBrowser-alignJustify",
+                                                "alignLeft": "PodBrowser-alignLeft",
+                                                "alignRight": "PodBrowser-alignRight",
+                                                "body1": "PodBrowser-body1",
+                                                "body2": "PodBrowser-body2",
+                                                "button": "PodBrowser-button",
+                                                "caption": "PodBrowser-caption",
+                                                "colorError": "PodBrowser-colorError",
+                                                "colorInherit": "PodBrowser-colorInherit",
+                                                "colorPrimary": "PodBrowser-colorPrimary",
+                                                "colorSecondary": "PodBrowser-colorSecondary",
+                                                "colorTextPrimary": "PodBrowser-colorTextPrimary",
+                                                "colorTextSecondary": "PodBrowser-colorTextSecondary",
+                                                "displayBlock": "PodBrowser-displayBlock",
+                                                "displayInline": "PodBrowser-displayInline",
+                                                "gutterBottom": "PodBrowser-gutterBottom",
+                                                "h1": "PodBrowser-h1",
+                                                "h2": "PodBrowser-h2",
+                                                "h3": "PodBrowser-h3",
+                                                "h4": "PodBrowser-h4",
+                                                "h5": "PodBrowser-h5",
+                                                "h6": "PodBrowser-h6",
+                                                "noWrap": "PodBrowser-noWrap",
+                                                "overline": "PodBrowser-overline",
+                                                "paragraph": "PodBrowser-paragraph",
+                                                "root": "PodBrowser-root",
+                                                "srOnly": "PodBrowser-srOnly",
+                                                "subtitle1": "PodBrowser-subtitle1",
+                                                "subtitle2": "PodBrowser-subtitle2",
+                                              }
+                                            }
+                                            component="span"
+                                          >
+                                            <span
+                                              className="PodBrowser-root PodBrowser-label PodBrowser-label PodBrowser-body1"
+                                            >
+                                              Control
+                                            </span>
+                                          </ForwardRef(Typography)>
+                                        </WithStyles(ForwardRef(Typography))>
+                                      </label>
+                                    </ForwardRef(FormControlLabel)>
+                                  </WithStyles(ForwardRef(FormControlLabel))>
+                                </li>
+                              </ForwardRef(ListItem)>
+                            </WithStyles(ForwardRef(ListItem))>
+                          </PermissionCheckbox>
+                        </ul>
+                      </ForwardRef(List)>
+                    </WithStyles(ForwardRef(List))>
+                    <Button
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <button
+                        className="PodBrowser-button"
+                        onClick={[Function]}
+                        type="submit"
+                      >
+                        Save
+                      </button>
+                    </Button>
+                  </section>
+                </div>
+              </PermissionsForm>
+            </form>
+          </Form>
         </AgentAccess>
       </m>
     </ThemeProvider>

--- a/components/resourceDetails/resourceSharing/agentAccess/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/index.jsx
@@ -27,7 +27,7 @@ import { Avatar, createStyles, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { DatasetContext, useSession } from "@inrupt/solid-ui-react";
 import { getSourceUrl } from "@inrupt/solid-client";
-import { Button } from "@inrupt/prism-react-components";
+import { Button, Form } from "@inrupt/prism-react-components";
 import PermissionsForm from "../../../permissionsForm";
 import styles from "./styles";
 import { displayProfileName } from "../../../../src/solidClientHelpers/profile";
@@ -47,7 +47,8 @@ export function submitHandler(
   savePermissions,
   tempAccess
 ) {
-  return async () => {
+  return async (event) => {
+    event.preventDefault();
     if (authenticatedWebId === webId) {
       setOpen(dialogId);
     } else {
@@ -136,7 +137,7 @@ export default function AgentAccess({
     setAlertOpen
   );
 
-  const onClick = submitHandler(
+  const onSubmit = submitHandler(
     authenticatedWebId,
     webId,
     setOpen,
@@ -190,9 +191,13 @@ export default function AgentAccess({
       >
         {name}
       </Typography>
-      <PermissionsForm key={webId} acl={access} onChange={setTempAccess}>
-        <Button onClick={onClick}>Save</Button>
-      </PermissionsForm>
+      <Form onSubmit={(event) => onSubmit(event)}>
+        <PermissionsForm key={webId} acl={access} onChange={setTempAccess}>
+          <Button onClick={onSubmit} type="submit">
+            Save
+          </Button>
+        </PermissionsForm>
+      </Form>
     </>
   );
 }

--- a/components/resourceDetails/resourceSharing/agentAccess/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/index.test.jsx
@@ -112,18 +112,26 @@ describe("getDialogId", () => {
 });
 
 describe("submitHandler", () => {
+  let event;
+
+  beforeEach(() => {
+    event = { preventDefault: jest.fn() };
+  });
+
   test("user changes their own permissions", () => {
     const setOpen = jest.fn();
     const dialogId = "dialogId";
-    submitHandler(42, 42, setOpen, dialogId)();
+    submitHandler(42, 42, setOpen, dialogId)(event);
 
+    expect(event.preventDefault).toHaveBeenCalledWith();
     expect(setOpen).toHaveBeenCalledWith(dialogId);
   });
   test("user changes someone else's permissions", () => {
     const savePermissions = jest.fn();
     const tempAccess = "tempAccess";
-    submitHandler(42, 1337, null, null, savePermissions, tempAccess)();
+    submitHandler(42, 1337, null, null, savePermissions, tempAccess)(event);
 
+    expect(event.preventDefault).toHaveBeenCalledWith();
     expect(savePermissions).toHaveBeenCalledWith(tempAccess);
   });
 });


### PR DESCRIPTION
I've added onSubmit handling (and removed the existing onClick handling) for

- Create folder
- Managing existing access for an agent

There is a form that I haven't fixed yet, because I'm waiting for a fix in the Solid UI React. I'll create a separate PR for it later.

I also checked the following forms, which was already fixed:

- Pod Navigator
- Adding new contact

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).