### PR TITLE
fix: focus on upload button and trigger file browser opening on enter

### DIFF
--- a/components/addFileButton/__snapshots__/index.test.jsx.snap
+++ b/components/addFileButton/__snapshots__/index.test.jsx.snap
@@ -2,15 +2,22 @@
 
 exports[`AddFileButton Renders an add file button 1`] = `
 <DocumentFragment>
-  <label
+  <button
     data-testid="upload-file-button"
+    type="button"
   >
-    Upload File
-    <input
-      data-testid="upload-file-input"
-      style="display: none;"
-      type="file"
-    />
-  </label>
+    <label
+      data-testid="upload-file-label"
+      for="upload-file-input"
+    >
+      Upload File
+      <input
+        data-testid="upload-file-input"
+        id="upload-file-input"
+        style="display: none;"
+        type="file"
+      />
+    </label>
+  </button>
 </DocumentFragment>
 `;

--- a/components/addFileButton/__snapshots__/index.test.jsx.snap
+++ b/components/addFileButton/__snapshots__/index.test.jsx.snap
@@ -2,22 +2,18 @@
 
 exports[`AddFileButton Renders an add file button 1`] = `
 <DocumentFragment>
-  <button
+  <label
     data-testid="upload-file-button"
-    type="button"
+    for="upload-file-input"
+    tabindex="0"
   >
-    <label
-      data-testid="upload-file-label"
-      for="upload-file-input"
-    >
-      Upload File
-      <input
-        data-testid="upload-file-input"
-        id="upload-file-input"
-        style="display: none;"
-        type="file"
-      />
-    </label>
-  </button>
+    Upload File
+    <input
+      data-testid="upload-file-input"
+      id="upload-file-input"
+      style="display: none;"
+      type="file"
+    />
+  </label>
 </DocumentFragment>
 `;

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import T from "prop-types";
 import { overwriteFile } from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
@@ -30,6 +30,8 @@ import { joinPath } from "../../src/stringHelpers";
 
 const TESTCAFE_ID_UPLOAD_BUTTON = "upload-file-button";
 const TESTCAFE_ID_UPLOAD_INPUT = "upload-file-input";
+const TESTCAFE_ID_UPLOAD_LABEL = "upload-file-label";
+
 export const DUPLICATE_DIALOG_ID = "upload-duplicate-file";
 
 function normalizeSafeFileName(fileName) {
@@ -170,6 +172,7 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   } = useContext(ConfirmationDialogContext);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
   const [file, setFile] = useState(null);
+  const ref = useRef();
 
   const saveResource = handleSaveResource({
     fetch,
@@ -216,23 +219,36 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   }, [confirmationSetup, confirmed, onConfirmation, file, open]);
 
   return (
-    // eslint-disable-next-line jsx-a11y/label-has-associated-control
-    <label
-      data-testid={TESTCAFE_ID_UPLOAD_BUTTON}
-      disabled={isUploading}
+    <button
+      type="button"
       className={className}
+      data-testid={TESTCAFE_ID_UPLOAD_BUTTON}
+      onClick={(e) => {
+        e.target.value = null;
+      }}
+      onKeyUp={(e) => {
+        if (ref.current) {
+          ref.current.click();
+        }
+        e.target.value = null;
+      }}
     >
-      {isUploading ? "Uploading..." : "Upload File"}
-      <input
-        data-testid={TESTCAFE_ID_UPLOAD_INPUT}
-        type="file"
-        style={{ display: "none" }}
-        onClick={(e) => {
-          e.target.value = null;
-        }}
-        onChange={onFileSelect}
-      />
-    </label>
+      <label
+        htmlFor="upload-file-input"
+        data-testid={TESTCAFE_ID_UPLOAD_LABEL}
+        disabled={isUploading}
+      >
+        {isUploading ? "Uploading..." : "Upload File"}
+        <input
+          ref={ref}
+          id="upload-file-input"
+          data-testid={TESTCAFE_ID_UPLOAD_INPUT}
+          type="file"
+          style={{ display: "none" }}
+          onChange={onFileSelect}
+        />
+      </label>
+    </button>
   );
 }
 

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -28,9 +28,8 @@ import AlertContext from "../../src/contexts/alertContext";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
 import { joinPath } from "../../src/stringHelpers";
 
-const TESTCAFE_ID_UPLOAD_BUTTON = "upload-file-button";
-const TESTCAFE_ID_UPLOAD_INPUT = "upload-file-input";
-const TESTCAFE_ID_UPLOAD_LABEL = "upload-file-label";
+export const TESTCAFE_ID_UPLOAD_BUTTON = "upload-file-button";
+export const TESTCAFE_ID_UPLOAD_INPUT = "upload-file-input";
 
 export const DUPLICATE_DIALOG_ID = "upload-duplicate-file";
 
@@ -219,36 +218,36 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   }, [confirmationSetup, confirmed, onConfirmation, file, open]);
 
   return (
-    <button
-      type="button"
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <label
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      tabIndex="0"
+      htmlFor="upload-file-input"
       className={className}
       data-testid={TESTCAFE_ID_UPLOAD_BUTTON}
+      disabled={isUploading}
       onClick={(e) => {
         e.target.value = null;
       }}
       onKeyUp={(e) => {
-        if (ref.current) {
-          ref.current.click();
+        if (e.key === "Enter") {
+          if (ref.current) {
+            ref.current.click();
+          }
+          e.target.value = null;
         }
-        e.target.value = null;
       }}
     >
-      <label
-        htmlFor="upload-file-input"
-        data-testid={TESTCAFE_ID_UPLOAD_LABEL}
-        disabled={isUploading}
-      >
-        {isUploading ? "Uploading..." : "Upload File"}
-        <input
-          ref={ref}
-          id="upload-file-input"
-          data-testid={TESTCAFE_ID_UPLOAD_INPUT}
-          type="file"
-          style={{ display: "none" }}
-          onChange={onFileSelect}
-        />
-      </label>
-    </button>
+      {isUploading ? "Uploading..." : "Upload File"}
+      <input
+        ref={ref}
+        id="upload-file-input"
+        data-testid={TESTCAFE_ID_UPLOAD_INPUT}
+        type="file"
+        style={{ display: "none" }}
+        onChange={onFileSelect}
+      />
+    </label>
   );
 }
 

--- a/components/addFileButton/index.test.jsx
+++ b/components/addFileButton/index.test.jsx
@@ -22,6 +22,7 @@
 import React from "react";
 import * as SolidClientFns from "@inrupt/solid-client";
 import { act, render } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
 import userEvent from "@testing-library/user-event";
 import { PodLocationProvider } from "../../src/contexts/podLocationContext";
 import mockSession from "../../__testUtils/mockSession";
@@ -29,6 +30,8 @@ import mockSessionContextProvider from "../../__testUtils/mockSessionContextProv
 import AlertContext from "../../src/contexts/alertContext";
 import AddFileButton, {
   DUPLICATE_DIALOG_ID,
+  TESTCAFE_ID_UPLOAD_BUTTON,
+  TESTCAFE_ID_UPLOAD_INPUT,
   handleConfirmation,
   handleFileSelect,
   handleSaveResource,
@@ -78,6 +81,28 @@ describe("AddFileButton", () => {
 
   test("Renders an add file button", () => {
     expect(renderResult.asFragment()).toMatchSnapshot();
+  });
+
+  test("Handles focus correctly on click", () => {
+    const label = renderResult.getByTestId(TESTCAFE_ID_UPLOAD_BUTTON);
+    userEvent.tab();
+    expect(label).toHaveFocus();
+
+    userEvent.click(label);
+
+    const input = renderResult.getByTestId(TESTCAFE_ID_UPLOAD_INPUT);
+    expect(input).toHaveFocus();
+  });
+
+  test("Handles focus correctly on enter", () => {
+    const label = renderResult.getByTestId(TESTCAFE_ID_UPLOAD_BUTTON);
+    userEvent.tab();
+    expect(label).toHaveFocus();
+
+    userEvent.type(label, "{enter}");
+
+    const input = renderResult.getByTestId(TESTCAFE_ID_UPLOAD_INPUT);
+    expect(input).toHaveFocus();
   });
 
   test("Uploads a file", async () => {

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -80,17 +80,24 @@ exports[`Container view Renders a table view without data 1`] = `
           >
             Create Folder
           </button>
-          <label
+          <button
             class="PodBrowser-page-header__action"
             data-testid="upload-file-button"
+            type="button"
           >
-            Upload File
-            <input
-              data-testid="upload-file-input"
-              style="display: none;"
-              type="file"
-            />
-          </label>
+            <label
+              data-testid="upload-file-label"
+              for="upload-file-input"
+            >
+              Upload File
+              <input
+                data-testid="upload-file-input"
+                id="upload-file-input"
+                style="display: none;"
+                type="file"
+              />
+            </label>
+          </button>
         </div>
       </div>
       <table
@@ -271,17 +278,24 @@ exports[`Container view Renders a table with data 1`] = `
           >
             Create Folder
           </button>
-          <label
+          <button
             class="PodBrowser-page-header__action"
             data-testid="upload-file-button"
+            type="button"
           >
-            Upload File
-            <input
-              data-testid="upload-file-input"
-              style="display: none;"
-              type="file"
-            />
-          </label>
+            <label
+              data-testid="upload-file-label"
+              for="upload-file-input"
+            >
+              Upload File
+              <input
+                data-testid="upload-file-input"
+                id="upload-file-input"
+                style="display: none;"
+                type="file"
+              />
+            </label>
+          </button>
         </div>
       </div>
       <table

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -80,24 +80,20 @@ exports[`Container view Renders a table view without data 1`] = `
           >
             Create Folder
           </button>
-          <button
+          <label
             class="PodBrowser-page-header__action"
             data-testid="upload-file-button"
-            type="button"
+            for="upload-file-input"
+            tabindex="0"
           >
-            <label
-              data-testid="upload-file-label"
-              for="upload-file-input"
-            >
-              Upload File
-              <input
-                data-testid="upload-file-input"
-                id="upload-file-input"
-                style="display: none;"
-                type="file"
-              />
-            </label>
-          </button>
+            Upload File
+            <input
+              data-testid="upload-file-input"
+              id="upload-file-input"
+              style="display: none;"
+              type="file"
+            />
+          </label>
         </div>
       </div>
       <table
@@ -278,24 +274,20 @@ exports[`Container view Renders a table with data 1`] = `
           >
             Create Folder
           </button>
-          <button
+          <label
             class="PodBrowser-page-header__action"
             data-testid="upload-file-button"
-            type="button"
+            for="upload-file-input"
+            tabindex="0"
           >
-            <label
-              data-testid="upload-file-label"
-              for="upload-file-input"
-            >
-              Upload File
-              <input
-                data-testid="upload-file-input"
-                id="upload-file-input"
-                style="display: none;"
-                type="file"
-              />
-            </label>
-          </button>
+            Upload File
+            <input
+              data-testid="upload-file-input"
+              id="upload-file-input"
+              style="display: none;"
+              type="file"
+            />
+          </label>
         </div>
       </div>
       <table

--- a/components/containerSubHeader/__snapshots__/index.test.jsx.snap
+++ b/components/containerSubHeader/__snapshots__/index.test.jsx.snap
@@ -38,24 +38,20 @@ exports[`ContainerSubHeader Renders subheader 1`] = `
       >
         Create Folder
       </button>
-      <button
+      <label
         class="PodBrowser-page-header__action"
         data-testid="upload-file-button"
-        type="button"
+        for="upload-file-input"
+        tabindex="0"
       >
-        <label
-          data-testid="upload-file-label"
-          for="upload-file-input"
-        >
-          Upload File
-          <input
-            data-testid="upload-file-input"
-            id="upload-file-input"
-            style="display: none;"
-            type="file"
-          />
-        </label>
-      </button>
+        Upload File
+        <input
+          data-testid="upload-file-input"
+          id="upload-file-input"
+          style="display: none;"
+          type="file"
+        />
+      </label>
     </div>
   </div>
 </DocumentFragment>

--- a/components/containerSubHeader/__snapshots__/index.test.jsx.snap
+++ b/components/containerSubHeader/__snapshots__/index.test.jsx.snap
@@ -38,17 +38,24 @@ exports[`ContainerSubHeader Renders subheader 1`] = `
       >
         Create Folder
       </button>
-      <label
+      <button
         class="PodBrowser-page-header__action"
         data-testid="upload-file-button"
+        type="button"
       >
-        Upload File
-        <input
-          data-testid="upload-file-input"
-          style="display: none;"
-          type="file"
-        />
-      </label>
+        <label
+          data-testid="upload-file-label"
+          for="upload-file-input"
+        >
+          Upload File
+          <input
+            data-testid="upload-file-input"
+            id="upload-file-input"
+            style="display: none;"
+            type="file"
+          />
+        </label>
+      </button>
     </div>
   </div>
 </DocumentFragment>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4643,6 +4643,79 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.11.8",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.8.tgz",
+      "integrity": "sha512-ScyKrWQM5xNcr79PkSewnA79CLaoxVskE+f7knTOhDD9ftZSA1Jw8mj+pneqhEu3x37ncNfW84NUr7lqK+mXjA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.1.1.tgz",
@@ -5039,6 +5112,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/testing-library__react-hooks": {
       "version": "3.4.1",
@@ -13906,6 +13988,12 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -15909,6 +15997,16 @@
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-2.0.0.tgz",
       "integrity": "sha512-v1SEYUOXXdbBZK8ZuNgO4TBjamPsiSgcFr0aP+tEKpQZK8vooEUqV6nm6Cv502mX4NF2EfsnVqtNAHG+/6Ur1Q=="
     },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      }
+    },
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
@@ -17115,6 +17213,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
+    },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@inrupt/eslint-config-react": "^0.0.4",
     "@sentry/webpack-plugin": "^1.13.0",
     "@testing-library/dom": "^7.26.5",
+    "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.1.0",
     "@testing-library/react-hooks": "^3.4.2",
     "@testing-library/user-event": "^12.2.0",


### PR DESCRIPTION
This PR adds:
- The "Upload File" button is now focusable
- The file browser opening is triggered by pressing "Enter" 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
