### PR TITLE
Returning error if you don't have access to Access Control resources

### DIFF
--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -42,6 +42,9 @@ import {
 import { getOrCreateDataset } from "../../solidClientHelpers/resource";
 import { getPolicyUrl } from "../../solidClientHelpers/policies";
 
+export const noAcrAccessError =
+  "No access to Access Control Resource for this resource";
+
 export function createAcpMap(read = false, write = false, append = false) {
   return {
     [ACL.READ.key]: read,
@@ -409,6 +412,9 @@ export default class AcpAccessControlStrategy {
     const datasetWithAcr = await acp.getResourceInfoWithAcr(resourceUrl, {
       fetch,
     });
+    if (!acp.hasAccessibleAcr(datasetWithAcr)) {
+      throw new Error(noAcrAccessError);
+    }
     return new AcpAccessControlStrategy(
       datasetWithAcr,
       policiesContainer,

--- a/src/accessControl/acp/index.test.js
+++ b/src/accessControl/acp/index.test.js
@@ -30,6 +30,7 @@ import AcpAccessControlStrategy, {
   getPolicyModesAndAgents,
   getRulesOrCreate,
   getRuleWithAgent,
+  noAcrAccessError,
   setAgents,
 } from "./index";
 import {
@@ -94,6 +95,14 @@ describe("AcpAccessControlStrategy", () => {
       ["getPermissions", "savePermissionsForAgent"].forEach((method) =>
         expect(acp[method]).toBeDefined()
       ));
+
+    it("throws an error if ACR is not accessible", async () => {
+      const dataset = mockSolidDatasetFrom(datasetWithAcrUrl);
+      acpFns.getResourceInfoWithAcr.mockResolvedValue(dataset);
+      await expect(
+        AcpAccessControlStrategy.init(resourceInfo, policiesContainer, fetch)
+      ).rejects.toEqual(new Error(noAcrAccessError));
+    });
   });
 
   describe("getPermissions", () => {

--- a/src/accessControl/wac/index.js
+++ b/src/accessControl/wac/index.js
@@ -44,6 +44,13 @@ import { displayPermissions } from "../../solidClientHelpers/permissions";
 import { fetchProfile } from "../../solidClientHelpers/profile";
 import { isUrl } from "../../stringHelpers";
 
+export const noAclError = "No available ACL resource for this resource";
+
+export function hasAcl(dataset) {
+  // TODO: stand-in until hasAcl is properly exported from @inrupt/solid-client
+  return typeof dataset.internal_acl === "object";
+}
+
 export default class WacAccessControlStrategy {
   #datasetWithAcl;
 
@@ -145,6 +152,12 @@ export default class WacAccessControlStrategy {
       getSourceUrl(resourceInfo),
       { fetch }
     );
+    if (
+      !hasAcl(datasetWithAcl) ||
+      (!hasResourceAcl(datasetWithAcl) && !hasFallbackAcl(datasetWithAcl))
+    ) {
+      throw new Error(noAclError);
+    }
     return new WacAccessControlStrategy(datasetWithAcl, fetch);
   }
 }

--- a/src/contexts/accessControlContext/index.jsx
+++ b/src/contexts/accessControlContext/index.jsx
@@ -35,10 +35,14 @@ function AccessControlProvider({ children, accessControl }) {
   );
 }
 
+AccessControlProvider.defaultProps = {
+  accessControl: null,
+};
+
 AccessControlProvider.propTypes = {
   children: T.node.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
-  accessControl: T.object.isRequired,
+  accessControl: T.object,
 };
 
 export { AccessControlProvider };


### PR DESCRIPTION
# Properly handles resources that you don't have access to

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).