### PR TITLE
Fix: add Profile link to hamburger menu in mobile

### DIFF
--- a/components/header/menuDrawer/index.jsx
+++ b/components/header/menuDrawer/index.jsx
@@ -95,18 +95,36 @@ export default function MenuDrawer() {
             );
           })}
           <Divider />
-          <LogOutButton
-            className={bem("header-banner__user-menu-item-trigger")}
-          >
-            <span
+          <ListItem button key="profile" onClick={handleDrawerClose}>
+            <Link href="/profile" replace>
+              <span
+                className={clsx(
+                  bem("menu-drawer-item"),
+                  bem("menu-drawer-item__text"),
+                  bem("menu-drawer-item__link")
+                )}
+              >
+                Profile
+              </span>
+            </Link>
+          </ListItem>
+          <ListItem button key="logout" onClick={handleDrawerClose}>
+            <LogOutButton
               className={clsx(
-                bem("menu-drawer-item__text", "menu-drawer-item__link"),
-                bem("menu-drawer-item__link")
+                bem("header-banner__user-menu-item-trigger"),
+                bem("menu-drawer-item")
               )}
             >
-              Log out
-            </span>
-          </LogOutButton>
+              <span
+                className={clsx(
+                  bem("menu-drawer-item__text"),
+                  bem("menu-drawer-item__link")
+                )}
+              >
+                Log out
+              </span>
+            </LogOutButton>
+          </ListItem>
         </List>
       </Drawer>
     </div>

--- a/components/header/menuDrawer/index.jsx
+++ b/components/header/menuDrawer/index.jsx
@@ -97,7 +97,7 @@ export default function MenuDrawer() {
           <Divider />
           <ListItem button key="profile" onClick={handleDrawerClose}>
             <Link href="/profile" replace>
-              <span
+              <a
                 className={clsx(
                   bem("menu-drawer-item"),
                   bem("menu-drawer-item__text"),
@@ -105,7 +105,7 @@ export default function MenuDrawer() {
                 )}
               >
                 Profile
-              </span>
+              </a>
             </Link>
           </ListItem>
           <ListItem button key="logout" onClick={handleDrawerClose}>

--- a/components/header/menuDrawer/styles.js
+++ b/components/header/menuDrawer/styles.js
@@ -28,6 +28,9 @@ const styles = (theme) =>
       ...theme.icons.iconColor(theme.palette.primary.text),
       fontSize: theme.typography.h1.fontSize,
     },
+    "menu-drawer-item": {
+      padding: theme.spacing(1),
+    },
     "menu-drawer-item__text": {
       fontSize: theme.typography.body.fontSize,
       fontWeight: theme.typography.fontWeightLight,

--- a/components/header/menuDrawer/styles.js
+++ b/components/header/menuDrawer/styles.js
@@ -37,6 +37,9 @@ const styles = (theme) =>
     },
     "menu-drawer-item__link": {
       "text-decoration": "underline",
+      "&:visited": {
+        color: "inherit",
+      },
     },
     drawerContainer: {
       borderRadius: `0 0 


### PR DESCRIPTION
This PR adds the Profile link to the hamburger menu in mobile.

Matched the link style to the Logout link since we don't have "Profile" in the design, and made sense to put it after the divider along with Logout since it's part of the user menu items.

## Screenshot

![image](https://user-images.githubusercontent.com/28412960/97590324-c5737d80-19fe-11eb-9e44-d9a037c41b7c.png)


- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
