### PR TITLE
Added data-testid to Add user with WebID (and checkboxes)

### DIFF
--- a/components/addPermissionUsingWebIdButton/__snapshots__/index.test.jsx.snap
+++ b/components/addPermissionUsingWebIdButton/__snapshots__/index.test.jsx.snap
@@ -857,6 +857,7 @@ font-display: block;",
           onLoading={[Function]}
         >
           <button
+            data-testid="permissions-add-user-with-webid-button"
             onClick={[Function]}
             type="button"
           >

--- a/components/addPermissionUsingWebIdButton/index.jsx
+++ b/components/addPermissionUsingWebIdButton/index.jsx
@@ -35,6 +35,8 @@ import styles from "./styles";
 import AccessControlContext from "../../src/contexts/accessControlContext";
 
 const POPOVER_ID = "AddPermissionWithWebId";
+const TESTCAFE_ID_ADD_USER_WITH_WEBID_BUTTON =
+  "permissions-add-user-with-webid-button";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
@@ -135,6 +137,7 @@ export default function AddPermissionUsingWebIdButton({
         type="button"
         {...buttonProps}
         onClick={handleClick}
+        data-testid={TESTCAFE_ID_ADD_USER_WITH_WEBID_BUTTON}
       >
         Add with WebId
       </button>

--- a/components/permissionsForm/__snapshots__/index.test.jsx.snap
+++ b/components/permissionsForm/__snapshots__/index.test.jsx.snap
@@ -1099,6 +1099,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-view"
                             key=".0"
                             label="View"
                           >
@@ -1126,10 +1127,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-view"
                               label="View"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-view"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -1474,6 +1477,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-edit"
                             key=".0"
                             label="Edit"
                           >
@@ -1501,10 +1505,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-edit"
                               label="Edit"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-edit"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -1849,6 +1855,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-append"
                             key=".0"
                             label="Append"
                           >
@@ -1876,10 +1883,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-append"
                               label="Append"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-append"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -2224,6 +2233,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-control"
                             key=".0"
                             label="Control"
                           >
@@ -2251,10 +2261,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-control"
                               label="Control"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-control"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -5398,6 +5410,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-view"
                             key=".0"
                             label="View"
                           >
@@ -5425,10 +5438,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-view"
                               label="View"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-view"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -5773,6 +5788,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-edit"
                             key=".0"
                             label="Edit"
                           >
@@ -5800,10 +5816,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-edit"
                               label="Edit"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-edit"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -6148,6 +6166,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-append"
                             key=".0"
                             label="Append"
                           >
@@ -6175,10 +6194,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-append"
                               label="Append"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-append"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={true}
@@ -6523,6 +6544,7 @@ font-display: block;",
                                 onChange={[Function]}
                               />
                             }
+                            data-testid="permission-checkbox-control"
                             key=".0"
                             label="Control"
                           >
@@ -6550,10 +6572,12 @@ font-display: block;",
                                   onChange={[Function]}
                                 />
                               }
+                              data-testid="permission-checkbox-control"
                               label="Control"
                             >
                               <label
                                 className="PodBrowser-root"
+                                data-testid="permission-checkbox-control"
                               >
                                 <WithStyles(ForwardRef(Checkbox))
                                   checked={false}

--- a/components/permissionsForm/permissionCheckbox/__snapshots__/index.test.jsx.snap
+++ b/components/permissionsForm/permissionCheckbox/__snapshots__/index.test.jsx.snap
@@ -890,6 +890,7 @@ font-display: block;",
                     onChange={[MockFunction]}
                   />
                 }
+                data-testid="permission-checkbox-read"
                 key=".0"
                 label="Read"
               >
@@ -917,10 +918,12 @@ font-display: block;",
                       onChange={[MockFunction]}
                     />
                   }
+                  data-testid="permission-checkbox-read"
                   label="Read"
                 >
                   <label
                     className="PodBrowser-root"
+                    data-testid="permission-checkbox-read"
                   >
                     <WithStyles(ForwardRef(Checkbox))
                       checked={true}

--- a/components/permissionsForm/permissionCheckbox/index.jsx
+++ b/components/permissionsForm/permissionCheckbox/index.jsx
@@ -30,6 +30,8 @@ import {
 } from "@material-ui/core";
 import styles from "../styles";
 
+const TESTCAFE_ID_PERMISSION_CHECKBOX = "permission-checkbox-";
+
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 function PermissionCheckbox({ value, label, disabled, onChange }) {
@@ -41,6 +43,7 @@ function PermissionCheckbox({ value, label, disabled, onChange }) {
     <ListItem className={classes.listItem}>
       <FormControlLabel
         classes={{ label: classes.label }}
+        data-testid={TESTCAFE_ID_PERMISSION_CHECKBOX + name}
         label={label}
         control={(
           <Checkbox

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -68,7 +68,7 @@ export default function ResourceDetails({ onDelete }) {
   const actionMenuBem = ActionMenu.useBem();
   const { accessControl } = useContext(AccessControlContext);
   const resourceIsContainer = isContainer(datasetUrl);
-  const showActions = accessControl || !resourceIsContainer;
+  const showActions = !!accessControl || !resourceIsContainer;
 
   const expandIcon = <ExpandMoreIcon />;
   return (

--- a/components/resourceDetails/resourceSharing/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/__snapshots__/index.test.jsx.snap
@@ -857,6 +857,7 @@ font-display: block;",
                 >
                   <button
                     className="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--prompt"
+                    data-testid="permissions-add-user-with-webid-button"
                     onClick={[Function]}
                     type="button"
                   >

--- a/components/resourceDetails/resourceSharing/agentAccess/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/__snapshots__/index.test.jsx.snap
@@ -1211,6 +1211,7 @@ font-display: block;",
                                         onChange={[Function]}
                                       />
                                     }
+                                    data-testid="permission-checkbox-view"
                                     key=".0"
                                     label="View"
                                   >
@@ -1238,10 +1239,12 @@ font-display: block;",
                                           onChange={[Function]}
                                         />
                                       }
+                                      data-testid="permission-checkbox-view"
                                       label="View"
                                     >
                                       <label
                                         className="PodBrowser-root"
+                                        data-testid="permission-checkbox-view"
                                       >
                                         <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
@@ -1586,6 +1589,7 @@ font-display: block;",
                                         onChange={[Function]}
                                       />
                                     }
+                                    data-testid="permission-checkbox-edit"
                                     key=".0"
                                     label="Edit"
                                   >
@@ -1613,10 +1617,12 @@ font-display: block;",
                                           onChange={[Function]}
                                         />
                                       }
+                                      data-testid="permission-checkbox-edit"
                                       label="Edit"
                                     >
                                       <label
                                         className="PodBrowser-root"
+                                        data-testid="permission-checkbox-edit"
                                       >
                                         <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
@@ -1961,6 +1967,7 @@ font-display: block;",
                                         onChange={[Function]}
                                       />
                                     }
+                                    data-testid="permission-checkbox-append"
                                     key=".0"
                                     label="Append"
                                   >
@@ -1988,10 +1995,12 @@ font-display: block;",
                                           onChange={[Function]}
                                         />
                                       }
+                                      data-testid="permission-checkbox-append"
                                       label="Append"
                                     >
                                       <label
                                         className="PodBrowser-root"
+                                        data-testid="permission-checkbox-append"
                                       >
                                         <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
@@ -2336,6 +2345,7 @@ font-display: block;",
                                         onChange={[Function]}
                                       />
                                     }
+                                    data-testid="permission-checkbox-control"
                                     key=".0"
                                     label="Control"
                                   >
@@ -2363,10 +2373,12 @@ font-display: block;",
                                           onChange={[Function]}
                                         />
                                       }
+                                      data-testid="permission-checkbox-control"
                                       label="Control"
                                     >
                                       <label
                                         className="PodBrowser-root"
+                                        data-testid="permission-checkbox-control"
                                       >
                                         <WithStyles(ForwardRef(Checkbox))
                                           checked={false}
@@ -3931,6 +3943,7 @@ font-display: block;",
                                             onChange={[Function]}
                                           />
                                         }
+                                        data-testid="permission-checkbox-view"
                                         key=".0"
                                         label="View"
                                       >
@@ -3958,10 +3971,12 @@ font-display: block;",
                                               onChange={[Function]}
                                             />
                                           }
+                                          data-testid="permission-checkbox-view"
                                           label="View"
                                         >
                                           <label
                                             className="PodBrowser-root"
+                                            data-testid="permission-checkbox-view"
                                           >
                                             <WithStyles(ForwardRef(Checkbox))
                                               checked={false}
@@ -4306,6 +4321,7 @@ font-display: block;",
                                             onChange={[Function]}
                                           />
                                         }
+                                        data-testid="permission-checkbox-edit"
                                         key=".0"
                                         label="Edit"
                                       >
@@ -4333,10 +4349,12 @@ font-display: block;",
                                               onChange={[Function]}
                                             />
                                           }
+                                          data-testid="permission-checkbox-edit"
                                           label="Edit"
                                         >
                                           <label
                                             className="PodBrowser-root"
+                                            data-testid="permission-checkbox-edit"
                                           >
                                             <WithStyles(ForwardRef(Checkbox))
                                               checked={false}
@@ -4681,6 +4699,7 @@ font-display: block;",
                                             onChange={[Function]}
                                           />
                                         }
+                                        data-testid="permission-checkbox-append"
                                         key=".0"
                                         label="Append"
                                       >
@@ -4708,10 +4727,12 @@ font-display: block;",
                                               onChange={[Function]}
                                             />
                                           }
+                                          data-testid="permission-checkbox-append"
                                           label="Append"
                                         >
                                           <label
                                             className="PodBrowser-root"
+                                            data-testid="permission-checkbox-append"
                                           >
                                             <WithStyles(ForwardRef(Checkbox))
                                               checked={false}
@@ -5056,6 +5077,7 @@ font-display: block;",
                                             onChange={[Function]}
                                           />
                                         }
+                                        data-testid="permission-checkbox-control"
                                         key=".0"
                                         label="Control"
                                       >
@@ -5083,10 +5105,12 @@ font-display: block;",
                                               onChange={[Function]}
                                             />
                                           }
+                                          data-testid="permission-checkbox-control"
                                           label="Control"
                                         >
                                           <label
                                             className="PodBrowser-root"
+                                            data-testid="permission-checkbox-control"
                                           >
                                             <WithStyles(ForwardRef(Checkbox))
                                               checked={false}

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -2375,6 +2375,7 @@ font-display: block;",
                                                                   >
                                                                     <button
                                                                       className="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--prompt"
+                                                                      data-testid="permissions-add-user-with-webid-button"
                                                                       onClick={[Function]}
                                                                       type="button"
                                                                     >
@@ -5210,6 +5211,7 @@ font-display: block;",
                                                               >
                                                                 <button
                                                                   className="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--prompt"
+                                                                  data-testid="permissions-add-user-with-webid-button"
                                                                   onClick={[Function]}
                                                                   type="button"
                                                                 >
@@ -8085,6 +8087,7 @@ font-display: block;",
                                                                   >
                                                                     <button
                                                                       className="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--prompt"
+                                                                      data-testid="permissions-add-user-with-webid-button"
                                                                       onClick={[Function]}
                                                                       type="button"
                                                                     >

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -984,23 +984,7 @@ font-display: block;",
                             </ForwardRef(Divider)>
                           </WithStyles(ForwardRef(Divider))>
                           <WithStyles(ForwardRef(Accordion))
-                            defaultExpanded={
-                              Object {
-                                "deleteFile": [MockFunction],
-                                "getPermissions": [MockFunction] {
-                                  "calls": Array [
-                                    Array [],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": Promise {},
-                                    },
-                                  ],
-                                },
-                                "savePermissionsForAgent": [MockFunction],
-                              }
-                            }
+                            defaultExpanded={true}
                           >
                             <ForwardRef(Accordion)
                               classes={
@@ -1011,23 +995,7 @@ font-display: block;",
                                   "rounded": "PodBrowser-rounded",
                                 }
                               }
-                              defaultExpanded={
-                                Object {
-                                  "deleteFile": [MockFunction],
-                                  "getPermissions": [MockFunction] {
-                                    "calls": Array [
-                                      Array [],
-                                    ],
-                                    "results": Array [
-                                      Object {
-                                        "type": "return",
-                                        "value": Promise {},
-                                      },
-                                    ],
-                                  },
-                                  "savePermissionsForAgent": [MockFunction],
-                                }
-                              }
+                              defaultExpanded={true}
                             >
                               <WithStyles(ForwardRef(Paper))
                                 className="PodBrowser-root PodBrowser-expanded PodBrowser-rounded"
@@ -1092,23 +1060,7 @@ font-display: block;",
                                         expandIcon={<Memo(ExpandMoreIcon) />}
                                       >
                                         <WithStyles(ForwardRef(ButtonBase))
-                                          aria-expanded={
-                                            Object {
-                                              "deleteFile": [MockFunction],
-                                              "getPermissions": [MockFunction] {
-                                                "calls": Array [
-                                                  Array [],
-                                                ],
-                                                "results": Array [
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": Promise {},
-                                                  },
-                                                ],
-                                              },
-                                              "savePermissionsForAgent": [MockFunction],
-                                            }
-                                          }
+                                          aria-expanded={true}
                                           className="PodBrowser-root PodBrowser-expanded"
                                           component="div"
                                           data-testid="accordion-resource-actions-trigger"
@@ -1120,23 +1072,7 @@ font-display: block;",
                                           onFocusVisible={[Function]}
                                         >
                                           <ForwardRef(ButtonBase)
-                                            aria-expanded={
-                                              Object {
-                                                "deleteFile": [MockFunction],
-                                                "getPermissions": [MockFunction] {
-                                                  "calls": Array [
-                                                    Array [],
-                                                  ],
-                                                  "results": Array [
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": Promise {},
-                                                    },
-                                                  ],
-                                                },
-                                                "savePermissionsForAgent": [MockFunction],
-                                              }
-                                            }
+                                            aria-expanded={true}
                                             className="PodBrowser-root PodBrowser-expanded"
                                             classes={
                                               Object {
@@ -1156,23 +1092,7 @@ font-display: block;",
                                           >
                                             <div
                                               aria-disabled={false}
-                                              aria-expanded={
-                                                Object {
-                                                  "deleteFile": [MockFunction],
-                                                  "getPermissions": [MockFunction] {
-                                                    "calls": Array [
-                                                      Array [],
-                                                    ],
-                                                    "results": Array [
-                                                      Object {
-                                                        "type": "return",
-                                                        "value": Promise {},
-                                                      },
-                                                    ],
-                                                  },
-                                                  "savePermissionsForAgent": [MockFunction],
-                                                }
-                                              }
+                                              aria-expanded={true}
                                               className="PodBrowser-root PodBrowser-root PodBrowser-expanded"
                                               data-testid="accordion-resource-actions-trigger"
                                               onBlur={[Function]}
@@ -1342,23 +1262,7 @@ font-display: block;",
                                       </ForwardRef(AccordionSummary)>
                                     </WithStyles(ForwardRef(AccordionSummary))>
                                     <WithStyles(ForwardRef(Collapse))
-                                      in={
-                                        Object {
-                                          "deleteFile": [MockFunction],
-                                          "getPermissions": [MockFunction] {
-                                            "calls": Array [
-                                              Array [],
-                                            ],
-                                            "results": Array [
-                                              Object {
-                                                "type": "return",
-                                                "value": Promise {},
-                                              },
-                                            ],
-                                          },
-                                          "savePermissionsForAgent": [MockFunction],
-                                        }
-                                      }
+                                      in={true}
                                       timeout="auto"
                                     >
                                       <ForwardRef(Collapse)
@@ -1371,23 +1275,7 @@ font-display: block;",
                                             "wrapperInner": "PodBrowser-wrapperInner",
                                           }
                                         }
-                                        in={
-                                          Object {
-                                            "deleteFile": [MockFunction],
-                                            "getPermissions": [MockFunction] {
-                                              "calls": Array [
-                                                Array [],
-                                              ],
-                                              "results": Array [
-                                                Object {
-                                                  "type": "return",
-                                                  "value": Promise {},
-                                                },
-                                              ],
-                                            },
-                                            "savePermissionsForAgent": [MockFunction],
-                                          }
-                                        }
+                                        in={true}
                                         timeout="auto"
                                       >
                                         <Transition
@@ -1395,23 +1283,7 @@ font-display: block;",
                                           appear={false}
                                           enter={true}
                                           exit={true}
-                                          in={
-                                            Object {
-                                              "deleteFile": [MockFunction],
-                                              "getPermissions": [MockFunction] {
-                                                "calls": Array [
-                                                  Array [],
-                                                ],
-                                                "results": Array [
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": Promise {},
-                                                  },
-                                                ],
-                                              },
-                                              "savePermissionsForAgent": [MockFunction],
-                                            }
-                                          }
+                                          in={true}
                                           mountOnEnter={false}
                                           onEnter={[Function]}
                                           onEntered={[Function]}
@@ -3820,23 +3692,7 @@ font-display: block;",
                         </ForwardRef(Divider)>
                       </WithStyles(ForwardRef(Divider))>
                       <WithStyles(ForwardRef(Accordion))
-                        defaultExpanded={
-                          Object {
-                            "deleteFile": [MockFunction],
-                            "getPermissions": [MockFunction] {
-                              "calls": Array [
-                                Array [],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "type": "return",
-                                  "value": Promise {},
-                                },
-                              ],
-                            },
-                            "savePermissionsForAgent": [MockFunction],
-                          }
-                        }
+                        defaultExpanded={true}
                       >
                         <ForwardRef(Accordion)
                           classes={
@@ -3847,23 +3703,7 @@ font-display: block;",
                               "rounded": "PodBrowser-rounded",
                             }
                           }
-                          defaultExpanded={
-                            Object {
-                              "deleteFile": [MockFunction],
-                              "getPermissions": [MockFunction] {
-                                "calls": Array [
-                                  Array [],
-                                ],
-                                "results": Array [
-                                  Object {
-                                    "type": "return",
-                                    "value": Promise {},
-                                  },
-                                ],
-                              },
-                              "savePermissionsForAgent": [MockFunction],
-                            }
-                          }
+                          defaultExpanded={true}
                         >
                           <WithStyles(ForwardRef(Paper))
                             className="PodBrowser-root PodBrowser-expanded PodBrowser-rounded"
@@ -3928,23 +3768,7 @@ font-display: block;",
                                     expandIcon={<Memo(ExpandMoreIcon) />}
                                   >
                                     <WithStyles(ForwardRef(ButtonBase))
-                                      aria-expanded={
-                                        Object {
-                                          "deleteFile": [MockFunction],
-                                          "getPermissions": [MockFunction] {
-                                            "calls": Array [
-                                              Array [],
-                                            ],
-                                            "results": Array [
-                                              Object {
-                                                "type": "return",
-                                                "value": Promise {},
-                                              },
-                                            ],
-                                          },
-                                          "savePermissionsForAgent": [MockFunction],
-                                        }
-                                      }
+                                      aria-expanded={true}
                                       className="PodBrowser-root PodBrowser-expanded"
                                       component="div"
                                       data-testid="accordion-resource-actions-trigger"
@@ -3956,23 +3780,7 @@ font-display: block;",
                                       onFocusVisible={[Function]}
                                     >
                                       <ForwardRef(ButtonBase)
-                                        aria-expanded={
-                                          Object {
-                                            "deleteFile": [MockFunction],
-                                            "getPermissions": [MockFunction] {
-                                              "calls": Array [
-                                                Array [],
-                                              ],
-                                              "results": Array [
-                                                Object {
-                                                  "type": "return",
-                                                  "value": Promise {},
-                                                },
-                                              ],
-                                            },
-                                            "savePermissionsForAgent": [MockFunction],
-                                          }
-                                        }
+                                        aria-expanded={true}
                                         className="PodBrowser-root PodBrowser-expanded"
                                         classes={
                                           Object {
@@ -3992,23 +3800,7 @@ font-display: block;",
                                       >
                                         <div
                                           aria-disabled={false}
-                                          aria-expanded={
-                                            Object {
-                                              "deleteFile": [MockFunction],
-                                              "getPermissions": [MockFunction] {
-                                                "calls": Array [
-                                                  Array [],
-                                                ],
-                                                "results": Array [
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": Promise {},
-                                                  },
-                                                ],
-                                              },
-                                              "savePermissionsForAgent": [MockFunction],
-                                            }
-                                          }
+                                          aria-expanded={true}
                                           className="PodBrowser-root PodBrowser-root PodBrowser-expanded"
                                           data-testid="accordion-resource-actions-trigger"
                                           onBlur={[Function]}
@@ -4178,23 +3970,7 @@ font-display: block;",
                                   </ForwardRef(AccordionSummary)>
                                 </WithStyles(ForwardRef(AccordionSummary))>
                                 <WithStyles(ForwardRef(Collapse))
-                                  in={
-                                    Object {
-                                      "deleteFile": [MockFunction],
-                                      "getPermissions": [MockFunction] {
-                                        "calls": Array [
-                                          Array [],
-                                        ],
-                                        "results": Array [
-                                          Object {
-                                            "type": "return",
-                                            "value": Promise {},
-                                          },
-                                        ],
-                                      },
-                                      "savePermissionsForAgent": [MockFunction],
-                                    }
-                                  }
+                                  in={true}
                                   timeout="auto"
                                 >
                                   <ForwardRef(Collapse)
@@ -4207,23 +3983,7 @@ font-display: block;",
                                         "wrapperInner": "PodBrowser-wrapperInner",
                                       }
                                     }
-                                    in={
-                                      Object {
-                                        "deleteFile": [MockFunction],
-                                        "getPermissions": [MockFunction] {
-                                          "calls": Array [
-                                            Array [],
-                                          ],
-                                          "results": Array [
-                                            Object {
-                                              "type": "return",
-                                              "value": Promise {},
-                                            },
-                                          ],
-                                        },
-                                        "savePermissionsForAgent": [MockFunction],
-                                      }
-                                    }
+                                    in={true}
                                     timeout="auto"
                                   >
                                     <Transition
@@ -4231,23 +3991,7 @@ font-display: block;",
                                       appear={false}
                                       enter={true}
                                       exit={true}
-                                      in={
-                                        Object {
-                                          "deleteFile": [MockFunction],
-                                          "getPermissions": [MockFunction] {
-                                            "calls": Array [
-                                              Array [],
-                                            ],
-                                            "results": Array [
-                                              Object {
-                                                "type": "return",
-                                                "value": Promise {},
-                                              },
-                                            ],
-                                          },
-                                          "savePermissionsForAgent": [MockFunction],
-                                        }
-                                      }
+                                      in={true}
                                       mountOnEnter={false}
                                       onEnter={[Function]}
                                       onEntered={[Function]}
@@ -6696,23 +6440,7 @@ font-display: block;",
                             </ForwardRef(Divider)>
                           </WithStyles(ForwardRef(Divider))>
                           <WithStyles(ForwardRef(Accordion))
-                            defaultExpanded={
-                              Object {
-                                "deleteFile": [MockFunction],
-                                "getPermissions": [MockFunction] {
-                                  "calls": Array [
-                                    Array [],
-                                  ],
-                                  "results": Array [
-                                    Object {
-                                      "type": "return",
-                                      "value": Promise {},
-                                    },
-                                  ],
-                                },
-                                "savePermissionsForAgent": [MockFunction],
-                              }
-                            }
+                            defaultExpanded={true}
                           >
                             <ForwardRef(Accordion)
                               classes={
@@ -6723,23 +6451,7 @@ font-display: block;",
                                   "rounded": "PodBrowser-rounded",
                                 }
                               }
-                              defaultExpanded={
-                                Object {
-                                  "deleteFile": [MockFunction],
-                                  "getPermissions": [MockFunction] {
-                                    "calls": Array [
-                                      Array [],
-                                    ],
-                                    "results": Array [
-                                      Object {
-                                        "type": "return",
-                                        "value": Promise {},
-                                      },
-                                    ],
-                                  },
-                                  "savePermissionsForAgent": [MockFunction],
-                                }
-                              }
+                              defaultExpanded={true}
                             >
                               <WithStyles(ForwardRef(Paper))
                                 className="PodBrowser-root PodBrowser-expanded PodBrowser-rounded"
@@ -6804,23 +6516,7 @@ font-display: block;",
                                         expandIcon={<Memo(ExpandMoreIcon) />}
                                       >
                                         <WithStyles(ForwardRef(ButtonBase))
-                                          aria-expanded={
-                                            Object {
-                                              "deleteFile": [MockFunction],
-                                              "getPermissions": [MockFunction] {
-                                                "calls": Array [
-                                                  Array [],
-                                                ],
-                                                "results": Array [
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": Promise {},
-                                                  },
-                                                ],
-                                              },
-                                              "savePermissionsForAgent": [MockFunction],
-                                            }
-                                          }
+                                          aria-expanded={true}
                                           className="PodBrowser-root PodBrowser-expanded"
                                           component="div"
                                           data-testid="accordion-resource-actions-trigger"
@@ -6832,23 +6528,7 @@ font-display: block;",
                                           onFocusVisible={[Function]}
                                         >
                                           <ForwardRef(ButtonBase)
-                                            aria-expanded={
-                                              Object {
-                                                "deleteFile": [MockFunction],
-                                                "getPermissions": [MockFunction] {
-                                                  "calls": Array [
-                                                    Array [],
-                                                  ],
-                                                  "results": Array [
-                                                    Object {
-                                                      "type": "return",
-                                                      "value": Promise {},
-                                                    },
-                                                  ],
-                                                },
-                                                "savePermissionsForAgent": [MockFunction],
-                                              }
-                                            }
+                                            aria-expanded={true}
                                             className="PodBrowser-root PodBrowser-expanded"
                                             classes={
                                               Object {
@@ -6868,23 +6548,7 @@ font-display: block;",
                                           >
                                             <div
                                               aria-disabled={false}
-                                              aria-expanded={
-                                                Object {
-                                                  "deleteFile": [MockFunction],
-                                                  "getPermissions": [MockFunction] {
-                                                    "calls": Array [
-                                                      Array [],
-                                                    ],
-                                                    "results": Array [
-                                                      Object {
-                                                        "type": "return",
-                                                        "value": Promise {},
-                                                      },
-                                                    ],
-                                                  },
-                                                  "savePermissionsForAgent": [MockFunction],
-                                                }
-                                              }
+                                              aria-expanded={true}
                                               className="PodBrowser-root PodBrowser-root PodBrowser-expanded"
                                               data-testid="accordion-resource-actions-trigger"
                                               onBlur={[Function]}
@@ -7054,23 +6718,7 @@ font-display: block;",
                                       </ForwardRef(AccordionSummary)>
                                     </WithStyles(ForwardRef(AccordionSummary))>
                                     <WithStyles(ForwardRef(Collapse))
-                                      in={
-                                        Object {
-                                          "deleteFile": [MockFunction],
-                                          "getPermissions": [MockFunction] {
-                                            "calls": Array [
-                                              Array [],
-                                            ],
-                                            "results": Array [
-                                              Object {
-                                                "type": "return",
-                                                "value": Promise {},
-                                              },
-                                            ],
-                                          },
-                                          "savePermissionsForAgent": [MockFunction],
-                                        }
-                                      }
+                                      in={true}
                                       timeout="auto"
                                     >
                                       <ForwardRef(Collapse)
@@ -7083,23 +6731,7 @@ font-display: block;",
                                             "wrapperInner": "PodBrowser-wrapperInner",
                                           }
                                         }
-                                        in={
-                                          Object {
-                                            "deleteFile": [MockFunction],
-                                            "getPermissions": [MockFunction] {
-                                              "calls": Array [
-                                                Array [],
-                                              ],
-                                              "results": Array [
-                                                Object {
-                                                  "type": "return",
-                                                  "value": Promise {},
-                                                },
-                                              ],
-                                            },
-                                            "savePermissionsForAgent": [MockFunction],
-                                          }
-                                        }
+                                        in={true}
                                         timeout="auto"
                                       >
                                         <Transition
@@ -7107,23 +6739,7 @@ font-display: block;",
                                           appear={false}
                                           enter={true}
                                           exit={true}
-                                          in={
-                                            Object {
-                                              "deleteFile": [MockFunction],
-                                              "getPermissions": [MockFunction] {
-                                                "calls": Array [
-                                                  Array [],
-                                                ],
-                                                "results": Array [
-                                                  Object {
-                                                    "type": "return",
-                                                    "value": Promise {},
-                                                  },
-                                                ],
-                                              },
-                                              "savePermissionsForAgent": [MockFunction],
-                                            }
-                                          }
+                                          in={true}
                                           mountOnEnter={false}
                                           onEnter={[Function]}
                                           onEntered={[Function]}


### PR DESCRIPTION
# Bug: Was missing data-testid for "Add user with WebID"-button in permissions in the Resource Drawer

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).