### PR TITLE
fix: handle deletion of current folder

### DIFF
--- a/components/containerDetails/index.jsx
+++ b/components/containerDetails/index.jsx
@@ -23,7 +23,10 @@ import React, { useContext } from "react";
 import T from "prop-types";
 import { DrawerContainer } from "@inrupt/prism-react-components";
 import { useRouter } from "next/router";
-import ResourceDrawer, { handleCloseDrawer } from "../resourceDrawer";
+import ResourceDrawer, {
+  handleCloseDrawer,
+  handleRedirectToParentContainer,
+} from "../resourceDrawer";
 import DetailsMenuContext from "../../src/contexts/detailsMenuContext";
 
 export default function ContainerDetails({ children, mutate }) {
@@ -35,6 +38,10 @@ export default function ContainerDetails({ children, mutate }) {
       onUpdate={() => {
         mutate();
         handleCloseDrawer({ setMenuOpen, router })();
+      }}
+      onDeleteCurrentContainer={(iri) => {
+        mutate();
+        handleRedirectToParentContainer({ setMenuOpen, iri, router })();
       }}
     />
   );

--- a/components/containerDetails/index.test.jsx
+++ b/components/containerDetails/index.test.jsx
@@ -87,7 +87,7 @@ describe("ContainerDetails", () => {
     beforeEach(() => onDeleteCurrentContainerFn());
 
     test("it calls mutate", () => expect(mutate).toHaveBeenCalled());
-    test("it calls handleCloseDrawerFn", () =>
+    test("it calls handleRedirectToParentContainerFn", () =>
       expect(handleRedirectToParentContainerFn).toHaveBeenCalled());
   });
 });

--- a/components/containerDetails/index.test.jsx
+++ b/components/containerDetails/index.test.jsx
@@ -24,14 +24,19 @@ import * as RouterFns from "next/router";
 import T from "prop-types";
 import { render } from "@testing-library/react";
 import ContainerDetails from "./index";
-import ResourceDrawer, { handleCloseDrawer } from "../resourceDrawer";
+import ResourceDrawer, {
+  handleCloseDrawer,
+  handleRedirectToParentContainer,
+} from "../resourceDrawer";
 
 jest.mock("../resourceDrawer");
 
 describe("ContainerDetails", () => {
   let mutate;
   let onUpdateFn;
+  let onDeleteCurrentContainerFn;
   let handleCloseDrawerFn;
+  let handleRedirectToParentContainerFn;
   let renderResult;
 
   beforeEach(() => {
@@ -41,18 +46,25 @@ describe("ContainerDetails", () => {
       query: {},
     });
 
-    function MockResourceDrawer({ onUpdate }) {
+    function MockResourceDrawer({ onUpdate, onDeleteCurrentContainer }) {
       onUpdateFn = onUpdate;
+      onDeleteCurrentContainerFn = onDeleteCurrentContainer;
       return null;
     }
     MockResourceDrawer.propTypes = {
       onUpdate: T.func.isRequired,
+      onDeleteCurrentContainer: T.func.isRequired,
     };
 
     ResourceDrawer.mockImplementationOnce(MockResourceDrawer);
 
     handleCloseDrawerFn = jest.fn().mockResolvedValue(jest.fn());
     handleCloseDrawer.mockImplementationOnce(() => handleCloseDrawerFn);
+
+    handleRedirectToParentContainerFn = jest.fn().mockResolvedValue(jest.fn());
+    handleRedirectToParentContainer.mockImplementationOnce(
+      () => handleRedirectToParentContainerFn
+    );
 
     mutate = jest.fn();
 
@@ -69,5 +81,13 @@ describe("ContainerDetails", () => {
     test("it calls mutate", () => expect(mutate).toHaveBeenCalled());
     test("it calls handleCloseDrawerFn", () =>
       expect(handleCloseDrawerFn).toHaveBeenCalled());
+  });
+
+  describe("when onDeleteCurrentContainer is called", () => {
+    beforeEach(() => onDeleteCurrentContainerFn());
+
+    test("it calls mutate", () => expect(mutate).toHaveBeenCalled());
+    test("it calls handleCloseDrawerFn", () =>
+      expect(handleRedirectToParentContainerFn).toHaveBeenCalled());
   });
 });

--- a/components/deleteResourceButton/index.jsx
+++ b/components/deleteResourceButton/index.jsx
@@ -24,7 +24,6 @@ import T from "prop-types";
 import { useRouter } from "next/router";
 import { useSession } from "@inrupt/solid-ui-react";
 import { getSourceIri, isContainer } from "@inrupt/solid-client";
-import { getParentContainerUrl } from "../../src/stringHelpers";
 import usePoliciesContainer from "../../src/hooks/usePoliciesContainer";
 import AlertContext from "../../src/contexts/alertContext";
 import useResourceInfo from "../../src/hooks/useResourceInfo";
@@ -35,21 +34,18 @@ export function createDeleteHandler(
   resourceInfo,
   policiesContainer,
   onDelete,
+  onDeleteCurrentContainer,
   router,
   fetch
 ) {
   return async () => {
     await deleteResource(resourceInfo, policiesContainer, fetch);
-    onDelete();
     const iri = getSourceIri(resourceInfo);
 
     if (isContainer(resourceInfo) && iri === router.query.iri) {
-      const parentContainerUrl = getParentContainerUrl(iri);
-
-      router.push(
-        "/resource/[iri]",
-        `/resource/${encodeURIComponent(parentContainerUrl)}`
-      );
+      onDeleteCurrentContainer(iri);
+    } else {
+      onDelete();
     }
   };
 }
@@ -59,6 +55,7 @@ export default function DeleteResourceButton({
   name,
   resourceIri,
   onDelete,
+  onDeleteCurrentContainer,
   ...buttonProps
 }) {
   const { fetch } = useSession();
@@ -78,6 +75,7 @@ export default function DeleteResourceButton({
     resourceInfo,
     policiesContainer,
     onDelete,
+    onDeleteCurrentContainer,
     router,
     fetch
   );
@@ -100,4 +98,5 @@ DeleteResourceButton.propTypes = {
   name: T.string.isRequired,
   resourceIri: T.string.isRequired,
   onDelete: T.func.isRequired,
+  onDeleteCurrentContainer: T.func.isRequired,
 };

--- a/components/deleteResourceButton/index.test.jsx
+++ b/components/deleteResourceButton/index.test.jsx
@@ -50,6 +50,7 @@ describe("Delete resource button", () => {
       renderResult = renderWithTheme(
         <DeleteResourceButton
           onDelete={jest.fn()}
+          onDeleteCurrentContainer={jest.fn()}
           resourceIri={resourceIri}
           name={name}
         />
@@ -97,6 +98,7 @@ describe("Delete resource button", () => {
 
   describe("when deleting current folder", () => {
     let onDelete;
+    let onDeleteCurrentContainer;
     let handleDelete;
     const router = {};
     router.push = jest.fn();
@@ -111,22 +113,19 @@ describe("Delete resource button", () => {
         iri: "https://example.org/folder/subfolder/",
       });
       onDelete = jest.fn();
+      onDeleteCurrentContainer = jest.fn();
       router.query = { iri: "https://example.org/folder/subfolder/" };
       handleDelete = createDeleteHandler(
         resourceInfo,
         policyUrl,
         onDelete,
+        onDeleteCurrentContainer,
         router,
         fetch
       );
       await handleDelete();
     });
-
-    it("redirects to parent container", () => {
-      expect(router.push).toHaveBeenCalledWith(
-        "/resource/[iri]",
-        `/resource/${encodeURIComponent("https://example.org/folder/")}`
-      );
-    });
+    it("triggers onDeleteCurrentContainer", () =>
+      expect(onDeleteCurrentContainer).toHaveBeenCalled());
   });
 });

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -54,7 +54,10 @@ const TESTCAFE_ID_TITLE = "resource-title";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
-export default function ResourceDetails({ onDelete }) {
+export default function ResourceDetails({
+  onDelete,
+  onDeleteCurrentContainer,
+}) {
   const { dataset } = useContext(DatasetContext);
   const datasetUrl = getSourceUrl(dataset);
   const classes = useStyles();
@@ -103,6 +106,7 @@ export default function ResourceDetails({ onDelete }) {
                 resourceIri={datasetUrl}
                 name={displayName}
                 onDelete={onDelete}
+                onDeleteCurrentContainer={onDeleteCurrentContainer}
                 data-testid={TESTCAFE_ID_DELETE_BUTTON}
               />
             </ActionMenuItem>
@@ -154,8 +158,10 @@ export default function ResourceDetails({ onDelete }) {
 
 ResourceDetails.propTypes = {
   onDelete: T.func,
+  onDeleteCurrentContainer: T.func,
 };
 
 ResourceDetails.defaultProps = {
   onDelete: () => {},
+  onDeleteCurrentContainer: () => {},
 };

--- a/components/resourceDrawer/index.jsx
+++ b/components/resourceDrawer/index.jsx
@@ -25,7 +25,10 @@ import { useRouter } from "next/router";
 import { Drawer, Message } from "@inrupt/prism-react-components";
 import { DatasetProvider } from "@inrupt/solid-ui-react";
 import DetailsMenuContext from "../../src/contexts/detailsMenuContext";
-import { stripQueryParams } from "../../src/stringHelpers";
+import {
+  getParentContainerUrl,
+  stripQueryParams,
+} from "../../src/stringHelpers";
 import ResourceDetails from "../resourceDetails";
 import DetailsLoading from "../resourceDetails/detailsLoading";
 import useAccessControl from "../../src/hooks/useAccessControl";
@@ -42,7 +45,18 @@ export function handleCloseDrawer({ setMenuOpen, router }) {
   };
 }
 
-export default function ResourceDrawer({ onUpdate }) {
+export function handleRedirectToParentContainer({ setMenuOpen, iri, router }) {
+  return async () => {
+    setMenuOpen(false);
+    const parentContainerUrl = getParentContainerUrl(iri);
+    await router.replace(
+      "/resource/[iri]",
+      `/resource/${encodeURIComponent(parentContainerUrl)}`
+    );
+  };
+}
+
+export default function ResourceDrawer({ onUpdate, onDeleteCurrentContainer }) {
   const { menuOpen, setMenuOpen } = useContext(DetailsMenuContext);
   const router = useRouter();
   const {
@@ -86,7 +100,10 @@ export default function ResourceDrawer({ onUpdate }) {
       ) : (
         <AccessControlProvider accessControl={accessControl}>
           <DatasetProvider dataset={resourceInfo}>
-            <ResourceDetails onDelete={onUpdate} />
+            <ResourceDetails
+              onDelete={onUpdate}
+              onDeleteCurrentContainer={onDeleteCurrentContainer}
+            />
           </DatasetProvider>
         </AccessControlProvider>
       )}
@@ -96,8 +113,10 @@ export default function ResourceDrawer({ onUpdate }) {
 
 ResourceDrawer.propTypes = {
   onUpdate: T.func,
+  onDeleteCurrentContainer: T.func,
 };
 
 ResourceDrawer.defaultProps = {
   onUpdate: () => {},
+  onDeleteCurrentContainer: () => {},
 };

--- a/components/resourceDrawer/index.test.jsx
+++ b/components/resourceDrawer/index.test.jsx
@@ -25,7 +25,10 @@ import * as RouterFns from "next/router";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import mockSession from "../../__testUtils/mockSession";
 import mockSessionContextProvider from "../../__testUtils/mockSessionContextProvider";
-import ResourceDrawer, { handleCloseDrawer } from "./index";
+import ResourceDrawer, {
+  handleCloseDrawer,
+  handleRedirectToParentContainer,
+} from "./index";
 import { renderWithTheme } from "../../__testUtils/withTheme";
 import mockDetailsContextMenuProvider from "../../__testUtils/mockDetailsContextMenuProvider";
 import useResourceInfo from "../../src/hooks/useResourceInfo";
@@ -200,5 +203,27 @@ describe("handleCloseDrawer", () => {
 
     expect(setMenuOpen).toHaveBeenCalledWith(false);
     expect(router.replace).toHaveBeenCalledWith("/resource/[iri]", "/");
+  });
+});
+
+describe("handleRedirectToParentContainer", () => {
+  test("it creates a function that closes the drawer and redirects to parent container", async () => {
+    const setMenuOpen = jest.fn();
+    const router = {
+      replace: jest.fn(),
+    };
+    const subfolderIri = "https://example.org/folder/subfolder/";
+    const handler = handleRedirectToParentContainer({
+      setMenuOpen,
+      iri: subfolderIri,
+      router,
+    });
+    await handler();
+
+    expect(setMenuOpen).toHaveBeenCalledWith(false);
+    expect(router.replace).toHaveBeenCalledWith(
+      "/resource/[iri]",
+      `/resource/${encodeURIComponent("https://example.org/folder/")}`
+    );
   });
 });


### PR DESCRIPTION
This PR fixes bug: pod indicator displays "unknown" after deleting current folder

The cause was redirecting to the deleted folder: `stripQueryParams` did not work in the case of the current folder because there are no query params to remove and we need to go up one level. When trying to fetch the pod owner for the resource requested, it cause an error which set the pod owner web to null.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

