### PR TITLE
refactoring to use index dataset

### DIFF
--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -26,8 +26,8 @@ import { useBem } from "@solid/lit-prism-patterns";
 import { BackToNavLink } from "@inrupt/prism-react-components";
 import clsx from "clsx";
 import Link from "next/link";
-import { getSourceUrl } from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
+import { foaf } from "rdf-namespaces";
 import Spinner from "../spinner";
 import { findContactInAddressBook, saveContact } from "../../src/addressBook";
 import useAddressBook from "../../src/hooks/useAddressBook";
@@ -37,6 +37,7 @@ import AlertContext from "../../src/contexts/alertContext";
 import { useRedirectIfLoggedOut } from "../../src/effects/auth";
 import styles from "./styles";
 import { fetchProfile } from "../../src/solidClientHelpers/profile";
+import useContacts from "../../src/hooks/useContacts";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 export const EXISTING_WEBID_ERROR_MESSAGE =
@@ -53,6 +54,8 @@ export function handleSubmit({
   alertSuccess,
   fetch,
   setDirtyForm,
+  peopleMutate,
+  people,
 }) {
   return async (iri) => {
     setDirtyForm(true);
@@ -60,17 +63,14 @@ export function handleSubmit({
       return;
     }
     setIsLoading(true);
-    const addressBookIri = getSourceUrl(addressBook);
 
     try {
       const { name, webId, types } = await fetchProfile(iri, fetch);
-
       const existingContact = await findContactInAddressBook(
-        addressBookIri,
+        people,
         webId,
         fetch
       );
-
       if (existingContact.length) {
         alertError(EXISTING_WEBID_ERROR_MESSAGE);
         setIsLoading(false);
@@ -80,7 +80,7 @@ export function handleSubmit({
       if (name) {
         const contact = { webId, fn: name };
         const { response, error } = await saveContact(
-          addressBookIri,
+          addressBook,
           contact,
           types,
           fetch
@@ -90,6 +90,7 @@ export function handleSubmit({
         if (response) {
           alertSuccess(`${contact.fn} was added to your contacts`);
           setAgentId("");
+          peopleMutate();
         }
       } else {
         alertError(NO_NAME_ERROR_MESSAGE);
@@ -120,6 +121,13 @@ export default function AddContact() {
   const [isLoading, setIsLoading] = useState(false);
   const [agentId, setAgentId] = useState("");
   const [dirtyForm, setDirtyForm] = useState(false);
+  const {
+    data: people,
+    error: peopleError,
+    mutate: peopleMutate,
+  } = useContacts(addressBook, foaf.Person);
+
+  if (peopleError) alertError(peopleError);
 
   if (!webId || isLoading) return <Spinner />;
 
@@ -132,6 +140,8 @@ export default function AddContact() {
     fetch,
     webId,
     setDirtyForm,
+    peopleMutate,
+    people,
   });
 
   const handleChange = (newValue) => {

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -104,6 +104,7 @@ describe("handleSubmit", () => {
   test("it alerts the user and exits if the webid already exists", async () => {
     const personDataset = mockPersonDatasetAlice();
     const personProfile = mockProfileAlice();
+    const people = [personDataset];
     const handler = handleSubmit({
       addressBook,
       setAgentId,
@@ -112,6 +113,7 @@ describe("handleSubmit", () => {
       alertSuccess,
       fetch,
       setDirtyForm,
+      people,
     });
     jest
       .spyOn(profileHelperFns, "fetchProfile")
@@ -121,7 +123,7 @@ describe("handleSubmit", () => {
       .mockResolvedValue([personDataset]);
     await handler("alreadyExistingWebId");
     expect(addressBookFns.findContactInAddressBook).toHaveBeenCalledWith(
-      addressBookUri,
+      people,
       aliceWebIdUrl,
       fetch
     );
@@ -180,8 +182,9 @@ describe("handleSubmit", () => {
       "Alice"
     );
     const contactsIri = contactsContainerIri("http://www.example.com/");
-    const peopleDataset = mockSolidDatasetFrom(contactsIri);
-    const peopleDatasetWithContact = setThing(peopleDataset, personDataset);
+    const people = mockSolidDatasetFrom(contactsIri);
+    const peopleMutate = jest.fn();
+    const peopleDatasetWithContact = setThing(people, personDataset);
     const mockProfile = mockProfileAlice();
     const handler = handleSubmit({
       addressBook,
@@ -191,6 +194,8 @@ describe("handleSubmit", () => {
       alertSuccess,
       fetch,
       setDirtyForm,
+      people,
+      peopleMutate,
     });
     jest
       .spyOn(addressBookFns, "findContactInAddressBook")

--- a/components/contactsList/__snapshots__/index.test.jsx.snap
+++ b/components/contactsList/__snapshots__/index.test.jsx.snap
@@ -892,7 +892,7 @@ font-display: block;",
 </Component>
 `;
 
-exports[`ContactsList renders error if usePeople returns error 1`] = `
+exports[`ContactsList renders error if useContacts returns error 1`] = `
 <Component
   theme={
     Object {
@@ -30896,7 +30896,7 @@ font-display: block;",
 </Component>
 `;
 
-exports[`ContactsList renders spinner while usePeople is loading 1`] = `
+exports[`ContactsList renders spinner while useContacts is loading 1`] = `
 <Component
   theme={
     Object {

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -39,7 +39,7 @@ import styles from "./styles";
 
 import { useRedirectIfLoggedOut } from "../../src/effects/auth";
 import useAddressBook from "../../src/hooks/useAddressBook";
-import usePeople from "../../src/hooks/usePeople";
+import useContacts from "../../src/hooks/useContacts";
 import useProfiles from "../../src/hooks/useProfiles";
 import ContactsListSearch from "./contactsListSearch";
 import ProfileLink from "../profileLink";
@@ -63,7 +63,13 @@ export function handleDeleteContact({
 }) {
   return async () => {
     const selectedContact = people[selectedContactIndex];
-    await deleteContact(getSourceUrl(addressBook), selectedContact, fetch);
+
+    await deleteContact(
+      getSourceUrl(addressBook),
+      selectedContact,
+      foaf.Person,
+      fetch
+    );
     peopleMutate();
     closeDrawer();
   };
@@ -79,9 +85,11 @@ function ContactsList() {
   const [search, setSearch] = useState("");
 
   const [addressBook, addressBookError] = useAddressBook();
-  const { data: people, error: peopleError, mutate: peopleMutate } = usePeople(
-    addressBook
-  );
+  const {
+    data: people,
+    error: peopleError,
+    mutate: peopleMutate,
+  } = useContacts(addressBook, foaf.Person);
   const profiles = useProfiles(people);
   const formattedNamePredicate = vcard.fn;
   const hasPhotoPredicate = vcard.hasPhoto;
@@ -103,6 +111,7 @@ function ContactsList() {
     setSelectedContactName(name);
 
     const webId = getUrl(people[selectedContactIndex].dataset, foaf.openid);
+
     setSelectedContactWebId(webId);
   }, [selectedContactIndex, formattedNamePredicate, people]);
 

--- a/components/contactsList/index.test.jsx
+++ b/components/contactsList/index.test.jsx
@@ -21,9 +21,10 @@
 
 import React from "react";
 import * as solidClientFns from "@inrupt/solid-client";
+import { foaf } from "rdf-namespaces";
 import { deleteContact } from "../../src/addressBook";
 import useAddressBook from "../../src/hooks/useAddressBook";
-import usePeople from "../../src/hooks/usePeople";
+import useContacts from "../../src/hooks/useContacts";
 import useProfiles from "../../src/hooks/useProfiles";
 import { mountToJson } from "../../__testUtils/mountWithTheme";
 import ContactsList, { handleDeleteContact } from "./index";
@@ -36,7 +37,7 @@ import mockSessionContextProvider from "../../__testUtils/mockSessionContextProv
 
 jest.mock("../../src/addressBook");
 jest.mock("../../src/hooks/useAddressBook");
-jest.mock("../../src/hooks/usePeople");
+jest.mock("../../src/hooks/useContacts");
 jest.mock("../../src/hooks/useProfiles");
 
 describe("ContactsList", () => {
@@ -44,7 +45,7 @@ describe("ContactsList", () => {
   const SessionProvider = mockSessionContextProvider(session);
   it("renders spinner while useAddressBook is loading", () => {
     useAddressBook.mockReturnValue([null, null]);
-    usePeople.mockReturnValue({
+    useContacts.mockReturnValue({
       data: undefined,
       error: undefined,
       mutate: () => {},
@@ -59,12 +60,12 @@ describe("ContactsList", () => {
       )
     ).toMatchSnapshot();
     expect(useAddressBook).toHaveBeenCalledWith();
-    expect(usePeople).toHaveBeenCalledWith(null);
+    expect(useContacts).toHaveBeenCalledWith(null, foaf.Person);
   });
 
-  it("renders spinner while usePeople is loading", () => {
+  it("renders spinner while useContacts is loading", () => {
     useAddressBook.mockReturnValue([42, null]);
-    usePeople.mockReturnValue({
+    useContacts.mockReturnValue({
       data: undefined,
       error: undefined,
       mutate: () => {},
@@ -78,12 +79,12 @@ describe("ContactsList", () => {
         </SessionProvider>
       )
     ).toMatchSnapshot();
-    expect(usePeople).toHaveBeenCalledWith(42);
+    expect(useContacts).toHaveBeenCalledWith(42, foaf.Person);
   });
 
   it("renders spinner while useProfiles is loading", () => {
     useAddressBook.mockReturnValue([42, null]);
-    usePeople.mockReturnValue({
+    useContacts.mockReturnValue({
       data: "peopleData",
       error: undefined,
       mutate: () => {},
@@ -102,7 +103,7 @@ describe("ContactsList", () => {
 
   it("renders error if useAddressBook returns error", () => {
     useAddressBook.mockReturnValue([null, "error"]);
-    usePeople.mockReturnValue({
+    useContacts.mockReturnValue({
       data: undefined,
       error: undefined,
       mutate: () => {},
@@ -119,7 +120,7 @@ describe("ContactsList", () => {
 
   it("renders page when people is loaded", () => {
     useAddressBook.mockReturnValue([42, null]);
-    usePeople.mockReturnValue({
+    useContacts.mockReturnValue({
       data: "peopleData",
       error: undefined,
       mutate: () => {},
@@ -138,9 +139,9 @@ describe("ContactsList", () => {
     ).toMatchSnapshot();
   });
 
-  it("renders error if usePeople returns error", () => {
+  it("renders error if useContacts returns error", () => {
     useAddressBook.mockReturnValue([42, null]);
-    usePeople.mockReturnValue({
+    useContacts.mockReturnValue({
       data: undefined,
       error: "error",
       mutate: () => {},
@@ -180,7 +181,12 @@ describe("handleDeleteContact", () => {
 
     await handler();
 
-    expect(deleteContact).toHaveBeenCalledWith(addressBookUrl, contact, fetch);
+    expect(deleteContact).toHaveBeenCalledWith(
+      addressBookUrl,
+      contact,
+      foaf.Person,
+      fetch
+    );
     expect(peopleMutate).toHaveBeenCalled();
     expect(closeDrawer).toHaveBeenCalled();
   });

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -37,7 +37,7 @@ import {
   setThing,
 } from "@inrupt/solid-client";
 import { v4 as uuid } from "uuid";
-import { rdf, dc, acl, vcard, ldp, foaf, schema } from "rdf-namespaces";
+import { rdf, dc, acl, vcard, foaf, schema } from "rdf-namespaces";
 import {
   createResponder,
   defineDataset,
@@ -50,19 +50,26 @@ import { joinPath } from "../stringHelpers";
 
 const CONTACTS_CONTAINER = "contacts/";
 
+const NAME_EMAIL_INDEX_PREDICATE =
+  "http://www.w3.org/2006/vcard/ns#nameEmailIndex";
+
 const INDEX_FILE = "index.ttl";
 const PEOPLE_INDEX_FILE = "people.ttl";
 const GROUPS_INDEX_FILE = "groups.ttl";
 const PERSON_CONTAINER = "Person";
 
-const TYPE_MAP = {
+export const TYPE_MAP = {
   [foaf.Person]: {
     indexFile: PEOPLE_INDEX_FILE,
     container: PERSON_CONTAINER,
+    indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
+    contactTypeIri: vcard.Individual,
   },
   [schema.Person]: {
     indexFile: PEOPLE_INDEX_FILE,
     container: PERSON_CONTAINER,
+    indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
+    contactTypeIri: vcard.Individual,
   },
 };
 
@@ -130,42 +137,26 @@ export async function getGroups(containerIri, fetch) {
   return respond(groups);
 }
 
-export async function getContacts(type, containerIri, fetch) {
-  const { respond, error } = createResponder();
-  const { container } = TYPE_MAP[type];
-
-  if (!container) {
-    throw new Error(`Cannot load contacts of type: ${type}`);
+export async function getContacts(indexFileDataset, contactTypeIri, fetch) {
+  const { respond } = createResponder();
+  let contacts = [];
+  if (!indexFileDataset) {
+    return respond(contacts);
   }
+  const contactsThings = getThingAll(indexFileDataset);
 
-  const contactsIri = `${joinPath(containerIri, container)}/`;
-
-  const {
-    response: contactsResponse,
-    error: contactsError,
-  } = await getResource(contactsIri, fetch);
-
-  if (contactsError && isHTTPError(contactsError, ERROR_CODES.NOT_FOUND)) {
-    // temporary solution to allow loading contacts page when /contacts/Person isn't created yet
-    return respond([]);
-  }
-
-  if (contactsError) {
-    return error(contactsError);
-  }
-
-  const contactsIris = getUrlAll(
-    contactsResponse.dataset,
-    ldp.contains
-  ).map((url) => joinPath(url, INDEX_FILE));
+  const contactsIris = contactsThings.map((t) => asUrl(t));
 
   const contactsResponses = await Promise.all(
     contactsIris.map((iri) => getResource(iri, fetch))
   );
 
-  const contacts = contactsResponses
+  contacts = contactsResponses
     .filter(({ error: e }) => !e)
-    .map(({ response }) => response);
+    .map(({ response }) => response)
+    .filter((contact) =>
+      getUrlAll(contact.dataset, rdf.type).includes(contactTypeIri)
+    );
 
   return respond(contacts);
 }
@@ -285,6 +276,28 @@ export function mapSchema(prefix) {
   };
 }
 
+export async function getIndexDatasetFromAddressBook(
+  addressBook,
+  indexFilePredicate,
+  fetch
+) {
+  const { respond, error } = createResponder();
+  try {
+    const contactsIri = getSourceUrl(addressBook);
+    const addressBookDatasetIri = joinPath(contactsIri, INDEX_FILE);
+    const addressBookDataset = await getSolidDataset(addressBookDatasetIri, {
+      fetch,
+    });
+
+    const indexDatasetIri = getUrl(addressBookDataset, indexFilePredicate);
+    const indexFileDataset = await getSolidDataset(indexDatasetIri, { fetch });
+
+    return respond(indexFileDataset);
+  } catch (e) {
+    return error(e);
+  }
+}
+
 export function createContact(addressBookIri, contact, types) {
   // Find the first matching container mapping.
   const containerMap = TYPE_MAP[types.find((type) => TYPE_MAP[type])];
@@ -337,13 +350,7 @@ export function createContact(addressBookIri, contact, types) {
   };
 }
 
-export async function findContactInAddressBook(addressBookIri, webId, fetch) {
-  const { response: people } = await getContacts(
-    foaf.Person,
-    addressBookIri,
-    fetch
-  );
-
+export async function findContactInAddressBook(people, webId, fetch) {
   const profiles = await getProfiles(people, fetch);
   const existingContact = profiles.filter(
     (profile) => asUrl(profile) === webId
@@ -351,16 +358,23 @@ export async function findContactInAddressBook(addressBookIri, webId, fetch) {
   return existingContact;
 }
 
-export async function saveContact(addressBookIri, contactSchema, types, fetch) {
+export async function saveContact(
+  addressBookContainer,
+  contactSchema,
+  types,
+  fetch
+) {
   const { respond, error } = createResponder();
-  const newContact = createContact(addressBookIri, contactSchema, types);
+  const addressBookContainerIri = getSourceUrl(addressBookContainer);
+  const newContact = createContact(
+    addressBookContainerIri,
+    contactSchema,
+    types
+  );
   const { iri } = newContact;
 
-  const containerMap = TYPE_MAP[types.find((type) => TYPE_MAP[type])];
-  const { indexFile } = containerMap;
-
-  const indexIri = joinPath(addressBookIri, INDEX_FILE);
-  const contactIndexIri = joinPath(addressBookIri, indexFile);
+  const indexIri = joinPath(addressBookContainerIri, INDEX_FILE);
+  const { indexFilePredicate } = TYPE_MAP[foaf.Person];
 
   const { response: contact, error: saveContactError } = await saveResource(
     newContact,
@@ -369,12 +383,11 @@ export async function saveContact(addressBookIri, contactSchema, types, fetch) {
 
   if (saveContactError) return error(saveContactError);
 
-  const { response: contactIndex, error: contactError } = await getResource(
-    contactIndexIri,
+  const { response: contactIndex } = await getIndexDatasetFromAddressBook(
+    addressBookContainer,
+    indexFilePredicate,
     fetch
   );
-
-  if (contactError) return error(contactError);
 
   const contactThing = defineThing(
     {
@@ -385,8 +398,9 @@ export async function saveContact(addressBookIri, contactSchema, types, fetch) {
     (t) => addUrl(t, vcardExtras("inAddressBook"), indexIri)
   );
 
+  const contactIndexIri = getSourceUrl(contactIndex);
   const contactResource = {
-    dataset: setThing(contactIndex.dataset, contactThing),
+    dataset: setThing(contactIndex, contactThing),
     iri: contactIndexIri,
   };
 
@@ -399,55 +413,44 @@ export async function saveContact(addressBookIri, contactSchema, types, fetch) {
   return respond({ iri, contact, contacts });
 }
 
-export async function deleteContact(addressBookIri, contactToDelete, fetch) {
-  const webId = getUrl(contactToDelete.dataset, foaf.openid);
-  const profileDataset = await getSolidDataset(webId);
-  const types = getUrlAll(profileDataset, rdf.type);
-
-  // TODO: get contact from contacts index once SOLIDOS-503 is resolved
-  const containerMap = TYPE_MAP[types.find((type) => TYPE_MAP[type])];
-
-  if (!containerMap) {
-    throw new Error(`Contact is unsupported type: ${webId}`);
-  }
-
-  const { indexFile } = containerMap;
-
-  const contactIri = contactToDelete.iri;
-  const contactsIri = joinPath(addressBookIri, indexFile);
-  const { response: contactsIndex, error: contactsError } = await getResource(
-    contactsIri,
-    fetch
+export async function deleteContact(
+  addressBookIri,
+  contactToDelete,
+  type,
+  fetch
+) {
+  const addressBookDatasetIri = joinPath(addressBookIri, INDEX_FILE);
+  const addressBookDataset = await getSolidDataset(addressBookDatasetIri, {
+    fetch,
+  });
+  const indexDatasetIri = await getUrl(
+    addressBookDataset,
+    TYPE_MAP[type].indexFilePredicate
   );
+  const indexFileDataset = await getSolidDataset(indexDatasetIri, { fetch });
+  const contactsIndexThings = getThingAll(indexFileDataset, { fetch });
 
-  if (contactsError) {
-    throw contactsError;
-  }
-
-  const contactsIndexThings = getThingAll(contactsIndex.dataset);
   const contactsIndexEntryToRemove = contactsIndexThings.find((thing) =>
-    asUrl(thing).includes(contactIri)
+    asUrl(thing).includes(contactToDelete.iri)
   );
-
-  const updatedcontactsIndex = removeThing(
-    contactsIndex.dataset,
+  const updatedContactsIndex = removeThing(
+    indexFileDataset,
     contactsIndexEntryToRemove
   );
-
-  const updatedcontactsIndexResponse = saveResource(
-    { dataset: updatedcontactsIndex, iri: contactsIri },
+  const updatedContactsIndexResponse = await saveResource(
+    { dataset: updatedContactsIndex, iri: indexDatasetIri },
     fetch
   );
 
-  const contactContainerIri = contactIri.substring(
+  const contactContainerIri = contactToDelete.iri.substring(
     0,
-    contactIri.lastIndexOf("/") + 1
+    contactToDelete.iri.lastIndexOf("/") + 1
   );
 
-  await deleteFile(contactIri, { fetch });
+  await deleteFile(contactToDelete.iri, { fetch });
   await deleteFile(contactContainerIri, { fetch });
 
-  const { error: saveContactsError } = await updatedcontactsIndexResponse;
+  const { error: saveContactsError } = updatedContactsIndexResponse;
 
   if (saveContactsError) {
     throw saveContactsError;

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -288,10 +288,8 @@ export async function getIndexDatasetFromAddressBook(
     const addressBookDataset = await getSolidDataset(addressBookDatasetIri, {
       fetch,
     });
-
     const indexDatasetIri = getUrl(addressBookDataset, indexFilePredicate);
     const indexFileDataset = await getSolidDataset(indexDatasetIri, { fetch });
-
     return respond(indexFileDataset);
   } catch (e) {
     return error(e);
@@ -419,15 +417,17 @@ export async function deleteContact(
   type,
   fetch
 ) {
-  const addressBookDatasetIri = joinPath(addressBookIri, INDEX_FILE);
-  const addressBookDataset = await getSolidDataset(addressBookDatasetIri, {
+  const addressBook = await getSolidDataset(addressBookIri, {
     fetch,
   });
-  const indexDatasetIri = await getUrl(
-    addressBookDataset,
-    TYPE_MAP[type].indexFilePredicate
+  const { indexFilePredicate } = TYPE_MAP[type];
+  const { response: indexFileDataset } = await getIndexDatasetFromAddressBook(
+    addressBook,
+    indexFilePredicate,
+    fetch
   );
-  const indexFileDataset = await getSolidDataset(indexDatasetIri, { fetch });
+
+  const indexDatasetIri = getSourceUrl(indexFileDataset);
   const contactsIndexThings = getThingAll(indexFileDataset, { fetch });
 
   const contactsIndexEntryToRemove = contactsIndexThings.find((thing) =>

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -23,6 +23,8 @@
 import { ldp, rdf, acl, dc, foaf, vcard } from "rdf-namespaces";
 import * as solidClientFns from "@inrupt/solid-client";
 import * as resourceFns from "../solidClientHelpers/resource";
+// eslint-disable-next-line import/no-useless-path-segments
+import * as addressBookFns from "../addressBook";
 
 import { mockPersonDatasetAlice } from "../../__testUtils/mockPersonResource";
 import { mockPersonContactDataset } from "../../__testUtils/mockContactResource";
@@ -44,15 +46,14 @@ import {
   contactsContainerIri,
   deleteContact,
 } from "./index";
+import { defineDataset } from "../solidClientHelpers/utils";
 
 const {
-  createSolidDataset,
   createThing,
   getStringNoLocale,
   getStringNoLocaleAll,
   getUrl,
   getUrlAll,
-  setThing,
 } = solidClientFns;
 
 describe("createAddressBook", () => {
@@ -271,47 +272,73 @@ describe("getContacts", () => {
     jest.restoreAllMocks();
   });
   test("it fetches the people in the address book", async () => {
-    const containerIri = "https://user.example.com/contacts";
+    const mockIndexFileDatasetIri =
+      "https://user.example.com/contacts/people.ttl";
+    const mockIndexFileDataset = solidClientFns.mockSolidDatasetFrom(
+      mockIndexFileDatasetIri
+    );
     const fetch = jest.fn();
     const personContainer1 = "https://user.example.com/contacts/Person/1234/";
     const personContainer2 = "https://user.example.com/contacts/Person/5678/";
     const expectedPerson1 = {
-      dataset: "Person 1",
+      dataset: mockPersonContactDataset(),
       iri: `${personContainer1}index.ttl`,
     };
     const expectedPerson2 = {
-      dataset: "Person 2",
+      dataset: mockPersonContactDataset(),
       iri: `${personContainer2}index.ttl`,
     };
 
     jest
       .spyOn(resourceFns, "getResource")
-      .mockResolvedValueOnce({ response: { dataset: "people container" } })
       .mockResolvedValueOnce({ response: expectedPerson1 })
       .mockResolvedValueOnce({ response: expectedPerson2 });
 
     jest
-      .spyOn(solidClientFns, "getUrlAll")
-      .mockReturnValueOnce([expectedPerson1.iri, expectedPerson2.iri]);
+      .spyOn(solidClientFns, "getThingAll")
+      .mockReturnValueOnce([expectedPerson1, expectedPerson2]);
 
     const {
       response: [person1, person2],
-    } = await getContacts(foaf.Person, containerIri, fetch);
+    } = await getContacts(mockIndexFileDataset, vcard.Individual, fetch);
 
     expect(person1).toEqual(expectedPerson1);
     expect(person2).toEqual(expectedPerson2);
   });
-  test("it returns an error if it can't fetch the people container", async () => {
-    const containerIri = "https://user.example.com/contacts";
+  test("it filters out the contacts that it cannot fetch due to an error", async () => {
+    const personContainer1 = "https://user.example.com/contacts/Person/1234/";
+    const personContainer2 = "https://user.example.com/contacts/Person/5678/";
+    const expectedPerson1 = {
+      dataset: mockPersonContactDataset(),
+      iri: `${personContainer1}index.ttl`,
+    };
+    const expectedPerson2 = {
+      dataset: mockPersonContactDataset(),
+      iri: `${personContainer2}index.ttl`,
+    };
+    const mockIndexFileDatasetIri =
+      "https://user.example.com/contacts/people.ttl";
+    const mockIndexFileDataset = solidClientFns.mockSolidDatasetFrom(
+      mockIndexFileDatasetIri
+    );
     const fetch = jest.fn();
 
     jest
+      .spyOn(solidClientFns, "getThingAll")
+      .mockReturnValueOnce([expectedPerson1, expectedPerson2]);
+
+    jest
       .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({ response: expectedPerson1 })
       .mockResolvedValueOnce({ error: "There was an error" });
 
-    const { error } = await getContacts(foaf.Person, containerIri, fetch);
+    const { response: results } = await getContacts(
+      mockIndexFileDataset,
+      vcard.Individual,
+      fetch
+    );
 
-    expect(error).toEqual("There was an error");
+    expect(results).toHaveLength(1);
   });
 });
 
@@ -408,9 +435,15 @@ describe("getProfiles", () => {
 });
 
 describe("saveContact", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
   test("it returns an error if it can't save the dataset", async () => {
     const fetch = jest.fn();
     const addressBookIri = "https://user.example.com/contacts";
+    const mockAddressBook = solidClientFns.mockSolidDatasetFrom(addressBookIri);
     const webId = "https://user.example.com/card#me";
     const contact = { webId, fn: "Test Person" };
 
@@ -421,7 +454,7 @@ describe("saveContact", () => {
       });
 
     const { error } = await saveContact(
-      addressBookIri,
+      mockAddressBook,
       contact,
       [foaf.Person],
       fetch
@@ -433,33 +466,34 @@ describe("saveContact", () => {
   test("it saves the contact and the people index", async () => {
     const fetch = jest.fn();
     const addressBookIri = "https://user.example.com/contacts";
+    const mockAddressBook = solidClientFns.mockSolidDatasetFrom(addressBookIri);
     const webId = "https://user.example.com/card#me";
     const schema = { webId, fn: "Test Person" };
-    const contactDataset = setThing(
-      createSolidDataset(),
-      createThing({
-        url: "https://user.example.com/contacts/People/1234/index.ttl",
-      })
-    );
-    const peopleIndexDataset = setThing(
-      createSolidDataset(),
-      createThing({ name: "this" })
-    );
-    const peopleDataset = setThing(
-      createSolidDataset(),
-      createThing({ name: "this" })
+    const contactDataset = mockPersonDatasetAlice();
+
+    const peopleIndexIri = `${addressBookIri}/people.ttl`;
+    const peopleIndexDataset = solidClientFns.mockSolidDatasetFrom(
+      peopleIndexIri
     );
 
+    jest.spyOn(solidClientFns, "getSourceUrl").mockReturnValue(addressBookIri);
+
     jest
-      .spyOn(solidClientFns, "getSourceUrl")
-      .mockReturnValueOnce(
-        "https://user.example.com/contacts/People/1234/index.ttl"
-      );
+      .spyOn(addressBookFns, "createContact")
+      .mockReturnValue({ dataset: contactDataset, iri: webId });
+
+    jest
+      .spyOn(addressBookFns, "getIndexDatasetFromAddressBook")
+      .mockResolvedValueOnce({ response: peopleIndexDataset });
+
+    jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValue(peopleIndexDataset);
 
     jest
       .spyOn(resourceFns, "saveResource")
       .mockResolvedValueOnce({ response: contactDataset })
-      .mockResolvedValueOnce({ response: peopleDataset });
+      .mockResolvedValueOnce({ response: peopleIndexDataset });
 
     jest.spyOn(resourceFns, "getResource").mockResolvedValueOnce({
       response: {
@@ -470,14 +504,17 @@ describe("saveContact", () => {
 
     const {
       response: { contact, contacts },
-    } = await saveContact(addressBookIri, schema, [foaf.Person], fetch);
+    } = await saveContact(mockAddressBook, schema, [foaf.Person], fetch);
 
     expect(contact).toEqual(contactDataset);
-    expect(contacts).toEqual(peopleDataset);
+    expect(contacts).toEqual(peopleIndexDataset);
   });
 });
 
 describe("deleteContact", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   const addressBookUrl = "https://example.com/contacts";
   const owner = "https://example.com/card#me";
   const contactContainerUrl = "http://example.com/contact/id-001/";
@@ -488,8 +525,15 @@ describe("deleteContact", () => {
     dataset: mockPersonContactDataset(),
   };
 
+  const peopleIndexIri = `${addressBookUrl}/people.ttl`;
+  const peopleIndexDataset = solidClientFns.mockSolidDatasetFrom(
+    peopleIndexIri
+  );
+  const updatedPeopleIndexDataset = solidClientFns.mockSolidDatasetFrom(
+    peopleIndexIri
+  );
+
   const addressBook = createAddressBook({ iri: addressBookUrl, owner });
-  const newAddressBook = createAddressBook({ iri: addressBookUrl, owner });
 
   beforeEach(() => {
     jest
@@ -508,8 +552,12 @@ describe("deleteContact", () => {
       .mockResolvedValueOnce({ response: addressBook.people });
 
     jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValueOnce(peopleIndexDataset);
+
+    jest
       .spyOn(solidClientFns, "removeThing")
-      .mockReturnValueOnce(newAddressBook.people.dataset);
+      .mockReturnValueOnce(updatedPeopleIndexDataset);
 
     const mockDeleteFile = jest
       .spyOn(solidClientFns, "deleteFile")
@@ -518,7 +566,7 @@ describe("deleteContact", () => {
 
     jest.spyOn(resourceFns, "saveResource").mockResolvedValueOnce({});
 
-    await deleteContact(addressBookUrl, contactToDelete, fetch);
+    await deleteContact(addressBookUrl, contactToDelete, foaf.Person, fetch);
     expect(mockDeleteFile).toHaveBeenCalledTimes(2);
     expect(mockDeleteFile).toHaveBeenNthCalledWith(1, contactUrl, { fetch });
     expect(mockDeleteFile).toHaveBeenNthCalledWith(2, contactContainerUrl, {
@@ -527,14 +575,19 @@ describe("deleteContact", () => {
   });
   test("it updates the people index", async () => {
     const fetch = jest.fn();
+    jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValue(addressBook.dataset);
+
+    jest.spyOn(solidClientFns, "getUrl").mockResolvedValue(peopleIndexIri);
 
     jest
-      .spyOn(resourceFns, "getResource")
-      .mockResolvedValueOnce({ response: addressBook.people });
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValueOnce(peopleIndexDataset);
 
     jest
       .spyOn(solidClientFns, "removeThing")
-      .mockReturnValueOnce(newAddressBook.people.dataset);
+      .mockReturnValueOnce(updatedPeopleIndexDataset);
 
     jest
       .spyOn(solidClientFns, "deleteFile")
@@ -543,21 +596,14 @@ describe("deleteContact", () => {
 
     const mockSaveResource = jest
       .spyOn(resourceFns, "saveResource")
-      .mockResolvedValueOnce({});
+      .mockResolvedValueOnce(updatedPeopleIndexDataset);
 
-    await deleteContact(addressBookUrl, contactToDelete, fetch);
+    await deleteContact(addressBookUrl, contactToDelete, foaf.Person, fetch);
 
-    expect(mockSaveResource).toHaveBeenCalledWith(newAddressBook.people, fetch);
-  });
-  test("it returns an error if fetching people index fails", async () => {
-    const fetch = jest.fn();
-
-    jest
-      .spyOn(resourceFns, "getResource")
-      .mockResolvedValueOnce({ error: "error" });
-    await expect(
-      deleteContact(addressBookUrl, contactToDelete, fetch)
-    ).rejects.toEqual("error");
+    expect(mockSaveResource).toHaveBeenCalledWith(
+      { dataset: updatedPeopleIndexDataset, iri: peopleIndexIri },
+      fetch
+    );
   });
 });
 
@@ -773,5 +819,41 @@ describe("contactsContainerIri", () => {
     expect(contactsContainerIri("http://example.com")).toEqual(
       "http://example.com/contacts/"
     );
+  });
+});
+
+describe("getIndexDatasetFromAddressBook", () => {
+  beforeAll(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test("it gets the index dataset for a given address book and predicate", async () => {
+    const addressBookIri = "https://user.example.com/contacts";
+    const peopleIndexIri = `${addressBookIri}/people.ttl`;
+    const peopleIndexDataset = solidClientFns.mockSolidDatasetFrom(
+      peopleIndexIri
+    );
+    const fetch = jest.fn();
+    const addressBook = solidClientFns.mockSolidDatasetFrom(addressBookIri);
+    const addressBookDataset = defineDataset(
+      { url: addressBookIri },
+      (t) => solidClientFns.addUrl(t, rdf.type, vcardExtras("AddressBook")),
+      (t) =>
+        solidClientFns.addUrl(t, vcardExtras("nameEmailIndex"), peopleIndexIri)
+    );
+    jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValueOnce(addressBookDataset)
+      .mockResolvedValueOnce(peopleIndexDataset);
+
+    const {
+      response: results,
+    } = await addressBookFns.getIndexDatasetFromAddressBook(
+      addressBook,
+      "http://www.w3.org/2006/vcard/ns#nameEmailIndex",
+      fetch
+    );
+    expect(results).toBe(peopleIndexDataset);
   });
 });

--- a/src/hooks/useContacts/index.js
+++ b/src/hooks/useContacts/index.js
@@ -21,27 +21,32 @@
 
 import useSWR from "swr";
 import { useSession } from "@inrupt/solid-ui-react";
-import { getSourceUrl } from "@inrupt/solid-client";
-import { foaf } from "rdf-namespaces";
-import { getContacts } from "../../addressBook";
+import {
+  getContacts,
+  getIndexDatasetFromAddressBook,
+  TYPE_MAP,
+} from "../../addressBook";
 
-export default function usePeople(addressBook) {
+export default function useContacts(addressBook, type) {
   const {
     session: { fetch },
   } = useSession();
-
   return useSWR(addressBook, async () => {
-    const contactsIri = getSourceUrl(addressBook);
-    const { response, error } = await getContacts(
-      foaf.Person,
-      contactsIri,
+    const { indexFilePredicate } = TYPE_MAP[type];
+    const { contactTypeIri } = TYPE_MAP[type];
+    const { response: indexFileDataset } = await getIndexDatasetFromAddressBook(
+      addressBook,
+      indexFilePredicate,
       fetch
     );
-
+    const { response, error } = await getContacts(
+      indexFileDataset,
+      contactTypeIri,
+      fetch
+    );
     if (error) {
       throw error;
     }
-
     return response;
   });
 }

--- a/src/hooks/useContacts/index.test.jsx
+++ b/src/hooks/useContacts/index.test.jsx
@@ -20,9 +20,9 @@
  */
 
 import React from "react";
-import { renderHook, cleanup } from "@testing-library/react-hooks";
+import { renderHook } from "@testing-library/react-hooks";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
-import { cache, SWRConfig } from "swr";
+import { SWRConfig } from "swr";
 import { foaf } from "rdf-namespaces";
 import useContacts from "./index";
 import mockSession from "../../../__testUtils/mockSession";
@@ -60,12 +60,6 @@ describe("useContacts", () => {
           <SWRConfig value={{ dedupingInterval: 0 }}>{children}</SWRConfig>
         </SessionProvider>
       );
-    });
-
-    afterEach(() => {
-      cache.clear();
-      jest.clearAllMocks();
-      cleanup();
     });
 
     it("should return error", async () => {

--- a/src/hooks/useContacts/index.test.jsx
+++ b/src/hooks/useContacts/index.test.jsx
@@ -20,23 +20,21 @@
  */
 
 import React from "react";
-import { renderHook } from "@testing-library/react-hooks";
+import { renderHook, cleanup } from "@testing-library/react-hooks";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import { cache, SWRConfig } from "swr";
 import { foaf } from "rdf-namespaces";
-import usePeople from "./index";
+import useContacts from "./index";
 import mockSession from "../../../__testUtils/mockSession";
 import mockSessionContextProvider from "../../../__testUtils/mockSessionContextProvider";
-import { getContacts } from "../../addressBook";
+import * as addressBookFns from "../../addressBook";
 
-jest.mock("../../addressBook");
-
-describe("usePeople", () => {
+describe("useContacts", () => {
   describe("with no address book", () => {
     it("should return undefined", () => {
       const session = mockSession();
       const wrapper = mockSessionContextProvider(session);
-      const { result } = renderHook(() => usePeople(null), {
+      const { result } = renderHook(() => useContacts(null, foaf.Person), {
         wrapper,
       });
       expect(result.current).toMatchObject({
@@ -66,49 +64,43 @@ describe("usePeople", () => {
 
     afterEach(() => {
       cache.clear();
-    });
-
-    it("should call getContacts", async () => {
-      getContacts.mockResolvedValue({ response });
-
-      renderHook(() => usePeople(addressBook), {
-        wrapper,
-      });
-
-      expect(getContacts).toHaveBeenCalledWith(
-        foaf.Person,
-        addressBookUrl,
-        session.fetch
-      );
-    });
-
-    it("should return response", async () => {
-      getContacts.mockResolvedValue({ response });
-
-      const { result, waitFor } = renderHook(() => usePeople(addressBook), {
-        wrapper,
-      });
-
-      await waitFor(() =>
-        expect(result.current).toMatchObject({
-          data: response,
-          error: undefined,
-        })
-      );
+      jest.clearAllMocks();
+      cleanup();
     });
 
     it("should return error", async () => {
       const error = "Some error";
-      getContacts.mockResolvedValue({ error });
+      jest.spyOn(addressBookFns, "getContacts").mockResolvedValue({ error });
 
-      const { result, waitFor } = renderHook(() => usePeople(addressBook), {
-        wrapper,
-      });
+      const { result, waitFor } = renderHook(
+        () => useContacts(addressBook, foaf.Person),
+        {
+          wrapper,
+        }
+      );
 
       await waitFor(() =>
         expect(result.current).toMatchObject({
           data: undefined,
           error,
+        })
+      );
+    });
+
+    it("should return response", async () => {
+      jest.spyOn(addressBookFns, "getContacts").mockResolvedValue({ response });
+
+      const { result, waitFor } = renderHook(
+        () => useContacts(addressBook, foaf.Person),
+        {
+          wrapper,
+        }
+      );
+
+      await waitFor(() =>
+        expect(result.current).toMatchObject({
+          data: response,
+          error: undefined,
         })
       );
     });

--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -47,7 +47,6 @@ export async function getResource(iri, fetch) {
   try {
     const dataset = await getSolidDataset(iri, { fetch });
     const resource = { dataset, iri };
-
     return respond(resource);
   } catch (e) {
     return error(e.message);


### PR DESCRIPTION
# People index

The people index (`people.ttl`) is now used to show, save and delete contacts. 

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
