### PR TITLE
Added support for passing IdP using query param

### DIFF
--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -80,19 +80,19 @@ export function getErrorMessage(error) {
 
 export default function Provider({ defaultError }) {
   const buttonBem = Button.useBem();
-  const [providerIri, setProviderIri] = useState("https://inrupt.net");
   const { login } = useSession();
   const [loginError, setLoginError] = useState(defaultError);
   const theme = useTheme();
   const idp = useIdpFromQuery();
+  const [providerIri, setProviderIri] = useState(
+    Object.values(providers)[0]?.iri
+  );
   const loginFieldRef = createRef();
 
   useEffect(() => {
     if (idp) {
       setProviderIri(idp.iri);
-    }
-    if (idp && loginFieldRef.current) {
-      loginFieldRef.current.querySelector("input")?.focus();
+      loginFieldRef.current?.querySelector("input")?.focus();
     }
   }, [idp, loginFieldRef]);
 

--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -37,9 +37,8 @@ import { LoginButton, useSession } from "@inrupt/solid-ui-react";
 import { Button } from "@inrupt/prism-react-components";
 import { generateRedirectUrl } from "../../../src/windowHelpers";
 import getIdentityProviders from "../../../constants/provider";
-
 import { ERROR_REGEXES, hasError } from "../../../src/error";
-import useIdp from "../../../src/hooks/useIdp";
+import useIdpFromQuery from "../../../src/hooks/useIdpFromQuery";
 
 const providers = getIdentityProviders();
 const TESTCAFE_ID_LOGIN_TITLE = "login-title";
@@ -85,7 +84,7 @@ export default function Provider({ defaultError }) {
   const { login } = useSession();
   const [loginError, setLoginError] = useState(defaultError);
   const theme = useTheme();
-  const idp = useIdp();
+  const idp = useIdpFromQuery();
   const loginFieldRef = createRef();
 
   useEffect(() => {

--- a/components/login/provider/index.test.jsx
+++ b/components/login/provider/index.test.jsx
@@ -32,10 +32,16 @@ import ProviderLogin, {
   TESTCAFE_ID_LOGIN_FIELD,
 } from "./index";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
+import useIdp from "../../../src/hooks/useIdp";
 
 jest.mock("../../../src/windowHelpers");
+jest.mock("../../../src/hooks/useIdp");
 
 describe("ProviderLogin form", () => {
+  beforeEach(() => {
+    useIdp.mockReturnValue(null);
+  });
+
   it("renders a webid login form", () => {
     const { asFragment } = renderWithTheme(<ProviderLogin />);
     expect(asFragment()).toMatchSnapshot();
@@ -60,6 +66,18 @@ describe("ProviderLogin form", () => {
       <ProviderLogin defaultError={new Error()} />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("allows setting idp with query param", () => {
+    const iri = "http://example.com";
+    useIdp.mockReturnValue({
+      iri,
+      label: "example.com",
+    });
+    const { getByTestId } = renderWithTheme(<ProviderLogin />);
+    const input = getByTestId(TESTCAFE_ID_LOGIN_FIELD).querySelector("input");
+    expect(input.value).toEqual(iri);
+    expect(document.activeElement).toEqual(input);
   });
 });
 

--- a/components/login/provider/index.test.jsx
+++ b/components/login/provider/index.test.jsx
@@ -32,14 +32,14 @@ import ProviderLogin, {
   TESTCAFE_ID_LOGIN_FIELD,
 } from "./index";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
-import useIdp from "../../../src/hooks/useIdp";
+import useIdpFromQuery from "../../../src/hooks/useIdpFromQuery";
 
 jest.mock("../../../src/windowHelpers");
-jest.mock("../../../src/hooks/useIdp");
+jest.mock("../../../src/hooks/useIdpFromQuery");
 
 describe("ProviderLogin form", () => {
   beforeEach(() => {
-    useIdp.mockReturnValue(null);
+    useIdpFromQuery.mockReturnValue(null);
   });
 
   it("renders a webid login form", () => {
@@ -70,7 +70,7 @@ describe("ProviderLogin form", () => {
 
   it("allows setting idp with query param", () => {
     const iri = "http://example.com";
-    useIdp.mockReturnValue({
+    useIdpFromQuery.mockReturnValue({
       iri,
       label: "example.com",
     });

--- a/components/pages/login/index.test.jsx
+++ b/components/pages/login/index.test.jsx
@@ -23,10 +23,16 @@ import React from "react";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
 import { useRedirectIfLoggedIn } from "../../../src/effects/auth";
 import LoginPage from "./index";
+import useIdp from "../../../src/hooks/useIdp";
 
 jest.mock("../../../src/effects/auth");
+jest.mock("../../../src/hooks/useIdp");
 
 describe("Login page", () => {
+  beforeEach(() => {
+    useIdp.mockReturnValue(null);
+  });
+
   test("Renders a login button", () => {
     const { asFragment } = renderWithTheme(<LoginPage />);
     expect(asFragment()).toMatchSnapshot();

--- a/components/pages/login/index.test.jsx
+++ b/components/pages/login/index.test.jsx
@@ -23,14 +23,14 @@ import React from "react";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
 import { useRedirectIfLoggedIn } from "../../../src/effects/auth";
 import LoginPage from "./index";
-import useIdp from "../../../src/hooks/useIdp";
+import useIdpFromQuery from "../../../src/hooks/useIdpFromQuery";
 
 jest.mock("../../../src/effects/auth");
-jest.mock("../../../src/hooks/useIdp");
+jest.mock("../../../src/hooks/useIdpFromQuery");
 
 describe("Login page", () => {
   beforeEach(() => {
-    useIdp.mockReturnValue(null);
+    useIdpFromQuery.mockReturnValue(null);
   });
 
   test("Renders a login button", () => {

--- a/src/hooks/useIdp/index.js
+++ b/src/hooks/useIdp/index.js
@@ -19,20 +19,32 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import Login from "./index";
-import { renderWithTheme } from "../../__testUtils/withTheme";
-import useIdp from "../../src/hooks/useIdp";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 
-jest.mock("../../src/hooks/useIdp");
+export default function useIdp() {
+  const [idp, setIdp] = useState(null);
+  const router = useRouter();
 
-describe("Login form", () => {
-  beforeEach(() => {
-    useIdp.mockReturnValue(null);
-  });
+  useEffect(() => {
+    const idpQuery =
+      typeof router.query.idp === "object"
+        ? router.query.idp[0]
+        : router.query.idp;
+    if (!idpQuery) {
+      setIdp(null);
+      return;
+    }
+    try {
+      const idpUrl = new URL(idpQuery);
+      setIdp({
+        iri: idpQuery,
+        label: idpUrl.hostname,
+      });
+    } catch (err) {
+      setIdp(null);
+    }
+  }, [router]);
 
-  test("Renders a login form, with button bound to swapLoginType", () => {
-    const { asFragment } = renderWithTheme(<Login />);
-    expect(asFragment()).toMatchSnapshot();
-  });
-});
+  return idp;
+}

--- a/src/hooks/useIdp/index.test.js
+++ b/src/hooks/useIdp/index.test.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import * as routerFns from "next/router";
+import { renderHook } from "@testing-library/react-hooks";
+import useIdp from "./index";
+
+describe("useIdp", () => {
+  it("returns null when there is no idp query param", () => {
+    jest.spyOn(routerFns, "useRouter").mockReturnValue({ query: {} });
+    const { result } = renderHook(() => useIdp());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns an object with a valid idp query param", () => {
+    const idp = "https://example.com";
+    jest.spyOn(routerFns, "useRouter").mockReturnValue({ query: { idp } });
+    const { result } = renderHook(() => useIdp());
+    expect(result.current).toEqual({
+      iri: idp,
+      label: "example.com",
+    });
+  });
+
+  it("will choose the first idp in a list of idps", () => {
+    const idp1 = "https://example.com";
+    const idp2 = "https://example2.com";
+    jest
+      .spyOn(routerFns, "useRouter")
+      .mockReturnValue({ query: { idp: [idp1, idp2] } });
+    const { result } = renderHook(() => useIdp());
+    expect(result.current).toEqual({
+      iri: idp1,
+      label: "example.com",
+    });
+  });
+
+  it("returns null on invalid idp query param", () => {
+    jest
+      .spyOn(routerFns, "useRouter")
+      .mockReturnValue({ query: { idp: "test" } });
+    const { result } = renderHook(() => useIdp());
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/useIdpFromQuery/index.js
+++ b/src/hooks/useIdpFromQuery/index.js
@@ -19,20 +19,28 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import Login from "./index";
-import { renderWithTheme } from "../../__testUtils/withTheme";
-import useIdpFromQuery from "../../src/hooks/useIdpFromQuery";
+import { useEffect, useState } from "react";
+import useQuery from "../useQuery";
 
-jest.mock("../../src/hooks/useIdpFromQuery");
+export default function useIdpFromQuery() {
+  const [idp, setIdp] = useState(null);
+  const idpQuery = useQuery("idp");
 
-describe("Login form", () => {
-  beforeEach(() => {
-    useIdpFromQuery.mockReturnValue(null);
-  });
+  useEffect(() => {
+    if (!idpQuery) {
+      setIdp(null);
+      return;
+    }
+    try {
+      const idpUrl = new URL(idpQuery);
+      setIdp({
+        iri: idpQuery,
+        label: idpUrl.hostname,
+      });
+    } catch (err) {
+      setIdp(null);
+    }
+  }, [idpQuery]);
 
-  test("Renders a login form, with button bound to swapLoginType", () => {
-    const { asFragment } = renderWithTheme(<Login />);
-    expect(asFragment()).toMatchSnapshot();
-  });
-});
+  return idp;
+}

--- a/src/hooks/useIdpFromQuery/index.test.js
+++ b/src/hooks/useIdpFromQuery/index.test.js
@@ -19,45 +19,32 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as routerFns from "next/router";
 import { renderHook } from "@testing-library/react-hooks";
-import useIdp from "./index";
+import useIdpFromQuery from "./index";
+import useQuery from "../useQuery";
 
-describe("useIdp", () => {
+jest.mock("../useQuery");
+
+describe("useIdpFromQuery", () => {
   it("returns null when there is no idp query param", () => {
-    jest.spyOn(routerFns, "useRouter").mockReturnValue({ query: {} });
-    const { result } = renderHook(() => useIdp());
+    useQuery.mockReturnValue(undefined);
+    const { result } = renderHook(() => useIdpFromQuery());
     expect(result.current).toBeNull();
   });
 
   it("returns an object with a valid idp query param", () => {
     const idp = "https://example.com";
-    jest.spyOn(routerFns, "useRouter").mockReturnValue({ query: { idp } });
-    const { result } = renderHook(() => useIdp());
+    useQuery.mockReturnValue(idp);
+    const { result } = renderHook(() => useIdpFromQuery());
     expect(result.current).toEqual({
       iri: idp,
       label: "example.com",
     });
   });
 
-  it("will choose the first idp in a list of idps", () => {
-    const idp1 = "https://example.com";
-    const idp2 = "https://example2.com";
-    jest
-      .spyOn(routerFns, "useRouter")
-      .mockReturnValue({ query: { idp: [idp1, idp2] } });
-    const { result } = renderHook(() => useIdp());
-    expect(result.current).toEqual({
-      iri: idp1,
-      label: "example.com",
-    });
-  });
-
   it("returns null on invalid idp query param", () => {
-    jest
-      .spyOn(routerFns, "useRouter")
-      .mockReturnValue({ query: { idp: "test" } });
-    const { result } = renderHook(() => useIdp());
+    useQuery.mockReturnValue("test");
+    const { result } = renderHook(() => useIdpFromQuery());
     expect(result.current).toBeNull();
   });
 });

--- a/src/hooks/useQuery/index.js
+++ b/src/hooks/useQuery/index.js
@@ -22,29 +22,16 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 
-export default function useIdp() {
-  const [idp, setIdp] = useState(null);
+export default function useQuery(key) {
+  const [query, setQuery] = useState();
   const router = useRouter();
 
   useEffect(() => {
-    const idpQuery =
-      typeof router.query.idp === "object"
-        ? router.query.idp[0]
-        : router.query.idp;
-    if (!idpQuery) {
-      setIdp(null);
-      return;
-    }
-    try {
-      const idpUrl = new URL(idpQuery);
-      setIdp({
-        iri: idpQuery,
-        label: idpUrl.hostname,
-      });
-    } catch (err) {
-      setIdp(null);
-    }
-  }, [router]);
-
-  return idp;
+    setQuery(
+      Array.isArray(router.query[key])
+        ? router.query[key][0]
+        : router.query[key]
+    );
+  }, [key, router]);
+  return query;
 }

--- a/src/hooks/useQuery/index.test.js
+++ b/src/hooks/useQuery/index.test.js
@@ -19,20 +19,35 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import Login from "./index";
-import { renderWithTheme } from "../../__testUtils/withTheme";
-import useIdpFromQuery from "../../src/hooks/useIdpFromQuery";
+import * as routerFns from "next/router";
+import { renderHook } from "@testing-library/react-hooks";
+import useQuery from "./index";
 
-jest.mock("../../src/hooks/useIdpFromQuery");
+describe("useQuery", () => {
+  const value1 = "value1";
+  const value2 = "value2";
 
-describe("Login form", () => {
   beforeEach(() => {
-    useIdpFromQuery.mockReturnValue(null);
+    jest.spyOn(routerFns, "useRouter").mockReturnValue({
+      query: {
+        bar: value1,
+        baz: [value2, value1],
+      },
+    });
   });
 
-  test("Renders a login form, with button bound to swapLoginType", () => {
-    const { asFragment } = renderWithTheme(<Login />);
-    expect(asFragment()).toMatchSnapshot();
+  it("returns undefined when there is no query param", () => {
+    const { result } = renderHook(() => useQuery("foo"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the value if query param is given", () => {
+    const { result } = renderHook(() => useQuery("bar"));
+    expect(result.current).toEqual(value1);
+  });
+
+  it("will choose the first value in a list of query params", () => {
+    const { result } = renderHook(() => useQuery("baz"));
+    expect(result.current).toEqual(value2);
   });
 });

--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -44,7 +44,6 @@ import {
   normalizeDataset,
   sharedStart,
 } from "./utils";
-import { isHTTPError } from "../error";
 
 const TIMESTAMP = new Date(Date.UTC(2020, 5, 2, 15, 59, 21));
 


### PR DESCRIPTION
# Allows passing IdP using query param

Can pass Idp to the login provider using a query param, e.g. `?idp=https%3A%2F%2Finrupt.net%2F`.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
