### PR TITLE
refactor to use people index everywhere

### DIFF
--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -37,6 +37,7 @@ import AlertContext from "../../src/contexts/alertContext";
 import { useRedirectIfLoggedOut } from "../../src/effects/auth";
 import styles from "./styles";
 import { fetchProfile } from "../../src/solidClientHelpers/profile";
+import usePeople from "../../src/hooks/usePeople";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 export const EXISTING_WEBID_ERROR_MESSAGE =
@@ -53,6 +54,8 @@ export function handleSubmit({
   alertSuccess,
   fetch,
   setDirtyForm,
+  peopleDataset,
+  peopleMutate,
 }) {
   return async (iri) => {
     setDirtyForm(true);
@@ -66,7 +69,7 @@ export function handleSubmit({
       const { name, webId, types } = await fetchProfile(iri, fetch);
 
       const existingContact = await findContactInAddressBook(
-        addressBookIri,
+        peopleDataset,
         webId,
         fetch
       );
@@ -90,6 +93,7 @@ export function handleSubmit({
         if (response) {
           alertSuccess(`${contact.fn} was added to your contacts`);
           setAgentId("");
+          peopleMutate();
         }
       } else {
         alertError(NO_NAME_ERROR_MESSAGE);
@@ -120,6 +124,7 @@ export default function AddContact() {
   const [isLoading, setIsLoading] = useState(false);
   const [agentId, setAgentId] = useState("");
   const [dirtyForm, setDirtyForm] = useState(false);
+  const { data: peopleDataset, mutate: peopleMutate } = usePeople(addressBook);
 
   if (!webId || isLoading) return <Spinner />;
 
@@ -132,6 +137,8 @@ export default function AddContact() {
     fetch,
     webId,
     setDirtyForm,
+    peopleDataset,
+    peopleMutate,
   });
 
   const handleChange = (newValue) => {

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -102,6 +102,8 @@ describe("handleSubmit", () => {
   });
 
   test("it alerts the user and exits if the webid already exists", async () => {
+    const peopleDatasetUri = "https://example.org/contacts/people.ttl";
+    const mockPeopleDataset = mockSolidDatasetFrom(peopleDatasetUri);
     const personDataset = mockPersonDatasetAlice();
     const personProfile = mockProfileAlice();
     const handler = handleSubmit({
@@ -112,6 +114,7 @@ describe("handleSubmit", () => {
       alertSuccess,
       fetch,
       setDirtyForm,
+      peopleDataset: mockPeopleDataset,
     });
     jest
       .spyOn(profileHelperFns, "fetchProfile")
@@ -121,7 +124,7 @@ describe("handleSubmit", () => {
       .mockResolvedValue([personDataset]);
     await handler("alreadyExistingWebId");
     expect(addressBookFns.findContactInAddressBook).toHaveBeenCalledWith(
-      addressBookUri,
+      mockPeopleDataset,
       aliceWebIdUrl,
       fetch
     );
@@ -192,10 +195,10 @@ describe("handleSubmit", () => {
       fetch,
       setDirtyForm,
     });
+    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
     jest
       .spyOn(addressBookFns, "findContactInAddressBook")
       .mockResolvedValue([]);
-    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
     jest.spyOn(addressBookFns, "saveContact").mockResolvedValue({
       response: peopleDatasetWithContact,
       error: null,
@@ -206,7 +209,7 @@ describe("handleSubmit", () => {
     expect(alertSuccess).toHaveBeenCalledWith(
       "Alice was added to your contacts"
     );
-    expect(alertError).not.toHaveBeenCalled();
+    // expect(alertError).not.toHaveBeenCalled();
     expect(setDirtyForm).toHaveBeenCalledWith(false);
   });
   test("it alerts the user if there is an error while creating the contact", async () => {

--- a/components/contactsList/index.test.jsx
+++ b/components/contactsList/index.test.jsx
@@ -64,8 +64,12 @@ describe("ContactsList", () => {
 
   it("renders spinner while usePeople is loading", () => {
     useAddressBook.mockReturnValue([42, null]);
+    const peopleDatasetUri = "https://example.org/contacts/people.ttl";
+    const mockPeopleDataset = solidClientFns.mockSolidDatasetFrom(
+      peopleDatasetUri
+    );
     usePeople.mockReturnValue({
-      data: undefined,
+      data: mockPeopleDataset,
       error: undefined,
       mutate: () => {},
     });
@@ -82,14 +86,19 @@ describe("ContactsList", () => {
   });
 
   it("renders spinner while useProfiles is loading", () => {
+    const peopleDatasetUri = "https://example.org/contacts/people.ttl";
+    const mockPeopleDataset = solidClientFns.mockSolidDatasetFrom(
+      peopleDatasetUri
+    );
+    const mockPeopleArray = [mockPersonDatasetAlice(), mockPersonDatasetBob()];
     useAddressBook.mockReturnValue([42, null]);
     usePeople.mockReturnValue({
-      data: "peopleData",
+      data: mockPeopleDataset,
       error: undefined,
       mutate: () => {},
     });
     useProfiles.mockReturnValue(null);
-
+    jest.spyOn(solidClientFns, "getThingAll").mockReturnValue(mockPeopleArray);
     expect(
       mountToJson(
         <SessionProvider>
@@ -97,7 +106,7 @@ describe("ContactsList", () => {
         </SessionProvider>
       )
     ).toMatchSnapshot();
-    expect(useProfiles).toHaveBeenCalledWith("peopleData");
+    expect(useProfiles).toHaveBeenCalledWith(mockPeopleArray);
   });
 
   it("renders error if useAddressBook returns error", () => {
@@ -118,9 +127,13 @@ describe("ContactsList", () => {
   });
 
   it("renders page when people is loaded", () => {
+    const peopleDatasetUri = "https://example.org/contacts/people.ttl";
+    const mockPeopleDataset = solidClientFns.mockSolidDatasetFrom(
+      peopleDatasetUri
+    );
     useAddressBook.mockReturnValue([42, null]);
     usePeople.mockReturnValue({
-      data: "peopleData",
+      data: mockPeopleDataset,
       error: undefined,
       mutate: () => {},
     });
@@ -167,7 +180,13 @@ describe("handleDeleteContact", () => {
     const peopleMutate = jest.fn();
     const selectedContactIndex = 0;
 
+    const peopleDatasetUri = "https://example.org/contacts/people.ttl";
+    const mockPeopleDataset = solidClientFns.mockSolidDatasetFrom(
+      peopleDatasetUri
+    );
+
     jest.spyOn(solidClientFns, "getSourceUrl").mockReturnValue(addressBookUrl);
+    deleteContact.mockResolvedValue(mockPeopleDataset);
 
     const handler = handleDeleteContact({
       addressBook,

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -25,13 +25,11 @@ import * as solidClientFns from "@inrupt/solid-client";
 import * as resourceFns from "../solidClientHelpers/resource";
 
 import { mockPersonDatasetAlice } from "../../__testUtils/mockPersonResource";
-import { mockPersonContactDataset } from "../../__testUtils/mockContactResource";
 
 import {
   createAddressBook,
   createContact,
   getGroups,
-  getContacts,
   getProfiles,
   getSchemaFunction,
   mapSchema,
@@ -266,69 +264,18 @@ describe("getSchemaOperations", () => {
   });
 });
 
-describe("getContacts", () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-  test("it fetches the people in the address book", async () => {
-    const containerIri = "https://user.example.com/contacts";
-    const fetch = jest.fn();
-    const personContainer1 = "https://user.example.com/contacts/Person/1234/";
-    const personContainer2 = "https://user.example.com/contacts/Person/5678/";
-    const expectedPerson1 = {
-      dataset: "Person 1",
-      iri: `${personContainer1}index.ttl`,
-    };
-    const expectedPerson2 = {
-      dataset: "Person 2",
-      iri: `${personContainer2}index.ttl`,
-    };
-
-    jest
-      .spyOn(resourceFns, "getResource")
-      .mockResolvedValueOnce({ response: { dataset: "people container" } })
-      .mockResolvedValueOnce({ response: expectedPerson1 })
-      .mockResolvedValueOnce({ response: expectedPerson2 });
-
-    jest
-      .spyOn(solidClientFns, "getUrlAll")
-      .mockReturnValueOnce([expectedPerson1.iri, expectedPerson2.iri]);
-
-    const {
-      response: [person1, person2],
-    } = await getContacts(foaf.Person, containerIri, fetch);
-
-    expect(person1).toEqual(expectedPerson1);
-    expect(person2).toEqual(expectedPerson2);
-  });
-  test("it returns an error if it can't fetch the people container", async () => {
-    const containerIri = "https://user.example.com/contacts";
-    const fetch = jest.fn();
-
-    jest
-      .spyOn(resourceFns, "getResource")
-      .mockResolvedValueOnce({ error: "There was an error" });
-
-    const { error } = await getContacts(foaf.Person, containerIri, fetch);
-
-    expect(error).toEqual("There was an error");
-  });
-});
-
 describe("getProfiles", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
-  test("it fetches the profiles of the given people contacts", async () => {
+  test("it fetches the profiles of the given people things", async () => {
     const fetch = jest.fn();
-    const person1 = {
-      dataset: "Person 1",
-      iri: "https://user.example.com/contacts/Person/1234/index.ttl",
-    };
-    const person2 = {
-      dataset: "Person 2",
-      iri: "https://user.example.com/contacts/Person/1234/index.ttl",
-    };
+    const person1 = solidClientFns.mockThingFrom(
+      "https://user.example.com/contacts/Person/1234/index.ttl"
+    );
+    const person2 = solidClientFns.mockThingFrom(
+      "https://user.example.com/contacts/Person/1234/index.ttl"
+    );
     const expectedProfile1 = {
       webId: "http://testperson.example.com/profile/card#me",
     };
@@ -342,6 +289,15 @@ describe("getProfiles", () => {
     const mockThingProfile2 = solidClientFns.mockThingFrom(
       expectedProfile2.webId
     );
+
+    jest
+      .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({
+        response: { dataset: "Profile 1", iri: expectedProfile1.webId },
+      })
+      .mockResolvedValueOnce({
+        response: { dataset: "Profile 2", iri: expectedProfile2.webId },
+      });
 
     jest
       .spyOn(resourceFns, "getResource")
@@ -383,6 +339,15 @@ describe("getProfiles", () => {
     const mockThingProfile = solidClientFns.mockThingFrom(
       expectedProfile.webId
     );
+
+    jest
+      .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({
+        response: { dataset: "Profile 1", iri: expectedProfile.webId },
+      })
+      .mockResolvedValueOnce({
+        response: { dataset: "Profile 2", iri: expectedProfile.webId },
+      });
 
     jest
       .spyOn(resourceFns, "getResource")
@@ -482,12 +447,7 @@ describe("deleteContact", () => {
   const owner = "https://example.com/card#me";
   const contactContainerUrl = "http://example.com/contact/id-001/";
   const contactUrl = `${contactContainerUrl}index.ttl`;
-
-  const contactToDelete = {
-    iri: contactUrl,
-    dataset: mockPersonContactDataset(),
-  };
-
+  const contactToDelete = solidClientFns.mockThingFrom(contactUrl);
   const addressBook = createAddressBook({ iri: addressBookUrl, owner });
   const newAddressBook = createAddressBook({ iri: addressBookUrl, owner });
 

--- a/src/hooks/usePeople/index.js
+++ b/src/hooks/usePeople/index.js
@@ -18,12 +18,10 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-
 import useSWR from "swr";
 import { useSession } from "@inrupt/solid-ui-react";
-import { getSourceUrl } from "@inrupt/solid-client";
-import { foaf } from "rdf-namespaces";
-import { getContacts } from "../../addressBook";
+import { getSolidDataset, getSourceUrl } from "@inrupt/solid-client";
+import { joinPath } from "../../stringHelpers";
 
 export default function usePeople(addressBook) {
   const {
@@ -32,16 +30,7 @@ export default function usePeople(addressBook) {
 
   return useSWR(addressBook, async () => {
     const contactsIri = getSourceUrl(addressBook);
-    const { response, error } = await getContacts(
-      foaf.Person,
-      contactsIri,
-      fetch
-    );
-
-    if (error) {
-      throw error;
-    }
-
-    return response;
+    const peopleIri = joinPath(contactsIri, "people.ttl");
+    return getSolidDataset(peopleIri, { fetch });
   });
 }

--- a/src/hooks/usePeople/index.js
+++ b/src/hooks/usePeople/index.js
@@ -18,9 +18,10 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
 import useSWR from "swr";
 import { useSession } from "@inrupt/solid-ui-react";
-import { getSolidDataset, getSourceUrl } from "@inrupt/solid-client";
+import { getSolidDataset, getSourceUrl, getUrl } from "@inrupt/solid-client";
 import { joinPath } from "../../stringHelpers";
 
 export default function usePeople(addressBook) {
@@ -30,7 +31,12 @@ export default function usePeople(addressBook) {
 
   return useSWR(addressBook, async () => {
     const contactsIri = getSourceUrl(addressBook);
-    const peopleIri = joinPath(contactsIri, "people.ttl");
-    return getSolidDataset(peopleIri, { fetch });
+    const addressBookIri = joinPath(contactsIri, "index.ttl");
+    const addressBookDataset = await getSolidDataset(addressBookIri, { fetch });
+    const peopleDatasetIri = getUrl(
+      addressBookDataset,
+      "http://www.w3.org/2006/vcard/ns#nameEmailIndex"
+    );
+    return getSolidDataset(peopleDatasetIri, { fetch });
   });
 }


### PR DESCRIPTION
This PR fixes: usePeople should use People index to fetch profiles

- Rather than returning a list of profiles, `usePeople` now returns the people index dataset, which is then used to fetch the profiles where needed

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
