### PR TITLE
Update setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
         os: [ubuntu-18.04]
-        node-version: [12.x, 10.x]
+        node-version: [14.x, 12.x, 10.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1.4.1
+      uses: actions/setup-node@v2-beta
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache node modules


### PR DESCRIPTION
Update actions/setup-node so that CI works again. The previous version, 1.4.1, had issues after GitHub [rightly fixed a security issue.](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

Additionally, add CI for node 14.x.