### PR TITLE
Added default content-type to uploaded files

### DIFF
--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -48,11 +48,14 @@ export function handleSaveResource({
   return async (uploadedFile) => {
     try {
       const fileName = normalizeSafeFileName(uploadedFile.name);
+      const { type } = uploadedFile;
+      Object.defineProperty(uploadedFile, "type", {
+        get: () => type || "application/octet-stream",
+      });
       await overwriteFile(
         joinPath(currentUri, encodeURIComponent(fileName)),
         uploadedFile,
         {
-          type: uploadedFile.type,
           fetch,
         }
       );
@@ -139,8 +142,13 @@ export function handleConfirmation({
   setConfirmationSetup,
 }) {
   return (confirmationSetup, confirmed, file, open) => {
-    if (confirmationSetup && confirmed === null && open === DUPLICATE_DIALOG_ID)
+    if (
+      confirmationSetup &&
+      confirmed === null &&
+      open === DUPLICATE_DIALOG_ID
+    ) {
       return;
+    }
 
     if (confirmationSetup && confirmed && open === DUPLICATE_DIALOG_ID) {
       saveResource(file);


### PR DESCRIPTION
# Added default content-type to uploaded files

Sets `application/octet-stream` as fallback for files that the browser are not able to figure out content type for.

Also improved test coverage.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).