### PR TITLE
Fix: move useResourceInfo into submit handler

### DIFF
--- a/components/podIndicator/podNavigatorPopover/__snapshots__/index.test.jsx.snap
+++ b/components/podIndicator/podNavigatorPopover/__snapshots__/index.test.jsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`it renders the pod indicator with the correct name with a formatted name 1`] = `<DocumentFragment />`;
+exports[`PodNavigatorPopover renders a pod navigator popover 1`] = `<DocumentFragment />`;

--- a/components/podIndicator/podNavigatorPopover/index.jsx
+++ b/components/podIndicator/podNavigatorPopover/index.jsx
@@ -53,12 +53,18 @@ export const submitHandler = (
   setUrl,
   setDirtyForm,
   setDirtyUrlField
-) => async (event, sourceUrl, router) => {
+) => async (event, url, router) => {
   event.preventDefault();
   setDirtyForm(true);
-  if (sourceUrl === "") {
+
+  if (url === "") {
     return;
   }
+
+  const { data: resourceInfo } = useResourceInfo(url);
+  const sourceUrl =
+    (resourceInfo && getSourceIri(resourceInfo)) || normalizeContainerUrl(url);
+
   await router.push("/resource/[iri]", resourceHref(sourceUrl));
   handleClose();
   setDirtyForm(false);
@@ -81,10 +87,6 @@ export default function PodNavigatorPopover({
   const [dirtyForm, setDirtyForm] = useState(false);
   const [dirtyUrlField, setDirtyUrlField] = useState(false);
   const invalidUrlField = !url && (dirtyForm || dirtyUrlField);
-
-  const { data: resourceInfo } = useResourceInfo(url);
-  const sourceUrl =
-    (resourceInfo && getSourceIri(resourceInfo)) || normalizeContainerUrl(url);
 
   const open = Boolean(anchorEl);
   const id = open ? "pod-navigator" : undefined;
@@ -118,7 +120,7 @@ export default function PodNavigatorPopover({
         horizontal: "left",
       }}
     >
-      <Form onSubmit={(event) => onSubmit(event, sourceUrl, router)}>
+      <Form onSubmit={(event) => onSubmit(event, url, router)}>
         <Label id="PodNavigator">Go to Pod</Label>
         {invalidUrlField ? (
           <Message variant="invalid">Please enter valid URL</Message>

--- a/components/podIndicator/podNavigatorPopover/index.test.jsx
+++ b/components/podIndicator/podNavigatorPopover/index.test.jsx
@@ -149,6 +149,8 @@ describe("submitHandler", () => {
   });
 
   test("it sets up a submit handler", async () => {
+    const resourceInfo = mockSolidDatasetFrom(url);
+    useResourceInfo.mockReturnValue({ data: resourceInfo });
     await submitHandler(
       handleClose,
       setUrl,

--- a/components/podIndicator/podNavigatorPopover/index.test.jsx
+++ b/components/podIndicator/podNavigatorPopover/index.test.jsx
@@ -20,9 +20,7 @@
  */
 
 import React from "react";
-import { mockSolidDatasetFrom } from "@inrupt/solid-client";
-import * as RouterFns from "next/router";
-import userEvent from "@testing-library/user-event";
+import * as solidClientFns from "@inrupt/solid-client";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
 import PodNavigatorPopover, {
   submitHandler,
@@ -30,156 +28,174 @@ import PodNavigatorPopover, {
   clickHandler,
 } from "./index";
 import { resourceHref } from "../../../src/navigator";
-import useResourceInfo from "../../../src/hooks/useResourceInfo";
-
-jest.mock("../../../src/hooks/useResourceInfo");
-
-test("it renders the pod indicator with the correct name with a formatted name", async () => {
-  const resourceInfo = mockSolidDatasetFrom("https://example.org/");
-  useResourceInfo.mockReturnValue({ data: resourceInfo });
-  const { asFragment, queryByText } = renderWithTheme(
-    <PodNavigatorPopover
-      anchor={{}}
-      setDisplayNavigator={() => {}}
-      popoverWidth={100}
-    />
-  );
-  expect(queryByText("Alice")).toBeDefined();
-  expect(asFragment()).toMatchSnapshot();
-});
 
 describe("PodNavigatorPopover", () => {
-  const router = { push: jest.fn() };
-  jest.spyOn(RouterFns, "useRouter").mockReturnValue(router);
-  test("it redirects with the correct url for a container on submit", () => {
-    const resourceInfo = mockSolidDatasetFrom("https://example.org/Photos/");
-    useResourceInfo.mockReturnValue({ data: resourceInfo });
-
-    const { getByTestId } = renderWithTheme(
+  test("renders a pod navigator popover", () => {
+    const { asFragment } = renderWithTheme(
       <PodNavigatorPopover
         anchor={{}}
-        setDisplayNavigator={() => {}}
+        setDisplayNavigator={jest.fn()}
         popoverWidth={100}
       />
     );
-    const button = getByTestId("pod-navigate-button");
-    const input = getByTestId("pod-navigate-input");
-    userEvent.type(input, "https://example.org/Photos");
-    userEvent.click(button);
-    expect(router.push).toHaveBeenCalledWith(
-      "/resource/[iri]",
-      resourceHref("https://example.org/Photos/")
-    );
+    expect(asFragment()).toMatchSnapshot();
   });
-  test("it redirects with the correct url for a resource on submit", () => {
-    const resourceInfo = mockSolidDatasetFrom("https://example.org/photo.jpg");
-    useResourceInfo.mockReturnValue({ data: resourceInfo });
-    const { getByTestId } = renderWithTheme(
-      <PodNavigatorPopover
-        anchor={{}}
-        setDisplayNavigator={() => {}}
-        popoverWidth={100}
-      />
-    );
-    const button = getByTestId("pod-navigate-button");
-    const input = getByTestId("pod-navigate-input");
-    userEvent.type(input, "https://example.org/photo.jpg");
-    userEvent.click(button);
-    expect(router.push).toHaveBeenCalledWith(
-      "/resource/[iri]",
-      resourceHref("https://example.org/photo.jpg")
-    );
-  });
-  test("it redirects to a url with ending slash when it cannot fetch the source url", () => {
-    const resourceInfo = null;
-    useResourceInfo.mockReturnValue({ data: resourceInfo });
-    const { getByTestId } = renderWithTheme(
-      <PodNavigatorPopover
-        anchor={{}}
-        setDisplayNavigator={() => {}}
-        popoverWidth={100}
-      />
-    );
-    const button = getByTestId("pod-navigate-button");
-    const input = getByTestId("pod-navigate-input");
-    userEvent.type(input, "https://example.org/photo.jpg");
-    userEvent.click(button);
-    expect(router.push).toHaveBeenCalledWith(
-      "/resource/[iri]",
-      resourceHref("https://example.org/photo.jpg/")
-    );
-  });
-});
+  describe("submitHandler", () => {
+    const url = "http://url.com";
+    let event;
+    let handleClose;
+    let setUrl;
+    const router = {};
+    let setDirtyForm;
+    let setDirtyUrlField;
+    const fetch = jest.fn();
 
-describe("submitHandler", () => {
-  const url = "http://url.com";
-  let event;
-  let handleClose;
-  let setUrl;
-  const router = {};
-  let setDirtyForm;
-  let setDirtyUrlField;
-
-  beforeEach(() => {
-    event = { preventDefault: jest.fn() };
-    handleClose = jest.fn();
-    setUrl = jest.fn();
-    router.push = jest.fn();
-    setDirtyForm = jest.fn();
-    setDirtyUrlField = jest.fn();
-  });
-
-  describe("clickHandler", () => {
-    test("it sets up a click handler", () => {
-      const setAnchorEl = jest.fn();
-      const currentTarget = "test";
-      clickHandler(setAnchorEl)({ currentTarget });
-      expect(setAnchorEl).toHaveBeenCalledWith(currentTarget);
+    beforeEach(() => {
+      event = { preventDefault: jest.fn() };
+      handleClose = jest.fn();
+      setUrl = jest.fn();
+      router.push = jest.fn();
+      setDirtyForm = jest.fn();
+      setDirtyUrlField = jest.fn();
     });
-  });
 
-  describe("closeHandler", () => {
-    test("it sets up a close handler", () => {
-      const setAnchorEl = jest.fn();
-      const setDisplayNavigator = jest.fn();
-      closeHandler(setAnchorEl, setDisplayNavigator)();
-      expect(setAnchorEl).toHaveBeenCalledWith(null);
-      expect(setDisplayNavigator).toHaveBeenCalledWith(false);
+    describe("clickHandler", () => {
+      test("it sets up a click handler", () => {
+        const setAnchorEl = jest.fn();
+        const currentTarget = "test";
+        clickHandler(setAnchorEl)({ currentTarget });
+        expect(setAnchorEl).toHaveBeenCalledWith(currentTarget);
+      });
     });
-  });
 
-  test("it sets up a submit handler", async () => {
-    const resourceInfo = mockSolidDatasetFrom(url);
-    useResourceInfo.mockReturnValue({ data: resourceInfo });
-    await submitHandler(
-      handleClose,
-      setUrl,
-      setDirtyForm,
-      setDirtyUrlField
-    )(event, url, router);
-    expect(event.preventDefault).toHaveBeenCalledWith();
-    expect(router.push).toHaveBeenCalledWith(
-      "/resource/[iri]",
-      resourceHref(url)
-    );
-    expect(handleClose).toHaveBeenCalledWith();
-    expect(setUrl).toHaveBeenCalledWith("");
-    expect(setDirtyForm).toHaveBeenCalledWith(false);
-    expect(setDirtyUrlField).toHaveBeenCalledWith(false);
-  });
+    describe("closeHandler", () => {
+      test("it sets up a close handler", () => {
+        const setAnchorEl = jest.fn();
+        const setDisplayNavigator = jest.fn();
+        closeHandler(setAnchorEl, setDisplayNavigator)();
+        expect(setAnchorEl).toHaveBeenCalledWith(null);
+        expect(setDisplayNavigator).toHaveBeenCalledWith(false);
+      });
+    });
 
-  it("should do nothing if no url is given", async () => {
-    await submitHandler(
-      handleClose,
-      setUrl,
-      setDirtyForm,
-      setDirtyUrlField
-    )(event, "", router);
-    expect(event.preventDefault).toHaveBeenCalledWith();
-    expect(router.push).not.toHaveBeenCalled();
-    expect(handleClose).not.toHaveBeenCalled();
-    expect(setUrl).not.toHaveBeenCalled();
-    expect(setDirtyForm).toHaveBeenCalledWith(true);
-    expect(setDirtyUrlField).not.toHaveBeenCalled();
+    test("it sets up a submit handler", async () => {
+      const resourceInfo = solidClientFns.mockSolidDatasetFrom(url);
+      jest
+        .spyOn(solidClientFns, "getResourceInfo")
+        .mockResolvedValue(resourceInfo);
+      await submitHandler(
+        handleClose,
+        setUrl,
+        setDirtyForm,
+        setDirtyUrlField,
+        url,
+        router,
+        fetch
+      )(event);
+      expect(event.preventDefault).toHaveBeenCalledWith();
+      expect(router.push).toHaveBeenCalledWith(
+        "/resource/[iri]",
+        resourceHref(url)
+      );
+      expect(handleClose).toHaveBeenCalledWith();
+      expect(setUrl).toHaveBeenCalledWith("");
+      expect(setDirtyForm).toHaveBeenCalledWith(false);
+      expect(setDirtyUrlField).toHaveBeenCalledWith(false);
+    });
+
+    it("should do nothing if no url is given", async () => {
+      await submitHandler(
+        handleClose,
+        setUrl,
+        setDirtyForm,
+        setDirtyUrlField,
+        "",
+        router,
+        fetch
+      )(event);
+      expect(event.preventDefault).toHaveBeenCalledWith();
+      expect(router.push).not.toHaveBeenCalled();
+      expect(handleClose).not.toHaveBeenCalled();
+      expect(setUrl).not.toHaveBeenCalled();
+      expect(setDirtyForm).toHaveBeenCalledWith(true);
+      expect(setDirtyUrlField).not.toHaveBeenCalled();
+    });
+
+    it("it redirects with the correct url for a container on submit", async () => {
+      const resourceInfo = solidClientFns.mockSolidDatasetFrom(
+        "https://example.org/Photos/"
+      );
+      jest
+        .spyOn(solidClientFns, "getResourceInfo")
+        .mockResolvedValue(resourceInfo);
+      await submitHandler(
+        handleClose,
+        setUrl,
+        setDirtyForm,
+        setDirtyUrlField,
+        "https://example.org/Photos",
+        router,
+        fetch
+      )(event);
+      expect(event.preventDefault).toHaveBeenCalledWith();
+      expect(router.push).toHaveBeenCalledWith(
+        "/resource/[iri]",
+        resourceHref("https://example.org/Photos/")
+      );
+      expect(handleClose).toHaveBeenCalled();
+      expect(setUrl).toHaveBeenCalled();
+      expect(setDirtyForm).toHaveBeenCalledWith(false);
+      expect(setDirtyUrlField).toHaveBeenCalledWith(false);
+    });
+
+    it("redirects with the correct url for a resource on submit", async () => {
+      const resourceInfo = solidClientFns.mockSolidDatasetFrom(
+        "https://example.org/photo.jpg"
+      );
+      jest
+        .spyOn(solidClientFns, "getResourceInfo")
+        .mockResolvedValue(resourceInfo);
+      await submitHandler(
+        handleClose,
+        setUrl,
+        setDirtyForm,
+        setDirtyUrlField,
+        "https://example.org/photo.jpg",
+        router,
+        fetch
+      )(event, "https://example.org/photo.jpg", router);
+      expect(event.preventDefault).toHaveBeenCalledWith();
+      expect(router.push).toHaveBeenCalledWith(
+        "/resource/[iri]",
+        resourceHref("https://example.org/photo.jpg")
+      );
+      expect(handleClose).toHaveBeenCalled();
+      expect(setUrl).toHaveBeenCalled();
+      expect(setDirtyForm).toHaveBeenCalledWith(false);
+      expect(setDirtyUrlField).toHaveBeenCalledWith(false);
+    });
+    it("redirects to a url with ending slash when it cannot fetch the source url", async () => {
+      jest
+        .spyOn(solidClientFns, "getResourceInfo")
+        .mockRejectedValue(new Error("error"));
+      await submitHandler(
+        handleClose,
+        setUrl,
+        setDirtyForm,
+        setDirtyUrlField,
+        "https://example.org/photo.jpg",
+        router,
+        fetch
+      )(event);
+      expect(event.preventDefault).toHaveBeenCalledWith();
+      expect(router.push).toHaveBeenCalledWith(
+        "/resource/[iri]",
+        resourceHref("https://example.org/photo.jpg/")
+      );
+      expect(handleClose).toHaveBeenCalled();
+      expect(setUrl).toHaveBeenCalled();
+      expect(setDirtyForm).toHaveBeenCalledWith(false);
+      expect(setDirtyUrlField).toHaveBeenCalledWith(false);
+    });
   });
 });


### PR DESCRIPTION
This PR fixes: HEAD requests on input change on pod navigator

- <del>move the `useResourceInfo` to the handler</del> refactor to use `getResourceInfo` directly in the submit handler
- update tests

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).