### PR TITLE
adding a maxWidth for small screens

### DIFF
--- a/components/header/podIndicator/styles.js
+++ b/components/header/podIndicator/styles.js
@@ -38,7 +38,10 @@ const styles = (theme) =>
     },
     popover: {
       padding: theme.spacing(2, 2, 0),
-      width: 450,
+      maxWidth: "100vw",
+      [theme.breakpoints.up("sm")]: {
+        width: 450,
+      },
     },
   });
 


### PR DESCRIPTION
This PR fixes the pod navigator going off the screen when the keyboard comes up in iOS devices.

## To test:
**Note**: needs to be tested on an actual iOS device (not browser emulators).
- Open the Vercel preview in a mobile device (iPhone)
- Open the Pod Navigator
- Start typing
- Verify that the PodNavigator is still fully  visible and usable

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

