### PR TITLE
fix: navigate to parent folder after deleting current folder

### DIFF
--- a/components/deleteResourceButton/index.jsx
+++ b/components/deleteResourceButton/index.jsx
@@ -21,7 +21,10 @@
 
 import React, { useContext } from "react";
 import T from "prop-types";
+import { useRouter } from "next/router";
 import { useSession } from "@inrupt/solid-ui-react";
+import { getSourceIri, isContainer } from "@inrupt/solid-client";
+import { getParentContainerUrl } from "../../src/stringHelpers";
 import usePoliciesContainer from "../../src/hooks/usePoliciesContainer";
 import AlertContext from "../../src/contexts/alertContext";
 import useResourceInfo from "../../src/hooks/useResourceInfo";
@@ -32,11 +35,22 @@ export function createDeleteHandler(
   resourceInfo,
   policiesContainer,
   onDelete,
+  router,
   fetch
 ) {
   return async () => {
     await deleteResource(resourceInfo, policiesContainer, fetch);
     onDelete();
+    const iri = getSourceIri(resourceInfo);
+
+    if (isContainer(resourceInfo) && iri === router.query.iri) {
+      const parentContainerUrl = getParentContainerUrl(iri);
+
+      router.push(
+        "/resource/[iri]",
+        `/resource/${encodeURIComponent(parentContainerUrl)}`
+      );
+    }
   };
 }
 
@@ -48,6 +62,7 @@ export default function DeleteResourceButton({
   ...buttonProps
 }) {
   const { fetch } = useSession();
+  const router = useRouter();
 
   const { alertError } = useContext(AlertContext);
   const { policiesContainer } = usePoliciesContainer();
@@ -63,6 +78,7 @@ export default function DeleteResourceButton({
     resourceInfo,
     policiesContainer,
     onDelete,
+    router,
     fetch
   );
 

--- a/src/stringHelpers/index.js
+++ b/src/stringHelpers/index.js
@@ -19,6 +19,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { isContainer } from "@inrupt/solid-client";
+
 export function parseUrl(url) {
   const a = document.createElement("a");
   a.href = url;
@@ -59,4 +61,11 @@ export function normalizeContainerUrl(url) {
 export function getContainerUrl(url) {
   const encodedIri = encodeURI(url);
   return encodedIri.substring(0, encodedIri.lastIndexOf("/") + 1);
+}
+
+export function getParentContainerUrl(url) {
+  const parts = url.split("/");
+  return isContainer(url)
+    ? parts.slice(0, -2).join("/").concat("/")
+    : parts.slice(0, -1).join("/").concat("/");
 }

--- a/src/stringHelpers/index.test.js
+++ b/src/stringHelpers/index.test.js
@@ -26,6 +26,7 @@ import {
   normalizeContainerUrl,
   joinPath,
   getContainerUrl,
+  getParentContainerUrl,
 } from "./index";
 
 describe("joinPath", () => {
@@ -130,5 +131,17 @@ describe("getContainerUrl", () => {
   });
   test("it returns the same url when passed a container url", () => {
     expect(getContainerUrl(containerUrl)).toEqual(containerUrl);
+  });
+});
+
+describe("getParentContainerUrl", () => {
+  const resourceUrl = "https://www.example.org/stuff/photo.jpg";
+  const containerUrl = "https://www.example.org/stuff/";
+  test("it returns the url of the parent container of a given resource", () => {
+    expect(getParentContainerUrl(resourceUrl)).toEqual(containerUrl);
+  });
+  const nestedContainerUrl = "https://www.example.org/stuff/nested/";
+  test("it returns the url of the parent container of a given container", () => {
+    expect(getParentContainerUrl(nestedContainerUrl)).toEqual(containerUrl);
   });
 });


### PR DESCRIPTION
This PR adds: 
- After deleting the current folder, PodBrowser navigates to the parent folder.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
