### PR TITLE
Add name as alt text for contact avatar

### DIFF
--- a/components/contactsList/__snapshots__/index.test.jsx.snap
+++ b/components/contactsList/__snapshots__/index.test.jsx.snap
@@ -10195,12 +10195,12 @@ font-display: block;",
                                       }
                                     >
                                       <WithStyles(ForwardRef(Avatar))
-                                        alt="Contact avatar"
+                                        alt="Alice"
                                         className="PodBrowser-avatar"
                                         src={null}
                                       >
                                         <ForwardRef(Avatar)
-                                          alt="Contact avatar"
+                                          alt="Alice"
                                           className="PodBrowser-avatar"
                                           classes={
                                             Object {

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -170,11 +170,11 @@ function ContactsList() {
             property={hasPhotoPredicate}
             header=""
             datatype="url"
-            body={({ value }) => {
+            body={({ value, row }) => {
               return (
                 <Avatar
                   className={bem("avatar")}
-                  alt="Contact avatar"
+                  alt={row.values.col1 || "Contact avatar"}
                   src={value}
                 />
               );


### PR DESCRIPTION
- Adds name as alt text for contact avatar
- Descriptive alt text means fallback image used by Material UI Avatar is appropriate
- Leaves alt as "Contact avatar" when name value is missing