### PR TITLE
Use foaf.name as fallback to vcard.fn

### DIFF
--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -83,7 +83,6 @@ function ContactsList() {
     addressBook
   );
   const profiles = useProfiles(people);
-  const formattedNamePredicate = vcard.fn;
   const hasPhotoPredicate = vcard.hasPhoto;
 
   const {
@@ -94,12 +93,21 @@ function ContactsList() {
   const [selectedContactName, setSelectedContactName] = useState("");
   const [selectedContactWebId, setSelectedContactWebId] = useState("");
 
+  const formattedNamePredicate =
+    [vcard.fn, foaf.name].find(
+      (prop) =>
+        selectedContactIndex &&
+        getStringNoLocale(people[selectedContactIndex].dataset, prop)
+    ) || vcard.fn;
+
   useEffect(() => {
     if (selectedContactIndex === null) return;
+
     const name = getStringNoLocale(
       people[selectedContactIndex].dataset,
       formattedNamePredicate
     );
+
     setSelectedContactName(name);
 
     const webId = getUrl(people[selectedContactIndex].dataset, foaf.openid);

--- a/components/profile/index.jsx
+++ b/components/profile/index.jsx
@@ -87,16 +87,6 @@ export function ProfileInfo({ editing }) {
       <hr />
 
       <Box mt={2}>
-        <Box>
-          <InputLabel>Name</InputLabel>
-          <Text
-            property={vcard.fn}
-            edit={editing}
-            autosave
-            inputProps={{ className: bem("input") }}
-          />
-        </Box>
-
         <Box mt={1}>
           <InputLabel>Role</InputLabel>
           <Text


### PR DESCRIPTION
In user profiles, "Show contact", and the contacts list, this uses vcard.fn and falls back to foaf.name if unavailable. Eventually, this code should be replaced with the ability to read a fallback from the react sdk.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).