### PR TITLE
Cleaning up the use of encoded URIs

### DIFF
--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -21,11 +21,12 @@
 
 import React, { useContext, useState, useEffect } from "react";
 import T from "prop-types";
-import { overwriteFile } from "@inrupt/solid-client";
+import { getSourceUrl, overwriteFile } from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
 import PodLocationContext from "../../src/contexts/podLocationContext";
 import AlertContext from "../../src/contexts/alertContext";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
+import { joinPath } from "../../src/stringHelpers";
 
 const TESTCAFE_ID_UPLOAD_BUTTON = "upload-file-button";
 const TESTCAFE_ID_UPLOAD_INPUT = "upload-file-input";
@@ -43,7 +44,7 @@ export function handleSaveResource({
   return async (uploadedFile) => {
     try {
       const response = await overwriteFile(
-        encodeURI(currentUri) + encodeURIComponent(uploadedFile.name),
+        joinPath(currentUri, encodeURIComponent(uploadedFile.name)),
         uploadedFile,
         {
           type: uploadedFile.type,
@@ -56,7 +57,7 @@ export function handleSaveResource({
       setSeverity("success");
       setMessage(
         `Your file has been saved to ${decodeURIComponent(
-          response.internal_resourceInfo.sourceIri
+          getSourceUrl(response)
         )}`
       );
       setAlertOpen(true);

--- a/components/addFolderFlyout/index.jsx
+++ b/components/addFolderFlyout/index.jsx
@@ -29,6 +29,7 @@ import { Button, Form, Input } from "@inrupt/prism-react-components";
 import PodLocationContext from "../../src/contexts/podLocationContext";
 import AlertContext from "../../src/contexts/alertContext";
 import styles from "../addPermissionUsingWebIdButton/styles";
+import { joinPath } from "../../src/stringHelpers";
 
 const TESTCAFE_ID_ADD_FOLDER_BUTTON = "add-folder-button";
 const TESTCAFE_ID_FOLDER_NAME_INPUT = "folder-name-input";
@@ -53,7 +54,7 @@ export function determineFinalUrl(folders, currentUri, name) {
     }
   }
   determineFinalName();
-  return encodeURI(currentUri) + encodeURIComponent(currentName);
+  return joinPath(currentUri, encodeURIComponent(currentName));
 }
 
 export function handleFolderSubmit({

--- a/components/addFolderFlyout/index.test.jsx
+++ b/components/addFolderFlyout/index.test.jsx
@@ -160,7 +160,7 @@ describe("handleFolderSubmit", () => {
   });
 
   it("returns a handler that creates a new folder within a folder which has spaces in its name", async () => {
-    const currentUri = "https://www.mypodbrowser.com/First Folder/";
+    const currentUri = "https://www.mypodbrowser.com/First%20Folder/";
     const folders = [];
     const name = "Second Folder";
 

--- a/components/breadcrumbs/index.jsx
+++ b/components/breadcrumbs/index.jsx
@@ -51,7 +51,10 @@ export default function Breadcrumbs() {
   const crumbs = [
     { uri: `/resource/${encodeURIComponent(baseUri)}`, label: "All files" },
   ].concat(
-    uriParts.map((part, index) => ({ uri: resourceHref(index), label: part }))
+    uriParts.map((part, index) => ({
+      uri: resourceHref(index),
+      label: decodeURIComponent(part),
+    }))
   );
 
   return (

--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -51,7 +51,7 @@ export default function Container({ iri }) {
   useRedirectIfLoggedOut();
   const encodedIri = encodeURI(iri);
 
-  const { data: container, error } = useDataset(iri);
+  const { data: container, error } = useDataset(encodedIri);
   const { data: resourceIris, mutate } = useContainerResourceIris(encodedIri);
 
   const loading = !resourceIris || !container;

--- a/components/deleteResourceLink/index.jsx
+++ b/components/deleteResourceLink/index.jsx
@@ -42,12 +42,10 @@ export default function DeleteResourceLink({
   return (
     <DeleteLink
       confirmationTitle="Confirm Delete"
-      confirmationContent={`Are you sure you wish to delete ${decodeURIComponent(
-        name
-      )}?`}
+      confirmationContent={`Are you sure you wish to delete ${name}?`}
       dialogId={`delete-resource-${resourceIri}`}
       onDelete={handleDelete}
-      successMessage={`${decodeURIComponent(name)} was successfully deleted.`}
+      successMessage={`${name} was successfully deleted.`}
       {...linkProps}
     >
       Delete

--- a/components/header/index.test.jsx
+++ b/components/header/index.test.jsx
@@ -35,7 +35,7 @@ describe("Header", () => {
     beforeEach(() => {
       useRouter.mockImplementation(() => ({
         query: {
-          iri: encodeURIComponent("https://mypod.myhost.com"),
+          iri: "https://mypod.myhost.com",
         },
       }));
     });

--- a/components/pages/resource/__snapshots__/index.test.jsx.snap
+++ b/components/pages/resource/__snapshots__/index.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Index page Renders a logout button 1`] = `
 <PodLocationProvider
-  currentUri="https://mypod.myhost.com"
+  currentUri="https%3A%2F%2Fmypod.myhost.com"
 >
   <DetailsMenuProvider>
     <Container

--- a/components/pages/resource/index.jsx
+++ b/components/pages/resource/index.jsx
@@ -34,7 +34,7 @@ export default function Resource() {
   const decodedIri = decodeURIComponent(router.query.iri);
 
   return (
-    <PodLocationProvider currentUri={decodedIri}>
+    <PodLocationProvider currentUri={router.query.iri}>
       <DetailsMenuProvider>
         <ContainerView iri={decodedIri} />
       </DetailsMenuProvider>

--- a/components/resourceDrawer/index.jsx
+++ b/components/resourceDrawer/index.jsx
@@ -48,9 +48,8 @@ export default function ResourceDrawer({ onUpdate }) {
   const {
     query: { action, resourceIri },
   } = router;
-  const encodedResourceIri = encodeURI(resourceIri);
   const { data: resourceInfo, error: resourceError } = useResourceInfo(
-    encodedResourceIri
+    resourceIri
   );
   const { accessControl, error: accessControlError } = useAccessControl(
     resourceInfo,

--- a/src/hooks/useContainerResourceIris/index.js
+++ b/src/hooks/useContainerResourceIris/index.js
@@ -34,9 +34,9 @@ async function fetchContainerResourceIris(containerIri, fetch) {
 
 export const GET_CONTAINER_RESOURCE_IRIS = "getContainerResourceIris";
 export default function useContainerResourceIris(iri) {
-  const { session } = useSession();
+  const { fetch } = useSession();
 
   return useSWR([iri, GET_CONTAINER_RESOURCE_IRIS], () =>
-    fetchContainerResourceIris(iri, session.fetch)
+    fetchContainerResourceIris(iri, fetch)
   );
 }

--- a/src/hooks/usePodOwnerProfile/index.js
+++ b/src/hooks/usePodOwnerProfile/index.js
@@ -30,8 +30,8 @@ export default function usePodOwnerProfile() {
   const [profile, setProfile] = useState();
   const [error, setError] = useState();
   const router = useRouter();
-  const decodedResourceUri = decodeURIComponent(router.query.iri);
-  const podRoot = usePodRootUri(decodedResourceUri, null);
+  // const decodedResourceUri = decodeURIComponent(router.query.iri);
+  const podRoot = usePodRootUri(router.query.iri, null);
   const profileIri = podRoot && joinPath(podRoot, "profile/card#me"); // we won't need to do this once ownership is available
   const { data: authProfile, error: authError } = useAuthenticatedProfile();
   const { data: ownerProfile, error: ownerError } = useFetchProfile(profileIri);

--- a/src/hooks/usePodOwnerProfile/index.test.jsx
+++ b/src/hooks/usePodOwnerProfile/index.test.jsx
@@ -59,7 +59,7 @@ describe("usePodOwnerProfile", () => {
 
   it("returns the user profile for the Pod if iri is given in router", () => {
     RouterFns.useRouter.mockReturnValue({
-      query: { iri: encodeURIComponent(resourceUrl) },
+      query: { iri: resourceUrl },
     });
     const { result } = renderHook(() => usePodOwnerProfile());
     expect(result.current.profile).toEqual(userProfile);
@@ -80,7 +80,7 @@ describe("usePodOwnerProfile", () => {
       data: authProfileWithStorageProfile,
     });
     RouterFns.useRouter.mockReturnValue({
-      query: { iri: encodeURIComponent(resourceUrl) },
+      query: { iri: resourceUrl },
     });
     const { result } = renderHook(() => usePodOwnerProfile());
     expect(result.current.profile).toEqual(authProfileWithStorageProfile);


### PR DESCRIPTION
This PR fixes bug: Various functions involving files and folders with special characters:

- Folders with special characters in name
  - Creating
  - Navigating to
  - Deleting
- Files with special characters in name
  - Uploading
  - Opening drawer for resource
  - Deleting

## Testing:

I've been using the following list when creating new folders:

- -initial-colon-final-
- :initial:colon:final:
- before[between]after
- colon:medial
- coma,comma
- LeHégaret
- movie@11
- now two spaces
- one space
- per%cent

I've also used files with corresponding names, except that colons are replaced with dashes. I've attached a ZIP file with the files included.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
[files-with-problematic-characters.zip](https://github.com/inrupt/pod-browser/files/5430617/files-with-problematic-characters.zip)

