### PR TITLE
Fix: pass client name in authOptions to Login button

### DIFF
--- a/components/login/__snapshots__/index.test.jsx.snap
+++ b/components/login/__snapshots__/index.test.jsx.snap
@@ -1715,7 +1715,7 @@ font-display: block;",
                     <L
                       authOptions={
                         Object {
-                          "clientName": "Pod Browser",
+                          "clientName": "Inrupt PodBrowser",
                         }
                       }
                       oidcIssuer="https://inrupt.net"

--- a/components/login/__snapshots__/index.test.jsx.snap
+++ b/components/login/__snapshots__/index.test.jsx.snap
@@ -1713,6 +1713,11 @@ font-display: block;",
                       </ForwardRef(Autocomplete)>
                     </WithStyles(ForwardRef(Autocomplete))>
                     <L
+                      authOptions={
+                        Object {
+                          "clientName": "Pod Browser",
+                        }
+                      }
                       oidcIssuer="https://inrupt.net"
                       redirectUrl="http://localhost/"
                     >

--- a/components/login/provider/__snapshots__/index.test.jsx.snap
+++ b/components/login/provider/__snapshots__/index.test.jsx.snap
@@ -1711,7 +1711,7 @@ font-display: block;",
                 <L
                   authOptions={
                     Object {
-                      "clientName": "Pod Browser",
+                      "clientName": "Inrupt PodBrowser",
                     }
                   }
                   oidcIssuer="https://inrupt.net"

--- a/components/login/provider/__snapshots__/index.test.jsx.snap
+++ b/components/login/provider/__snapshots__/index.test.jsx.snap
@@ -1709,6 +1709,11 @@ font-display: block;",
                   </ForwardRef(Autocomplete)>
                 </WithStyles(ForwardRef(Autocomplete))>
                 <L
+                  authOptions={
+                    Object {
+                      "clientName": "Pod Browser",
+                    }
+                  }
                   oidcIssuer="https://inrupt.net"
                 >
                   <div

--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -45,7 +45,9 @@ export default function Provider() {
   const onProviderChange = (e, newValue) => {
     setProviderIri(newValue);
   };
-
+  const authOptions = {
+    clientName: "Pod Browser",
+  };
   /* eslint react/jsx-props-no-spreading: 0 */
 
   return (
@@ -74,6 +76,7 @@ export default function Provider() {
         <LoginButton
           oidcIssuer={providerIri}
           redirectUrl={generateRedirectUrl("")}
+          authOptions={authOptions}
         >
           <button
             data-testid={TESTCAFE_ID_LOGIN_BUTTON}

--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -46,7 +46,7 @@ export default function Provider() {
     setProviderIri(newValue);
   };
   const authOptions = {
-    clientName: "Pod Browser",
+    clientName: "Inrupt PodBrowser",
   };
   /* eslint react/jsx-props-no-spreading: 0 */
 

--- a/components/pages/login/__snapshots__/index.test.jsx.snap
+++ b/components/pages/login/__snapshots__/index.test.jsx.snap
@@ -1725,6 +1725,11 @@ font-display: block;",
                             </ForwardRef(Autocomplete)>
                           </WithStyles(ForwardRef(Autocomplete))>
                           <L
+                            authOptions={
+                              Object {
+                                "clientName": "Pod Browser",
+                              }
+                            }
                             oidcIssuer="https://inrupt.net"
                             redirectUrl="http://localhost/"
                           >

--- a/components/pages/login/__snapshots__/index.test.jsx.snap
+++ b/components/pages/login/__snapshots__/index.test.jsx.snap
@@ -1727,7 +1727,7 @@ font-display: block;",
                           <L
                             authOptions={
                               Object {
-                                "clientName": "Pod Browser",
+                                "clientName": "Inrupt PodBrowser",
                               }
                             }
                             oidcIssuer="https://inrupt.net"


### PR DESCRIPTION
This PR fixes:
 - Random client id displayed instead of client name in client registration requests

## To test:
- login with ESS
- verify that "Pod Browser" is now displayed instead of randomly generate client id (see screenshot below)

![image](https://user-images.githubusercontent.com/28412960/97557406-06599b00-19db-11eb-94f2-2956b88a857f.png)


- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
