### PR TITLE
Add ellipsis cutoff to long names in podIndicator

### DIFF
--- a/components/header/podIndicator/__snapshots__/index.test.jsx.snap
+++ b/components/header/podIndicator/__snapshots__/index.test.jsx.snap
@@ -856,9 +856,14 @@ font-display: block;",
               data-testid="pod-indicator-prompt"
               id="pod-indicator-prompt"
               onClick={[Function]}
+              title="Alice"
               type="button"
             >
-              Alice
+              <span
+                className="PodBrowser-indicatorName"
+              >
+                Alice
+              </span>
             </button>
             <WithStyles(ForwardRef(Popover))
               anchorEl={null}
@@ -1781,9 +1786,14 @@ font-display: block;",
               data-testid="pod-indicator-prompt"
               id="pod-indicator-prompt"
               onClick={[Function]}
+              title="Bob"
               type="button"
             >
-              Bob
+              <span
+                className="PodBrowser-indicatorName"
+              >
+                Bob
+              </span>
             </button>
             <WithStyles(ForwardRef(Popover))
               anchorEl={null}

--- a/components/header/podIndicator/index.jsx
+++ b/components/header/podIndicator/index.jsx
@@ -86,8 +86,11 @@ export default function PodIndicator() {
             aria-describedby={id}
             onClick={handleClick}
             className={clsx(bem("button", "prompt"), classes.indicatorPrompt)}
+            title={profile ? profile.name : "Unknown"}
           >
-            {profile ? profile.name : "Unknown"}
+            <span className={classes.indicatorName}>
+              {profile ? profile.name : "Unknown"}
+            </span>
           </button>
         )}
         <Popover

--- a/components/header/podIndicator/styles.js
+++ b/components/header/podIndicator/styles.js
@@ -31,10 +31,16 @@ const styles = (theme) =>
       fontWeight: theme.typography.fontWeightMedium,
     },
     indicatorPrompt: {
+      display: "inline-flex",
       color: theme.palette.text.secondary,
       textTransform: "none",
       fontSize: "0.825rem",
       fontWeight: theme.typography.fontWeightRegular,
+    },
+    indicatorName: {
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      maxWidth: "200px",
     },
     popover: {
       padding: theme.spacing(2, 2, 0),

--- a/components/header/podIndicator/styles.js
+++ b/components/header/podIndicator/styles.js
@@ -40,7 +40,7 @@ const styles = (theme) =>
     indicatorName: {
       textOverflow: "ellipsis",
       overflow: "hidden",
-      maxWidth: "200px",
+      maxWidth: "12rem",
       whiteSpace: "nowrap",
     },
     popover: {

--- a/components/header/podIndicator/styles.js
+++ b/components/header/podIndicator/styles.js
@@ -41,6 +41,7 @@ const styles = (theme) =>
       textOverflow: "ellipsis",
       overflow: "hidden",
       maxWidth: "200px",
+      whiteSpace: "nowrap",
     },
     popover: {
       padding: theme.spacing(2, 2, 0),


### PR DESCRIPTION
- Adds max width to pod indicator name, with ellipsis cutoff
- Adds title attribute to button, with full name

Explored solutions wrapping the pod name — however, the headers in Prism are a fixed height 100px, which means there isn’t room for even a second line without shuffling things. _Could_ allow the header to grow vertically, but either it could do so indefinitely, or we’d probably want to truncate the name at some point anyway.