### PR TITLE
Fix: move deleteFile logic out of access control

### DIFF
--- a/components/deleteResourceLink/__snapshots__/index.test.jsx.snap
+++ b/components/deleteResourceLink/__snapshots__/index.test.jsx.snap
@@ -1,17 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Delete resource link handles if useAccessControl fails 1`] = `""`;
-
-exports[`Delete resource link handles if useResourceInfo fails 1`] = `""`;
-
 exports[`Delete resource link it hooks works successfully renders a delete resource link 1`] = `
-<DeleteLink
-  confirmationContent="Are you sure you wish to delete Resource?"
-  confirmationTitle="Confirm Delete"
-  dialogId="delete-resource-iri"
-  onDelete={[Function]}
-  successMessage="Resource was successfully deleted."
+<DeleteResourceLink
+  name="Resource"
+  onDelete={[MockFunction]}
+  resourceIri="iri"
 >
-  Delete
-</DeleteLink>
+  <DeleteLink
+    confirmationContent="Are you sure you wish to delete Resource?"
+    confirmationTitle="Confirm Delete"
+    dialogId="delete-resource-iri"
+    onDelete={[Function]}
+    successMessage="Resource was successfully deleted."
+  >
+    <a
+      data-testid="delete-button"
+      href="#delete"
+      onClick={[Function]}
+    >
+      Delete
+    </a>
+  </DeleteLink>
+</DeleteResourceLink>
 `;

--- a/components/deleteResourceLink/index.jsx
+++ b/components/deleteResourceLink/index.jsx
@@ -19,18 +19,22 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 import T from "prop-types";
 import { useDataset, useSession } from "@inrupt/solid-ui-react";
 import DeleteLink from "../deleteLink";
 import usePoliciesContainer from "../../src/hooks/usePoliciesContainer";
 import AlertContext from "../../src/contexts/alertContext";
 import { deleteResource } from "../../src/solidClientHelpers/resource";
-import { getPolicyUrl } from "../../src/accessControl/acp";
 
-export function createDeleteHandler(resourceIri, policyUrl, onDelete, fetch) {
+export function createDeleteHandler(
+  resource,
+  policiesContainer,
+  onDelete,
+  fetch
+) {
   return async () => {
-    await deleteResource(resourceIri, policyUrl, fetch);
+    await deleteResource(resource, policiesContainer, fetch);
     onDelete();
   };
 }
@@ -46,23 +50,20 @@ export default function DeleteResourceLink({
 
   const { alertError } = useContext(AlertContext);
   const { policiesContainer } = usePoliciesContainer();
-  const [policyUrl, setPolicyUrl] = useState(null);
   const { dataset: resourceDataset, error: datasetError } = useDataset(
     resourceIri
   );
   if (datasetError) {
     alertError(datasetError);
   }
-
-  useEffect(() => {
-    if (!policiesContainer || !resourceDataset) return;
-    const url = getPolicyUrl(resourceDataset, policiesContainer);
-    setPolicyUrl(url);
-  }, [policiesContainer, resourceDataset, fetch]);
+  const resource = {
+    dataset: resourceDataset,
+    iri: resourceIri,
+  };
 
   const handleDelete = createDeleteHandler(
-    resourceIri,
-    policyUrl,
+    resource,
+    policiesContainer,
     onDelete,
     fetch
   );

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -844,7 +844,24 @@ font-display: block;",
         <y
           session={
             Object {
-              "fetch": [MockFunction],
+              "fetch": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "http://example.com/webId#me",
+                    Object {
+                      "headers": Object {
+                        "Accept": "text/turtle",
+                      },
+                    },
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": undefined,
+                  },
+                ],
+              },
               "handleIncomingRedirect": [MockFunction] {
                 "calls": Array [
                   Array [
@@ -6300,7 +6317,24 @@ font-display: block;",
         <y
           session={
             Object {
-              "fetch": [MockFunction],
+              "fetch": [MockFunction] {
+                "calls": Array [
+                  Array [
+                    "http://example.com/webId#me",
+                    Object {
+                      "headers": Object {
+                        "Accept": "text/turtle",
+                      },
+                    },
+                  ],
+                ],
+                "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": undefined,
+                  },
+                ],
+              },
               "handleIncomingRedirect": [MockFunction] {
                 "calls": Array [
                   Array [

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -854,8 +854,20 @@ font-display: block;",
                       },
                     },
                   ],
+                  Array [
+                    "/iri/",
+                    Object {
+                      "headers": Object {
+                        "Accept": "text/turtle",
+                      },
+                    },
+                  ],
                 ],
                 "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": undefined,
+                  },
                   Object {
                     "type": "return",
                     "value": undefined,
@@ -6327,8 +6339,20 @@ font-display: block;",
                       },
                     },
                   ],
+                  Array [
+                    "/iri/",
+                    Object {
+                      "headers": Object {
+                        "Accept": "text/turtle",
+                      },
+                    },
+                  ],
                 ],
                 "results": Array [
+                  Object {
+                    "type": "return",
+                    "value": undefined,
+                  },
                   Object {
                     "type": "return",
                     "value": undefined,

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -22,7 +22,6 @@
 import {
   acp_v1 as acp,
   asUrl,
-  deleteFile,
   getSolidDataset,
   getSourceUrl,
   saveSolidDatasetAt,
@@ -185,19 +184,6 @@ export default class AcpAccessControlStrategy {
     this.#datasetWithAcr = datasetWithAcr;
     this.#policyUrl = getPolicyUrl(datasetWithAcr, policiesContainer);
     this.#fetch = fetch;
-  }
-
-  async deleteFile() {
-    await deleteFile(getSourceUrl(this.#datasetWithAcr), {
-      fetch: this.#fetch,
-    });
-    try {
-      await deleteFile(this.#policyUrl, { fetch: this.#fetch });
-    } catch (err) {
-      if (!isHTTPError(err.message, 404)) {
-        throw err;
-      }
-    }
   }
 
   async getPermissions() {

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -27,7 +27,6 @@ import {
   saveSolidDatasetAt,
   setThing,
 } from "@inrupt/solid-client";
-import { joinPath } from "../../stringHelpers";
 import { fetchProfile } from "../../solidClientHelpers/profile";
 import {
   ACL,
@@ -39,15 +38,9 @@ import {
   chainPromise,
   createResponder,
   isHTTPError,
-  sharedStart,
 } from "../../solidClientHelpers/utils";
 import { getOrCreateDataset } from "../../solidClientHelpers/resource";
-
-const POLICIES_CONTAINER = "pb_policies/";
-
-export function getPoliciesContainerUrl(podRootUri) {
-  return joinPath(podRootUri, POLICIES_CONTAINER);
-}
+import { getPolicyUrl } from "../../solidClientHelpers/policies";
 
 export function createAcpMap(read = false, write = false, append = false) {
   return {
@@ -85,18 +78,6 @@ export function getOrCreatePermission(permissions, webId) {
     access: createAcpMap(),
   };
   return permission;
-}
-
-export function getPolicyUrl(resource, policiesContainer) {
-  const resourceUrl = getSourceUrl(resource);
-  const policiesContainerUrl = getSourceUrl(policiesContainer);
-  const rootUrl = policiesContainerUrl.substr(
-    0,
-    policiesContainerUrl.length - POLICIES_CONTAINER.length
-  );
-  const matchingStart = sharedStart(resourceUrl, rootUrl);
-  const path = resourceUrl.substr(matchingStart.length);
-  return `${getPoliciesContainerUrl(matchingStart) + path}.ttl`;
 }
 
 export function getOrCreatePolicy(policyDataset, url) {

--- a/src/accessControl/acp/index.test.js
+++ b/src/accessControl/acp/index.test.js
@@ -27,13 +27,15 @@ import AcpAccessControlStrategy, {
   createAcpMap,
   getOrCreatePermission,
   getOrCreatePolicy,
-  getPoliciesContainerUrl,
   getPolicyModesAndAgents,
-  getPolicyUrl,
   getRulesOrCreate,
   getRuleWithAgent,
   setAgents,
 } from "./index";
+import {
+  getPolicyUrl,
+  getPoliciesContainerUrl,
+} from "../../solidClientHelpers/policies";
 import { createAccessMap } from "../../solidClientHelpers/permissions";
 import { chain } from "../../solidClientHelpers/utils";
 import { mockProfileAlice } from "../../../__testUtils/mockPersonResource";
@@ -455,35 +457,6 @@ describe("getOrCreatePolicy", () => {
     );
     expect(policy).toEqual(policyThing);
     expect(dataset).toEqual(setThing(policyDataset, policyThing));
-  });
-});
-
-describe("getPolicyUrl", () => {
-  const policiesUrl = getPoliciesContainerUrl(podUrl);
-  const policies = mockSolidDatasetFrom(policiesUrl);
-
-  it("returns corresponding policy URLs", () => {
-    expect(getPolicyUrl(mockSolidDatasetFrom(podUrl), policies)).toEqual(
-      "http://example.com/pb_policies/.ttl"
-    );
-    expect(
-      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}test`), policies)
-    ).toEqual("http://example.com/pb_policies/test.ttl");
-    expect(
-      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}test.ttl`), policies)
-    ).toEqual("http://example.com/pb_policies/test.ttl.ttl");
-    expect(
-      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}foo/bar`), policies)
-    ).toEqual("http://example.com/pb_policies/foo/bar.ttl");
-    expect(getPolicyUrl(mockSolidDatasetFrom(policiesUrl), policies)).toEqual(
-      "http://example.com/pb_policies/pb_policies/.ttl"
-    );
-    expect(
-      getPolicyUrl(mockSolidDatasetFrom(`${policiesUrl}test`), policies)
-    ).toEqual("http://example.com/pb_policies/pb_policies/test.ttl");
-    expect(
-      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}public`), policies)
-    ).toEqual("http://example.com/pb_policies/public.ttl");
   });
 });
 

--- a/src/accessControl/acp/index.test.js
+++ b/src/accessControl/acp/index.test.js
@@ -89,47 +89,9 @@ describe("AcpAccessControlStrategy", () => {
       ).toHaveBeenCalledWith(resourceInfoUrl, { fetch }));
 
     it("exposes the methods we expect for a access control strategy", () =>
-      [
-        "deleteFile",
-        "getPermissions",
-        "savePermissionsForAgent",
-      ].forEach((method) => expect(acp[method]).toBeDefined()));
-  });
-
-  describe("deleteFile", () => {
-    beforeEach(() => {
-      acp = new AcpAccessControlStrategy(
-        datasetWithAcr,
-        policiesContainer,
-        fetch
-      );
-      jest.spyOn(scFns, "deleteFile").mockResolvedValue();
-    });
-    it("deletes original resource", async () => {
-      await acp.deleteFile();
-      expect(scFns.deleteFile).toHaveBeenCalledWith(datasetWithAcrUrl, {
-        fetch,
-      });
-    });
-    it("deletes the corresponding policy resource", async () => {
-      await acp.deleteFile();
-      expect(scFns.deleteFile).toHaveBeenCalledWith(
-        getPolicyUrl(datasetWithAcr, policiesContainer),
-        { fetch }
-      );
-    });
-    it("ignores if the policy resource does not exist", async () => {
-      scFns.deleteFile.mockResolvedValueOnce().mockImplementationOnce(() => {
-        throw new Error("404");
-      });
-      await expect(acp.deleteFile()).resolves.toBeUndefined();
-    });
-    it("throws the error if it's anything besides 404", async () => {
-      scFns.deleteFile.mockResolvedValueOnce().mockImplementationOnce(() => {
-        throw new Error("500");
-      });
-      await expect(acp.deleteFile()).rejects.toEqual(new Error("500"));
-    });
+      ["getPermissions", "savePermissionsForAgent"].forEach((method) =>
+        expect(acp[method]).toBeDefined()
+      ));
   });
 
   describe("getPermissions", () => {

--- a/src/hooks/usePoliciesContainer/index.js
+++ b/src/hooks/usePoliciesContainer/index.js
@@ -24,7 +24,7 @@ import { useSession } from "@inrupt/solid-ui-react";
 // eslint-disable-next-line camelcase
 import { acp_v1 } from "@inrupt/solid-client/dist";
 import useAuthenticatedProfile from "../useAuthenticatedProfile";
-import { getPoliciesContainerUrl } from "../../accessControl/acp";
+import { getPoliciesContainerUrl } from "../../solidClientHelpers/policies";
 import { getOrCreateContainer } from "../../solidClientHelpers/resource";
 import useResourceInfo from "../useResourceInfo";
 

--- a/src/hooks/usePoliciesContainer/index.test.js
+++ b/src/hooks/usePoliciesContainer/index.test.js
@@ -24,7 +24,7 @@ import { acp_v1 as acp } from "@inrupt/solid-client";
 import usePoliciesContainer from "./index";
 import mockSession, { storageUrl } from "../../../__testUtils/mockSession";
 import mockSessionContextProvider from "../../../__testUtils/mockSessionContextProvider";
-import { getPoliciesContainerUrl } from "../../accessControl/acp";
+import { getPoliciesContainerUrl } from "../../solidClientHelpers/policies";
 
 import * as resourceHelperFns from "../../solidClientHelpers/resource";
 import useResourceInfo from "../useResourceInfo";

--- a/src/solidClientHelpers/policies.js
+++ b/src/solidClientHelpers/policies.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { getSourceUrl } from "@inrupt/solid-client";
+import { sharedStart } from "./utils";
+import { joinPath } from "../stringHelpers";
+
+const POLICIES_CONTAINER = "pb_policies/";
+
+export function getPoliciesContainerUrl(podRootUri) {
+  return joinPath(podRootUri, POLICIES_CONTAINER);
+}
+
+export function getPolicyUrl(resource, policiesContainer) {
+  const resourceUrl = getSourceUrl(resource);
+  const policiesContainerUrl = getSourceUrl(policiesContainer);
+  const rootUrl = policiesContainerUrl.substr(
+    0,
+    policiesContainerUrl.length - POLICIES_CONTAINER.length
+  );
+  const matchingStart = sharedStart(resourceUrl, rootUrl);
+  const path = resourceUrl.substr(matchingStart.length);
+  return `${getPoliciesContainerUrl(matchingStart) + path}.ttl`;
+}

--- a/src/solidClientHelpers/policies.test.js
+++ b/src/solidClientHelpers/policies.test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { mockSolidDatasetFrom } from "@inrupt/solid-client";
+import { getPolicyUrl, getPoliciesContainerUrl } from "./policies";
+
+const podUrl = "http://example.com/";
+
+describe("getPolicyUrl", () => {
+  const policiesUrl = getPoliciesContainerUrl(podUrl);
+  const policies = mockSolidDatasetFrom(policiesUrl);
+
+  it("returns corresponding policy URLs", () => {
+    expect(getPolicyUrl(mockSolidDatasetFrom(podUrl), policies)).toEqual(
+      "http://example.com/pb_policies/.ttl"
+    );
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}test`), policies)
+    ).toEqual("http://example.com/pb_policies/test.ttl");
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}test.ttl`), policies)
+    ).toEqual("http://example.com/pb_policies/test.ttl.ttl");
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}foo/bar`), policies)
+    ).toEqual("http://example.com/pb_policies/foo/bar.ttl");
+    expect(getPolicyUrl(mockSolidDatasetFrom(policiesUrl), policies)).toEqual(
+      "http://example.com/pb_policies/pb_policies/.ttl"
+    );
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${policiesUrl}test`), policies)
+    ).toEqual("http://example.com/pb_policies/pb_policies/test.ttl");
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}public`), policies)
+    ).toEqual("http://example.com/pb_policies/public.ttl");
+  });
+});

--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -30,6 +30,7 @@ import {
   setThing,
 } from "@inrupt/solid-client";
 import { parseUrl } from "../stringHelpers";
+import { getPolicyUrl } from "./policies";
 import { createResponder, isContainerIri, isHTTPError } from "./utils";
 
 export function getResourceName(iri) {
@@ -105,10 +106,13 @@ export async function saveResource({ dataset, iri }, fetch) {
   }
 }
 
-export async function deleteResource(resourceIri, policyUrl, fetch) {
-  await deleteFile(resourceIri, {
+export async function deleteResource(resource, policiesContainer, fetch) {
+  const { dataset, iri } = resource;
+  await deleteFile(iri, {
     fetch,
   });
+  if (!policiesContainer) return;
+  const policyUrl = getPolicyUrl(dataset, policiesContainer);
   try {
     if (!policyUrl) return;
     await deleteFile(policyUrl, { fetch });

--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -23,6 +23,7 @@ import {
   createContainerAt,
   createSolidDataset,
   createThing,
+  deleteFile,
   getSolidDataset,
   getThing,
   saveSolidDatasetAt,
@@ -101,5 +102,19 @@ export async function saveResource({ dataset, iri }, fetch) {
     return respond(response);
   } catch (e) {
     return error(e.message);
+  }
+}
+
+export async function deleteResource(resourceIri, policyUrl, fetch) {
+  await deleteFile(resourceIri, {
+    fetch,
+  });
+  try {
+    if (!policyUrl) return;
+    await deleteFile(policyUrl, { fetch });
+  } catch (err) {
+    if (!isHTTPError(err.message, 404) && !isHTTPError(err.message, 403)) {
+      throw err;
+    }
   }
 }

--- a/src/solidClientHelpers/resource.test.js
+++ b/src/solidClientHelpers/resource.test.js
@@ -35,6 +35,7 @@ import {
   getResource,
   getResourceName,
   saveResource,
+  deleteResource,
 } from "./resource";
 
 describe("getResource", () => {
@@ -235,5 +236,41 @@ describe("saveResource", () => {
     );
 
     expect(error).toEqual("boom");
+  });
+});
+
+describe("deleteResource", () => {
+  const mockDeleteFile = jest
+    .spyOn(SolidClientFns, "deleteFile")
+    .mockImplementation(jest.fn());
+
+  test("it deletes the given resource only when no policy is found", async () => {
+    const fetch = jest.fn();
+    const resourceIri = "https://example.org/example.txt";
+    const policyUrl = null;
+
+    await deleteResource(resourceIri, policyUrl, fetch);
+
+    expect(mockDeleteFile).toHaveBeenCalledWith(resourceIri, {
+      fetch,
+    });
+    expect(mockDeleteFile).not.toHaveBeenCalledWith(policyUrl, {
+      fetch,
+    });
+  });
+
+  test("it deletes the given resource and corresponding access policy if available", async () => {
+    const policyUrl = "https://example.org/examplePolicyUrl";
+    const fetch = jest.fn();
+    const resourceIri = "https://example.org/example.txt";
+
+    await deleteResource(resourceIri, policyUrl, fetch);
+
+    expect(mockDeleteFile).toHaveBeenCalledWith(resourceIri, {
+      fetch,
+    });
+    expect(mockDeleteFile).toHaveBeenCalledWith(policyUrl, {
+      fetch,
+    });
   });
 });


### PR DESCRIPTION
This PR fixes the delay when trying to delete a resource (getting an error when clicking immediately after details drawer is loaded).

- create new deleteResource function that deletes a file and its corresponding policy (if available)
- remove deleteFile from access control
- update/add tests

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
