### PR TITLE
Fix: filter bookmarks by type

### DIFF
--- a/components/bookmarksList/index.jsx
+++ b/components/bookmarksList/index.jsx
@@ -30,15 +30,18 @@ import {
   Table as PrismTable,
 } from "@inrupt/prism-react-components";
 import { Table, TableColumn } from "@inrupt/solid-ui-react";
-import { getThingAll } from "@inrupt/solid-client";
-import { dct } from "rdf-namespaces";
+import { getThingAll, getUrl } from "@inrupt/solid-client";
+import { dct, rdf } from "rdf-namespaces";
 import BookmarksContext from "../../src/contexts/bookmarksContext";
 import Bookmark from "../bookmark";
 import ResourceLink from "../resourceLink";
 import SortedTableCarat from "../sortedTableCarat";
 import Spinner from "../spinner";
 import styles from "./styles";
-import { RECALLS_PROPERTY_IRI } from "../../src/solidClientHelpers/bookmarks";
+import {
+  RECALLS_PROPERTY_IRI,
+  BOOKMARK_TYPE_IRI,
+} from "../../src/solidClientHelpers/bookmarks";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
@@ -71,13 +74,14 @@ function BookmarksList() {
 
   if (isLoading) return <Spinner />;
   const { dataset } = bookmarks;
-  const bookmarksList = getThingAll(dataset).map((b) => {
-    return {
-      thing: b,
-      dataset,
-    };
-  });
-
+  const bookmarksList = getThingAll(dataset)
+    .filter((b) => getUrl(b, rdf.type) === BOOKMARK_TYPE_IRI)
+    .map((b) => {
+      return {
+        thing: b,
+        dataset,
+      };
+    });
   return (
     <>
       <PageHeader title="Bookmarks">


### PR DESCRIPTION
This PR fixes blank bookmark added to ESS pods.

The ESS server injects a triple with the type of resource in the `index.ttl` which the table was trying to render as a bookmark. This PR fixes that by filtering by type before creating the bookmark array in order to make sure we only have bookmarks.

## To test:
- Log in with https://broker.pod.inrupt.com
- Verify that there is no longer a blank bookmark added

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

