### PR TITLE
Making sure we don't get policy resource URLs with double slashes

### DIFF
--- a/src/solidClientHelpers/policies.js
+++ b/src/solidClientHelpers/policies.js
@@ -37,6 +37,6 @@ export function getPolicyUrl(resource, policiesContainer) {
     policiesContainerUrl.length - POLICIES_CONTAINER.length
   );
   const matchingStart = sharedStart(resourceUrl, rootUrl);
-  const path = resourceUrl.substr(matchingStart.length);
-  return `${getPoliciesContainerUrl(matchingStart) + path}.ttl`;
+  const path = `${resourceUrl.substr(matchingStart.length)}.ttl`;
+  return joinPath(getPoliciesContainerUrl(matchingStart), path);
 }

--- a/src/solidClientHelpers/policies.test.js
+++ b/src/solidClientHelpers/policies.test.js
@@ -50,5 +50,11 @@ describe("getPolicyUrl", () => {
     expect(
       getPolicyUrl(mockSolidDatasetFrom(`${podUrl}public`), policies)
     ).toEqual("http://example.com/pb_policies/public.ttl");
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}pb_policies/.ttl`), policies)
+    ).toEqual("http://example.com/pb_policies/pb_policies/.ttl.ttl");
+    expect(
+      getPolicyUrl(mockSolidDatasetFrom(`${podUrl}pb_policies/test/`), policies)
+    ).toEqual("http://example.com/pb_policies/pb_policies/test/.ttl");
   });
 });


### PR DESCRIPTION
In some rare cases we would get a double slash in the URLs for policy resources. This PR aims to fix that.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).