### PR TITLE
Fix: use own.sameAs instead of foaf.openid for contacts

### DIFF
--- a/__testUtils/mockContactResource.js
+++ b/__testUtils/mockContactResource.js
@@ -20,7 +20,7 @@
  */
 
 import { addUrl, mockThingFrom } from "@inrupt/solid-client";
-import { vcard, rdf, foaf } from "rdf-namespaces";
+import { vcard, rdf, owl } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 
 export const webIdUrl = "http://example.com/alice#me";
@@ -29,6 +29,6 @@ export function mockPersonContactDataset() {
   return chain(
     mockThingFrom(webIdUrl),
     (t) => addUrl(t, rdf.type, vcard.Individual),
-    (t) => addUrl(t, foaf.openid, webIdUrl)
+    (t) => addUrl(t, owl.sameAs, webIdUrl)
   );
 }

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -20,7 +20,7 @@
  */
 
 import { addStringNoLocale, addUrl, mockThingFrom } from "@inrupt/solid-client";
-import { vcard, foaf, rdf } from "rdf-namespaces";
+import { vcard, foaf, rdf, owl } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { packageProfile } from "../src/solidClientHelpers/profile";
 
@@ -36,7 +36,7 @@ export function mockPersonDatasetAlice() {
     (t) => addStringNoLocale(t, vcard.nickname, aliceNick),
     (t) => addUrl(t, vcard.hasPhoto, alicePhoto),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, foaf.openid, aliceWebIdUrl)
+    (t) => addUrl(t, owl.sameAs, aliceWebIdUrl)
   );
 }
 
@@ -54,7 +54,7 @@ export function mockPersonDatasetBob() {
     (t) => addStringNoLocale(t, foaf.name, bobName),
     (t) => addStringNoLocale(t, foaf.nick, bobNick),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, foaf.openid, bobWebIdUrl)
+    (t) => addUrl(t, owl.sameAs, bobWebIdUrl)
   );
 }
 

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -32,7 +32,7 @@ import {
 } from "@inrupt/prism-react-components";
 import { getSourceUrl, getUrl, getStringNoLocale } from "@inrupt/solid-client";
 import { Table, TableColumn, useSession } from "@inrupt/solid-ui-react";
-import { vcard, foaf } from "rdf-namespaces";
+import { vcard, foaf, owl } from "rdf-namespaces";
 import SortedTableCarat from "../sortedTableCarat";
 import Spinner from "../spinner";
 import styles from "./styles";
@@ -111,7 +111,9 @@ function ContactsList() {
     );
     setSelectedContactName(name);
 
-    const webId = getUrl(people[selectedContactIndex].dataset, foaf.openid);
+    const webId =
+      getUrl(people[selectedContactIndex].dataset, owl.sameAs) ||
+      getUrl(people[selectedContactIndex].dataset, foaf.openid);
 
     setSelectedContactWebId(webId);
   }, [selectedContactIndex, formattedNamePredicate, people]);

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -37,7 +37,7 @@ import {
   setThing,
 } from "@inrupt/solid-client";
 import { v4 as uuid } from "uuid";
-import { rdf, dc, acl, vcard, foaf, schema } from "rdf-namespaces";
+import { rdf, dc, acl, vcard, foaf, schema, owl } from "rdf-namespaces";
 import {
   createResponder,
   defineDataset,
@@ -163,7 +163,7 @@ export async function getContacts(indexFileDataset, contactTypeIri, fetch) {
 export async function getProfiles(people, fetch) {
   const profileResponses = await Promise.all(
     people.map(({ dataset }) => {
-      const url = getUrl(dataset, foaf.openid);
+      const url = getUrl(dataset, owl.sameAs) || getUrl(dataset, foaf.openid);
       return getResource(url, fetch);
     })
   );
@@ -226,7 +226,7 @@ export async function saveNewAddressBook(
 }
 
 export const schemaFunctionMappings = {
-  webId: (v) => (t) => addUrl(t, foaf.openid, v),
+  webId: (v) => (t) => addUrl(t, owl.sameAs, v),
   fn: (v) => (t) => addStringNoLocale(t, vcard.fn, v),
   name: (v) => (t) => addStringNoLocale(t, foaf.name, v),
   organizationName: (v) => (t) =>

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -20,7 +20,7 @@
  */
 
 /* eslint-disable camelcase */
-import { ldp, rdf, acl, dc, foaf, vcard } from "rdf-namespaces";
+import { ldp, rdf, acl, dc, foaf, vcard, owl } from "rdf-namespaces";
 import * as solidClientFns from "@inrupt/solid-client";
 import { asUrl } from "@inrupt/solid-client";
 import * as resourceFns from "../solidClientHelpers/resource";
@@ -155,7 +155,7 @@ describe("createContact", () => {
     const emailsAndPhones = getStringNoLocaleAll(dataset, vcard.value);
 
     expect(getStringNoLocale(dataset, vcard.fn)).toEqual("Test Person");
-    expect(getUrl(dataset, foaf.openid)).toEqual(webId);
+    expect(getUrl(dataset, owl.sameAs)).toEqual(webId);
     expect(
       getStringNoLocale(dataset, vcardExtras("organization-name"))
     ).toEqual("Test Company");
@@ -235,7 +235,7 @@ describe("getSchemaFunction", () => {
     const fn = getSchemaFunction("webId", value);
     const thing = fn(createThing(options));
 
-    expect(getUrl(thing, foaf.openid)).toEqual(value);
+    expect(getUrl(thing, owl.sameAs)).toEqual(value);
   });
 
   test("it returns an identity function if the key does not exist in the map", () => {
@@ -598,7 +598,7 @@ describe("deleteContact", () => {
   const mockContactToDelete = chain(
     solidClientFns.mockThingFrom(contactUrl),
     (t) => solidClientFns.addUrl(t, rdf.type, vcard.Individual),
-    (t) => solidClientFns.addUrl(t, foaf.openid, contactUrl)
+    (t) => solidClientFns.addUrl(t, owl.sameAs, contactUrl)
   );
 
   const contactToDelete = {
@@ -767,12 +767,12 @@ describe("saveNewAddressBook", () => {
 });
 
 describe("schemaFunctionMappings", () => {
-  test("webId sets a foaf.openid", () => {
+  test("webId sets a own.sameAs", () => {
     const webId = "https://user.example.com/card#me";
     const options = { name: "this" };
     const thing = schemaFunctionMappings.webId(webId)(createThing(options));
 
-    expect(getUrl(thing, foaf.openid)).toEqual(webId);
+    expect(getUrl(thing, owl.sameAs)).toEqual(webId);
   });
 
   test("fn sets a vcard.fn", () => {


### PR DESCRIPTION
This PR fixes: use `use.sameAs` for contacts instead of `foaf.openid`.

# To test:
- Add a new contact
- Verify that it is correctly added
- Verify that old contacts with `foaf.openid` are still displayed

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
