### PR TITLE
Fix: disallow existing or own webId in permissions

### DIFF
--- a/components/addPermissionUsingWebIdButton/index.jsx
+++ b/components/addPermissionUsingWebIdButton/index.jsx
@@ -108,7 +108,6 @@ export default function AddPermissionUsingWebIdButton({
 
   useEffect(() => {
     if (!accessControl) {
-      setPermissions(null);
       return;
     }
     accessControl.getPermissions().then((normalizedPermissions) => {

--- a/components/addPermissionUsingWebIdButton/index.jsx
+++ b/components/addPermissionUsingWebIdButton/index.jsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable react/jsx-props-no-spreading */
 
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import T from "prop-types";
 import { createStyles, makeStyles, Popover } from "@material-ui/core";
 import { InputGroup, Label, Message } from "@inrupt/prism-react-components";
@@ -99,11 +99,22 @@ export default function AddPermissionUsingWebIdButton({
 }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const [access, setAccess] = useState(createAccessMap(true));
+  const [permissions, setPermissions] = useState(null);
   const classes = useStyles();
   const [disabled, setDisabled] = useState(false);
   const { accessControl } = useContext(AccessControlContext);
   const [agentId, setAgentId] = useState("");
   const [dirtyForm, setDirtyForm] = useState(false);
+
+  useEffect(() => {
+    if (!accessControl) {
+      setPermissions(null);
+      return;
+    }
+    accessControl.getPermissions().then((normalizedPermissions) => {
+      setPermissions(normalizedPermissions.reverse());
+    });
+  }, [accessControl]);
 
   const handleChange = changeHandler(setAgentId);
 
@@ -123,7 +134,8 @@ export default function AddPermissionUsingWebIdButton({
     access,
     setDisabled,
     handleClose,
-    setDirtyForm
+    setDirtyForm,
+    permissions
   );
 
   const open = Boolean(anchorEl);
@@ -161,6 +173,7 @@ export default function AddPermissionUsingWebIdButton({
           onChange={handleChange}
           onSubmit={onSubmit}
           value={agentId}
+          permissions={permissions}
         >
           <InputGroup>
             <Label>Assign permissions</Label>

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -62,6 +62,8 @@ function AgentSearchForm({
 
   const handleChange = (event) => {
     onChange(event.target.value);
+    setIsPodOwner(false);
+    setExistingWebId(null);
   };
 
   return (

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -65,7 +65,7 @@ function AgentSearchForm({
         <Message variant="invalid">Please provide a valid WebID</Message>
       ) : null}
       {existingWebId ? (
-        <Message variant="error">
+        <Message variant="invalid">
           {session.info.webId === existingWebId
             ? "You cannot overwrite your own permissions."
             : `The WebID ${existingWebId} is already in your permissions.`}

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -45,8 +45,14 @@ function AgentSearchForm({
   const [dirtyWebIdField, setDirtyWebIdField] = useState(dirtyForm);
   const invalidWebIdField = !value && (dirtyForm || dirtyWebIdField);
   const [existingWebId, setExistingWebId] = useState(null);
+  const [isPodOwner, setIsPodOwner] = useState(false);
+
   const handleSubmit = async (event) => {
     event.preventDefault();
+    if (value === session.info.webId) {
+      setIsPodOwner(true);
+      return;
+    }
     if (permissions.filter((p) => p.webId === value).length) {
       setExistingWebId(value);
       return;
@@ -64,11 +70,14 @@ function AgentSearchForm({
       {invalidWebIdField ? (
         <Message variant="invalid">Please provide a valid WebID</Message>
       ) : null}
+      {isPodOwner ? (
+        <Message variant="invalid">
+          You cannot overwrite your own permissions.
+        </Message>
+      ) : null}
       {existingWebId ? (
         <Message variant="invalid">
-          {session.info.webId === existingWebId
-            ? "You cannot overwrite your own permissions."
-            : `The WebID ${existingWebId} is already in your permissions.`}
+          {`The WebID ${existingWebId} is already in your permissions.`}
         </Message>
       ) : null}
       <SimpleInput
@@ -80,7 +89,7 @@ function AgentSearchForm({
         title="Must start with https://"
         onBlur={() => setDirtyWebIdField(true)}
         required={invalidWebIdField}
-        variant={existingWebId ? "invalid" : null}
+        variant={existingWebId || isPodOwner ? "invalid" : null}
       />
 
       {children}

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -29,6 +29,7 @@ import {
   Message,
   SimpleInput,
 } from "@inrupt/prism-react-components";
+import { useSession } from "@inrupt/solid-ui-react";
 
 function AgentSearchForm({
   children,
@@ -37,13 +38,19 @@ function AgentSearchForm({
   value,
   onChange,
   dirtyForm,
+  permissions,
 }) {
   const inputId = useId();
+  const { session } = useSession();
   const [dirtyWebIdField, setDirtyWebIdField] = useState(dirtyForm);
   const invalidWebIdField = !value && (dirtyForm || dirtyWebIdField);
-
+  const [existingWebId, setExistingWebId] = useState(null);
   const handleSubmit = async (event) => {
     event.preventDefault();
+    if (permissions.filter((p) => p.webId === value).length) {
+      setExistingWebId(value);
+      return;
+    }
     await onSubmit(value);
   };
 
@@ -56,6 +63,13 @@ function AgentSearchForm({
       <Label>WebID</Label>
       {invalidWebIdField ? (
         <Message variant="invalid">Please provide a valid WebID</Message>
+      ) : null}
+      {existingWebId ? (
+        <Message variant="error">
+          {session.info.webId === existingWebId
+            ? "You cannot overwrite your own permissions."
+            : `The WebID ${existingWebId} is already in your permissions.`}
+        </Message>
       ) : null}
       <SimpleInput
         id={inputId}
@@ -82,6 +96,7 @@ AgentSearchForm.propTypes = {
   onChange: T.func,
   onSubmit: T.func,
   value: T.string,
+  permissions: T.arrayOf(T.shape),
 };
 
 AgentSearchForm.defaultProps = {
@@ -91,6 +106,7 @@ AgentSearchForm.defaultProps = {
   onChange: () => {},
   onSubmit: () => {},
   value: "",
+  permissions: null,
 };
 
 export default AgentSearchForm;

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -69,19 +69,19 @@ function AgentSearchForm({
   return (
     <Form onSubmit={handleSubmit}>
       <Label>WebID</Label>
-      {invalidWebIdField ? (
+      {invalidWebIdField && (
         <Message variant="invalid">Please provide a valid WebID</Message>
-      ) : null}
-      {isPodOwner ? (
+      )}
+      {isPodOwner && (
         <Message variant="invalid">
           You cannot overwrite your own permissions.
         </Message>
-      ) : null}
-      {existingWebId ? (
+      )}
+      {existingWebId && (
         <Message variant="invalid">
           {`The WebID ${existingWebId} is already in your permissions.`}
         </Message>
-      ) : null}
+      )}
       <SimpleInput
         id={inputId}
         onChange={handleChange}

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -80,6 +80,7 @@ function AgentSearchForm({
         title="Must start with https://"
         onBlur={() => setDirtyWebIdField(true)}
         required={invalidWebIdField}
+        variant={existingWebId ? "invalid" : null}
       />
 
       {children}

--- a/components/containerPageHeader/index.test.jsx
+++ b/components/containerPageHeader/index.test.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import { useRouter } from "next/router";
-import { screen, render } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { useSession } from "@inrupt/solid-ui-react";
 import { renderWithTheme } from "../../__testUtils/withTheme";
 import ContainerPageHeader from "./index";


### PR DESCRIPTION
This PR fixes bug: users can still overwrite their own permissions by re-adding their webId.

We now display an error when the users tries to add themselves to the permissions, or a webId that is also in the permissions for that resource.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

