### PR TITLE
Feat: bookmark links open parent container and resource details drawer

### DIFF
--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -25841,7 +25841,9 @@ font-display: block;",
                       role="rowgroup"
                     >
                       <ContainerTableRow
+                        container="https://example.com/container/"
                         key="https://myaccount.mypodserver.com/inbox"
+                        preselected={false}
                         resource={
                           Object {
                             "filename": "inbox",
@@ -25903,7 +25905,9 @@ font-display: block;",
                         </tr>
                       </ContainerTableRow>
                       <ContainerTableRow
+                        container="https://example.com/container/"
                         key="https://myaccount.mypodserver.com/private"
+                        preselected={false}
                         resource={
                           Object {
                             "filename": "private",
@@ -25965,7 +25969,9 @@ font-display: block;",
                         </tr>
                       </ContainerTableRow>
                       <ContainerTableRow
+                        container="https://example.com/container/"
                         key="https://myaccount.mypodserver.com/note.txt"
+                        preselected={false}
                         resource={
                           Object {
                             "filename": "note.txt",

--- a/components/containerTableRow/__snapshots__/index.test.jsx.snap
+++ b/components/containerTableRow/__snapshots__/index.test.jsx.snap
@@ -843,6 +843,7 @@ font-display: block;",
       <table>
         <tbody>
           <ContainerTableRow
+            preselected={false}
             resource={
               Object {
                 "iri": "https://example.com/example.ttl",
@@ -1752,6 +1753,7 @@ font-display: block;",
       <table>
         <tbody>
           <ContainerTableRow
+            preselected={false}
             resource={
               Object {
                 "iri": "https://example.com/example.ttl",
@@ -2663,6 +2665,7 @@ font-display: block;",
       <table>
         <tbody>
           <ContainerTableRow
+            preselected={false}
             resource={
               Object {
                 "iri": "https://example.com/example.ttl",

--- a/components/containerTableRow/index.jsx
+++ b/components/containerTableRow/index.jsx
@@ -20,19 +20,20 @@
  */
 
 /* eslint-disable camelcase */
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { makeStyles, createStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
 import { useRouter } from "next/router";
 import clsx from "clsx";
 import T from "prop-types";
+import { isContainer } from "@inrupt/solid-client";
 import { DETAILS_CONTEXT_ACTIONS } from "../../src/contexts/detailsMenuContext";
-import { isContainerIri } from "../../src/solidClientHelpers/utils";
 import PodLocationContext from "../../src/contexts/podLocationContext";
 import ResourceLink from "../resourceLink";
 import Bookmark from "../bookmark";
 import styles from "./styles";
 import { resourceContextRedirect } from "../../src/navigator";
+import { isContainerIri } from "../../src/solidClientHelpers/utils";
 
 export function ResourceIcon({ iri, bem }) {
   // keeping it very simple for now (either folder or file), and then we can expand upon it later
@@ -64,13 +65,46 @@ export function handleAction(resourceIri, containerIri, router) {
   };
 }
 
-export default function ContainerTableRow({ resource }) {
+export function handlePreselection(resourceIri, containerIri, router) {
+  const action = DETAILS_CONTEXT_ACTIONS.DETAILS;
+  return (async () => {
+    await resourceContextRedirect(action, resourceIri, containerIri, router);
+  })();
+}
+
+export default function ContainerTableRow({
+  resource,
+  container,
+  preselected,
+}) {
   const classes = useStyles();
   const bem = useBem(classes);
   const { name, iri } = resource;
   const router = useRouter();
   const { currentUri } = useContext(PodLocationContext);
-  const isActive = router.query.resourceIri === iri;
+  const isActive = router.query.resourceIri === iri || preselected;
+  const [shouldRedirect, setShouldRedirect] = useState(preselected);
+
+  useEffect(() => {
+    if (!isContainer(iri) && preselected) {
+      setShouldRedirect(true);
+    }
+  }, [preselected, iri, setShouldRedirect]);
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      handlePreselection(iri, container, router);
+      setShouldRedirect(false);
+    }
+  }, [
+    shouldRedirect,
+    setShouldRedirect,
+    container,
+    iri,
+    router,
+    preselected,
+    resource,
+  ]);
 
   return (
     <tr
@@ -88,7 +122,7 @@ export default function ContainerTableRow({ resource }) {
         <ResourceIcon iri={iri} bem={bem} />
       </td>
       <td className={bem("table__body-cell")}>
-        {isContainerIri(iri) ? (
+        {isContainer(iri) ? (
           <ResourceLink
             containerIri={iri}
             resourceIri={iri}
@@ -112,6 +146,8 @@ ContainerTableRow.propTypes = {
     name: T.string.isRequired,
     iri: T.string.isRequired,
   }),
+  container: T.string.isRequired,
+  preselected: T.bool,
 };
 
 ContainerTableRow.defaultProps = {
@@ -119,4 +155,5 @@ ContainerTableRow.defaultProps = {
     name: "",
     iri: "",
   },
+  preselected: false,
 };

--- a/components/containerTableRow/index.jsx
+++ b/components/containerTableRow/index.jsx
@@ -82,7 +82,7 @@ export default function ContainerTableRow({
   const { name, iri } = resource;
   const router = useRouter();
   const { currentUri } = useContext(PodLocationContext);
-  const isActive = router.query.resourceIri === iri || preselected;
+  const isActive = router.query.resourceIri === iri;
   const [shouldRedirect, setShouldRedirect] = useState(preselected);
 
   useEffect(() => {

--- a/src/stringHelpers/index.js
+++ b/src/stringHelpers/index.js
@@ -55,3 +55,8 @@ export function joinPath(root, ...paths) {
 export function normalizeContainerUrl(url) {
   return joinPath(url, "");
 }
+
+export function getContainerUrl(url) {
+  const encodedIri = encodeURI(url);
+  return encodedIri.substring(0, encodedIri.lastIndexOf("/") + 1);
+}

--- a/src/stringHelpers/index.test.js
+++ b/src/stringHelpers/index.test.js
@@ -25,6 +25,7 @@ import {
   stripQueryParams,
   normalizeContainerUrl,
   joinPath,
+  getContainerUrl,
 } from "./index";
 
 describe("joinPath", () => {
@@ -118,5 +119,16 @@ describe("isUrl", () => {
 describe("stripQueryParams", () => {
   test("it removes everything in a string after a ?", () => {
     expect(stripQueryParams("foo?bar=baz")).toEqual("foo");
+  });
+});
+
+describe("getContainerUrl", () => {
+  const resourceUrl = "https://www.example.org/stuff/photo.jpg";
+  const containerUrl = "https://www.example.org/stuff/";
+  test("it returns the url of the parent container of a given resource", () => {
+    expect(getContainerUrl(resourceUrl)).toEqual(containerUrl);
+  });
+  test("it returns the same url when passed a container url", () => {
+    expect(getContainerUrl(containerUrl)).toEqual(containerUrl);
   });
 });


### PR DESCRIPTION
# Navigate to bookmarked resource

This PR fixes the issue of the "resource not supported" message when the clicking on a bookmarked resource that isn't a container, by navigating to the parent container, preselecting the row, and opening the drawer for the resource. 

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
