### PR TITLE
Fix: add min and max width to input

### DIFF
--- a/components/bookmarksList/styles.js
+++ b/components/bookmarksList/styles.js
@@ -30,7 +30,8 @@ const styles = (theme) => {
       },
     },
     search: {
-      width: 450,
+      width: "100%",
+      maxWidth: 450,
     },
     searchInput: {
       backgroundColor: theme.palette.background.default,


### PR DESCRIPTION
This PR fixes: bookmark list search box exceeding screen width in small devices.

The input box now has a max width (like the Contacts search input box) and a width.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
