### PR TITLE
Fix: use vcard.url instead of foaf.openid for new contacts

### DIFF
--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -19,7 +19,12 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { addStringNoLocale, addUrl, mockThingFrom } from "@inrupt/solid-client";
+import {
+  addStringNoLocale,
+  addUrl,
+  asUrl,
+  mockThingFrom,
+} from "@inrupt/solid-client";
 import { vcard, foaf, rdf } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { packageProfile } from "../src/solidClientHelpers/profile";
@@ -29,6 +34,20 @@ export const aliceName = "Alice";
 export const aliceNick = "A";
 export const alicePhoto = "http://example.com/alice.jpg";
 
+const VCARD_WEBID_PREDICATE = "https://www.w3.org/2006/vcard/ns#WebId";
+
+export function mockWebIdNode(webId) {
+  const dataset = chain(
+    mockThingFrom("https://example.org/contacts/Person/1234/index.ttl#4567"),
+    (t) => addUrl(t, rdf.type, VCARD_WEBID_PREDICATE),
+    (t) => addUrl(t, vcard.value, webId)
+  );
+  const url = asUrl(dataset);
+  return { webIdNode: dataset, webIdNodeUrl: url };
+}
+
+const mockWebIdNodeAlice = mockWebIdNode(aliceWebIdUrl);
+
 export function mockPersonDatasetAlice() {
   return chain(
     mockThingFrom(aliceWebIdUrl),
@@ -36,7 +55,7 @@ export function mockPersonDatasetAlice() {
     (t) => addStringNoLocale(t, vcard.nickname, aliceNick),
     (t) => addUrl(t, vcard.hasPhoto, alicePhoto),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, foaf.openid, aliceWebIdUrl)
+    (t) => addUrl(t, vcard.url, mockWebIdNodeAlice.webIdNodeUrl)
   );
 }
 

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -37,13 +37,13 @@ export const alicePhoto = "http://example.com/alice.jpg";
 const VCARD_WEBID_PREDICATE = "https://www.w3.org/2006/vcard/ns#WebId";
 
 export function mockWebIdNode(webId) {
-  const dataset = chain(
+  const webIdNode = chain(
     mockThingFrom("https://example.org/contacts/Person/1234/index.ttl#4567"),
     (t) => addUrl(t, rdf.type, VCARD_WEBID_PREDICATE),
     (t) => addUrl(t, vcard.value, webId)
   );
-  const url = asUrl(dataset);
-  return { webIdNode: dataset, webIdNodeUrl: url };
+  const url = asUrl(webIdNode);
+  return { webIdNode, webIdNodeUrl: url };
 }
 
 const mockWebIdNodeAlice = mockWebIdNode(aliceWebIdUrl);

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -124,12 +124,10 @@ function ContactsList() {
   if (isLoading) return <Spinner />;
 
   // format things for the data table
-  const contacts = profiles.map((p) => {
-    return {
-      thing: p,
-      dataset: addressBook,
-    };
-  });
+  const contacts = profiles.map((p) => ({
+    thing: p,
+    dataset: addressBook,
+  }));
 
   const closeDrawer = handleClose(setSelectedContactIndex);
   const deleteSelectedContact = handleDeleteContact({

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -111,7 +111,7 @@ function ContactsList() {
     );
     setSelectedContactName(name);
     (async () => {
-      const webId = await getWebId(people[selectedContactIndex].dataset, fetch);
+      const webId = getWebId(people[selectedContactIndex].dataset, fetch);
       setSelectedContactWebId(webId);
     })();
   }, [selectedContactIndex, formattedNamePredicate, people, fetch]);

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -30,7 +30,7 @@ import {
   PageHeader,
   Table as PrismTable,
 } from "@inrupt/prism-react-components";
-import { getSourceUrl, getUrl, getStringNoLocale } from "@inrupt/solid-client";
+import { getSourceUrl, getStringNoLocale } from "@inrupt/solid-client";
 import { Table, TableColumn, useSession } from "@inrupt/solid-ui-react";
 import { vcard, foaf } from "rdf-namespaces";
 import SortedTableCarat from "../sortedTableCarat";
@@ -44,7 +44,7 @@ import useProfiles from "../../src/hooks/useProfiles";
 import ContactsListSearch from "./contactsListSearch";
 import ProfileLink from "../profileLink";
 import { SearchProvider } from "../../src/contexts/searchContext";
-import { deleteContact } from "../../src/addressBook";
+import { deleteContact, getWebId } from "../../src/addressBook";
 import ContactsDrawer from "./contactsDrawer";
 import ContactsEmptyState from "./contactsEmptyState";
 
@@ -110,11 +110,11 @@ function ContactsList() {
       formattedNamePredicate
     );
     setSelectedContactName(name);
-
-    const webId = getUrl(people[selectedContactIndex].dataset, foaf.openid);
-
-    setSelectedContactWebId(webId);
-  }, [selectedContactIndex, formattedNamePredicate, people]);
+    (async () => {
+      const webId = await getWebId(people[selectedContactIndex].dataset, fetch);
+      setSelectedContactWebId(webId);
+    })();
+  }, [selectedContactIndex, formattedNamePredicate, people, fetch]);
 
   if (addressBookError) return addressBookError;
   if (peopleError) return peopleError;

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -124,10 +124,12 @@ function ContactsList() {
   if (isLoading) return <Spinner />;
 
   // format things for the data table
-  const contacts = profiles.map((p) => ({
-    thing: p,
-    dataset: addressBook,
-  }));
+  const contacts = profiles.map((p) => {
+    return {
+      thing: p,
+      dataset: addressBook,
+    };
+  });
 
   const closeDrawer = handleClose(setSelectedContactIndex);
   const deleteSelectedContact = handleDeleteContact({

--- a/components/profile/index.jsx
+++ b/components/profile/index.jsx
@@ -32,8 +32,9 @@ import {
 import { makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
 import { Container } from "@inrupt/prism-react-components";
-
 import { CombinedDataProvider, Text, Image } from "@inrupt/solid-ui-react";
+
+import { vcardExtras } from "../../src/addressBook";
 
 import ContactInfoTable from "./contactInfoTable";
 import styles from "./styles";
@@ -123,7 +124,7 @@ export default function Profile(props) {
               <Box mt={1}>
                 <InputLabel>Company</InputLabel>
                 <Text
-                  property={vcard.org}
+                  property={vcardExtras("organization-name")}
                   edit={editing}
                   inputProps={{
                     className: bem("input"),

--- a/shapes/contacts/person.shex
+++ b/shapes/contacts/person.shex
@@ -9,12 +9,11 @@ PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 vcard:Individual {
     vcard:fn xsd:string {1} ;
     vcard:inAddressBook vcard:AddressBook + ;
-    owl:sameAs vcard:Individual * ; # WebIds
+    vcard:url vcard:WebId {1}; 
     vcard:hasUID xsd:string ? ;
     vcard:hasName xsd:string ? ; # structured name
     vcard:hasPhoto dc:Image * ;
     vcard:hasRelated vcard:RelatedType * ;
-    vcard:url rdf:Resource * ; # need to describe the type of url to be able to identify WebIds
     vcard:hasAddress vcard:Address * ;
     vcard:bday xsd:date ? ;
     vcard:hasEmail vcard:Email * ;
@@ -23,6 +22,10 @@ vcard:Individual {
     vcard:role xsd:string ? ;
     vcard:title xsd:string ? ;
     vcard:note xsd:string ? ;
+}
+
+vcard:WebId {
+    vcard:value xsd:string {1};
 }
 
 vcard:Address {

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -35,10 +35,12 @@ import {
   removeThing,
   getSolidDataset,
   setThing,
+  createThing,
 } from "@inrupt/solid-client";
 import { v4 as uuid } from "uuid";
 import { rdf, dc, acl, vcard, foaf, schema } from "rdf-namespaces";
 import {
+  chain,
   createResponder,
   defineDataset,
   defineThing,
@@ -56,6 +58,8 @@ const INDEX_FILE = "index.ttl";
 const PEOPLE_INDEX_FILE = "people.ttl";
 const GROUPS_INDEX_FILE = "groups.ttl";
 const PERSON_CONTAINER = "Person";
+
+const VCARD_WEBID_PREDICATE = "https://www.w3.org/2006/vcard/ns#WebId";
 
 export const TYPE_MAP = {
   [foaf.Person]: {
@@ -162,8 +166,19 @@ export async function getContacts(indexFileDataset, contactTypeIri, fetch) {
 
 export async function getProfiles(people, fetch) {
   const profileResponses = await Promise.all(
-    people.map(({ dataset }) => {
-      const url = getUrl(dataset, foaf.openid);
+    people.map(async ({ dataset }) => {
+      const webIdNodeUrl = getUrl(dataset, vcard.url);
+      let webIdNode;
+      let webIdUrl;
+      let url;
+      try {
+        webIdNode = await getSolidDataset(webIdNodeUrl, { fetch });
+        webIdUrl = webIdNode && getUrl(webIdNode, vcard.value);
+        url = webIdUrl;
+      } catch {
+        webIdNode = null;
+        url = getUrl(dataset, foaf.openid);
+      }
       return getResource(url, fetch);
     })
   );
@@ -225,8 +240,18 @@ export async function saveNewAddressBook(
   return respond({ iri, index, groups, people });
 }
 
+export const createWebIdNodeFn = (webId, iri) => {
+  const webIdNode = chain(
+    createThing(),
+    (t) => addUrl(t, rdf.type, VCARD_WEBID_PREDICATE),
+    (t) => addUrl(t, vcard.value, webId)
+  );
+  const webIdNodeUrl = asUrl(webIdNode, iri);
+  return { webIdNode, webIdNodeUrl };
+};
+
 export const schemaFunctionMappings = {
-  webId: (v) => (t) => addUrl(t, foaf.openid, v),
+  webId: (v) => (t) => addUrl(t, vcard.url, v),
   fn: (v) => (t) => addStringNoLocale(t, vcard.fn, v),
   name: (v) => (t) => addStringNoLocale(t, foaf.name, v),
   organizationName: (v) => (t) =>
@@ -249,11 +274,14 @@ export function getSchemaFunction(type, value) {
   return fn(value);
 }
 
-export function getSchemaOperations(contactSchema) {
+export function getSchemaOperations(contactSchema, webIdNodeUrl) {
   if (!contactSchema) return [];
 
   return Object.keys(contactSchema).reduce((acc, key) => {
-    const value = contactSchema[key];
+    let value = contactSchema[key];
+    if (webIdNodeUrl && key === "webId") {
+      value = webIdNodeUrl;
+    }
     if (typeof value === "string") {
       return [...acc, getSchemaFunction(key, value)];
     }
@@ -270,7 +298,6 @@ export function mapSchema(prefix) {
     const name = [prefix, shortId()].join("-");
     const operations = getSchemaOperations(contactSchema);
     const thing = defineThing({ name }, ...operations);
-
     return { name, thing };
   };
 }
@@ -299,7 +326,12 @@ export function createContactTypeNotFoundError(contact) {
   return new Error(`Contact is unsupported type: ${contact.type}`);
 }
 
-export function createContact(addressBookIri, contact, types) {
+export function createContact(
+  addressBookIri,
+  contact,
+  types,
+  createWebIdNode = createWebIdNodeFn
+) {
   // Find the first matching container mapping.
   const containerMap = TYPE_MAP[types.find((type) => TYPE_MAP[type])];
 
@@ -318,13 +350,13 @@ export function createContact(addressBookIri, contact, types) {
 
   const id = uuid();
   const iri = joinPath(addressBookIri, container, id, INDEX_FILE);
-  const rootAttributeFns = getSchemaOperations(contact);
-
+  const { webIdNode, webIdNodeUrl } = createWebIdNode(contact.webId, iri);
+  const rootAttributeFns = getSchemaOperations(contact, webIdNodeUrl);
   const emails = normalizedContact.emails.map(mapSchema("email"));
   const addresses = normalizedContact.addresses.map(mapSchema("address"));
   const telephones = normalizedContact.telephones.map(mapSchema("telephone"));
 
-  const person = defineDataset(
+  const person = defineThing(
     { name: "this" },
     ...[(t) => addUrl(t, rdf.type, vcard.Individual), ...rootAttributeFns],
     ...emails.map(({ name }) => {
@@ -337,13 +369,13 @@ export function createContact(addressBookIri, contact, types) {
       return (t) => addUrl(t, vcard.hasTelephone, [iri, name].join("#"));
     })
   );
-
-  const dataset = [...emails, ...addresses, ...telephones].reduce(
+  let dataset = [...emails, ...addresses, ...telephones].reduce(
     (acc, { thing }) => {
       return setThing(acc, thing);
     },
     person
   );
+  dataset = webIdNode && setThing(dataset, webIdNode);
 
   return {
     iri,
@@ -370,7 +402,8 @@ export async function saveContact(
   const newContact = createContact(
     addressBookContainerIri,
     contactSchema,
-    types
+    types,
+    createWebIdNodeFn
   );
   const { iri } = newContact;
 

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -375,7 +375,8 @@ export function createContact(
     },
     person
   );
-  dataset = webIdNode && setThing(dataset, webIdNode);
+
+  dataset = setThing(dataset, webIdNode);
 
   return {
     iri,

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -164,17 +164,14 @@ export async function getContacts(indexFileDataset, contactTypeIri, fetch) {
   return respond(contacts);
 }
 
-export async function getWebId(dataset, fetch) {
-  const webIdNodeUrl = getUrl(dataset, vcard.url);
-  let webIdNode;
-  let webIdUrl;
+export function getWebId(dataset) {
   let url;
-  try {
-    webIdNode = await getSolidDataset(webIdNodeUrl, { fetch });
-    webIdUrl = webIdNode && getUrl(webIdNode, vcard.value);
+  const webIdNodeUrl = getUrl(dataset, vcard.url);
+  if (webIdNodeUrl) {
+    const webIdNode = getThing(dataset, webIdNodeUrl);
+    const webIdUrl = webIdNode && getUrl(webIdNode, vcard.value);
     url = webIdUrl;
-  } catch {
-    webIdNode = null;
+  } else {
     url = getUrl(dataset, foaf.openid);
   }
   return url;
@@ -183,7 +180,7 @@ export async function getWebId(dataset, fetch) {
 export async function getProfiles(people, fetch) {
   const profileResponses = await Promise.all(
     people.map(async ({ dataset }) => {
-      const url = await getWebId(dataset, fetch);
+      const url = getWebId(dataset);
       return getResource(url, fetch);
     })
   );

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -164,21 +164,26 @@ export async function getContacts(indexFileDataset, contactTypeIri, fetch) {
   return respond(contacts);
 }
 
+export async function getWebId(dataset, fetch) {
+  const webIdNodeUrl = getUrl(dataset, vcard.url);
+  let webIdNode;
+  let webIdUrl;
+  let url;
+  try {
+    webIdNode = await getSolidDataset(webIdNodeUrl, { fetch });
+    webIdUrl = webIdNode && getUrl(webIdNode, vcard.value);
+    url = webIdUrl;
+  } catch {
+    webIdNode = null;
+    url = getUrl(dataset, foaf.openid);
+  }
+  return url;
+}
+
 export async function getProfiles(people, fetch) {
   const profileResponses = await Promise.all(
     people.map(async ({ dataset }) => {
-      const webIdNodeUrl = getUrl(dataset, vcard.url);
-      let webIdNode;
-      let webIdUrl;
-      let url;
-      try {
-        webIdNode = await getSolidDataset(webIdNodeUrl, { fetch });
-        webIdUrl = webIdNode && getUrl(webIdNode, vcard.value);
-        url = webIdUrl;
-      } catch {
-        webIdNode = null;
-        url = getUrl(dataset, foaf.openid);
-      }
+      const url = await getWebId(dataset, fetch);
       return getResource(url, fetch);
     })
   );

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -374,6 +374,20 @@ describe("getContacts", () => {
   });
 });
 
+describe("getWebId", () => {
+  test("it returns the webId for a given person dataset", async () => {
+    const personDataset = mockPersonDatasetAlice();
+    const mockPersonWebIdNode = mockWebIdNode("http://example.com/alice#me");
+    const fetch = jest.fn();
+    jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValueOnce(mockPersonWebIdNode.webIdNode);
+
+    const webId = await addressBookFns.getWebId(personDataset, fetch);
+    expect(webId).toEqual("http://example.com/alice#me");
+  });
+});
+
 describe("getProfiles", () => {
   afterEach(() => {
     jest.restoreAllMocks();

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -31,6 +31,7 @@ import {
   bobWebIdUrl,
   mockPersonDatasetAlice,
   mockPersonDatasetBob,
+  mockWebIdNode,
 } from "../../__testUtils/mockPersonResource";
 import { mockPersonContactDataset } from "../../__testUtils/mockContactResource";
 
@@ -117,6 +118,10 @@ describe("createAddressBook", () => {
 describe("createContact", () => {
   const addressBookIri = "https://user.example.com/contacts";
   const webId = "https://user.example.com/card";
+  const { webIdNodeUrl } = mockWebIdNode(webId);
+  const mockWebIdNodeFn = jest
+    .spyOn(addressBookFns, "createWebIdNodeFn")
+    .mockImplementation(mockWebIdNode);
 
   test("it creates a new contact with a given schema object", () => {
     const schema = {
@@ -151,11 +156,18 @@ describe("createContact", () => {
       role: "Developer",
     };
 
-    const { dataset } = createContact(addressBookIri, schema, [foaf.Person]);
+    const { dataset } = createContact(
+      addressBookIri,
+      schema,
+      [foaf.Person],
+      mockWebIdNodeFn
+    );
+
     const emailsAndPhones = getStringNoLocaleAll(dataset, vcard.value);
 
     expect(getStringNoLocale(dataset, vcard.fn)).toEqual("Test Person");
-    expect(getUrl(dataset, foaf.openid)).toEqual(webId);
+    expect(mockWebIdNodeFn).toHaveBeenCalledWith(webId, expect.anything());
+    expect(getUrl(dataset, vcard.url)).toEqual(webIdNodeUrl);
     expect(
       getStringNoLocale(dataset, vcardExtras("organization-name"))
     ).toEqual("Test Company");
@@ -230,12 +242,13 @@ describe("getGroups", () => {
 
 describe("getSchemaFunction", () => {
   test("it returns a function for the given key, value", () => {
-    const value = "https://user.example.com/card#me";
+    const value = mockWebIdNode("https://user.example.com/card#me")
+      .webIdNodeUrl;
     const options = { name: "this" };
     const fn = getSchemaFunction("webId", value);
     const thing = fn(createThing(options));
 
-    expect(getUrl(thing, foaf.openid)).toEqual(value);
+    expect(getUrl(thing, vcard.url)).toEqual(value);
   });
 
   test("it returns an identity function if the key does not exist in the map", () => {
@@ -371,6 +384,11 @@ describe("getProfiles", () => {
       dataset: "Person 1",
       iri: "https://user.example.com/contacts/Person/1234/index.ttl",
     };
+    const mockWebIdNodePerson1 = mockWebIdNode(person1.iri);
+    jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockReturnValueOnce(mockWebIdNodePerson1)
+      .mockReturnValue(undefined);
     const person2 = {
       dataset: "Person 2",
       iri: "https://user.example.com/contacts/Person/1234/index.ttl",
@@ -767,12 +785,15 @@ describe("saveNewAddressBook", () => {
 });
 
 describe("schemaFunctionMappings", () => {
-  test("webId sets a foaf.openid", () => {
+  test("webId sets a vcard.url", () => {
     const webId = "https://user.example.com/card#me";
     const options = { name: "this" };
-    const thing = schemaFunctionMappings.webId(webId)(createThing(options));
-
-    expect(getUrl(thing, foaf.openid)).toEqual(webId);
+    const { webIdNode, webIdNodeUrl } = mockWebIdNode(webId);
+    const thing = schemaFunctionMappings.webId(webIdNodeUrl)(
+      createThing(options)
+    );
+    expect(getUrl(thing, vcard.url)).toEqual(webIdNodeUrl);
+    expect(getUrl(webIdNode, vcard.value)).toEqual(webId);
   });
 
   test("fn sets a vcard.fn", () => {

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -375,15 +375,15 @@ describe("getContacts", () => {
 });
 
 describe("getWebId", () => {
-  test("it returns the webId for a given person dataset", async () => {
+  test("it returns the webId for a given person dataset", () => {
     const personDataset = mockPersonDatasetAlice();
     const mockPersonWebIdNode = mockWebIdNode("http://example.com/alice#me");
-    const fetch = jest.fn();
-    jest
-      .spyOn(solidClientFns, "getSolidDataset")
-      .mockResolvedValueOnce(mockPersonWebIdNode.webIdNode);
 
-    const webId = await addressBookFns.getWebId(personDataset, fetch);
+    jest
+      .spyOn(solidClientFns, "getThing")
+      .mockReturnValueOnce(mockPersonWebIdNode.webIdNode);
+
+    const webId = addressBookFns.getWebId(personDataset);
     expect(webId).toEqual("http://example.com/alice#me");
   });
 });


### PR DESCRIPTION
- with new contacts, create a 'blank' node under `vcard.url`
- read from `foaf.openid` and `vcard.url`
- update tests

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
