### PR TITLE
Upgrading solid client to 1.3.0

### DIFF
--- a/__testUtils/mockBookmarks.js
+++ b/__testUtils/mockBookmarks.js
@@ -29,10 +29,10 @@ import {
 } from "@inrupt/solid-client";
 import { dct, rdf } from "rdf-namespaces";
 import {
-  RECALLS_PROPERTY_IRI,
   BOOKMARK_TYPE_IRI,
+  RECALLS_PROPERTY_IRI,
 } from "../src/solidClientHelpers/bookmarks";
-import { changeThing } from "../src/solidClientHelpers/utils";
+import { chain } from "../src/solidClientHelpers/utils";
 
 const bookmarksUrl = "http://example.com/bookmarks/index.ttl";
 const bookmark1Title = "Cat gifs";
@@ -41,31 +41,42 @@ const bookmark2Title = "Dog videos";
 const bookmark2Recalls = "https://example.com/dogvideos";
 
 export default function mockBookmarks() {
-  let bookmarksDataset = mockSolidDatasetFrom(bookmarksUrl);
-  const bookmark1Thing = mockThingFrom(`${bookmarksUrl}#1234`);
-  const bookmark1 = changeThing(
-    bookmark1Thing,
-    (t) => addStringNoLocale(t, dct.title, bookmark1Title),
-    (t) => addUrl(t, RECALLS_PROPERTY_IRI, bookmark1Recalls),
-    (t) => addUrl(t, rdf.type, BOOKMARK_TYPE_IRI),
-    (t) =>
-      addDatetime(t, dct.created, new Date(Date.UTC(2020, 9, 28, 3, 24, 0)))
-  );
-
-  bookmarksDataset = setThing(bookmarksDataset, bookmark1);
-  const bookmark2Thing = mockThingFrom(`${bookmarksUrl}#4567`);
-  const bookmark2 = changeThing(
-    bookmark2Thing,
-    (t) => addStringNoLocale(t, dct.title, bookmark2Title),
-    (t) => addUrl(t, RECALLS_PROPERTY_IRI, bookmark2Recalls),
-    (t) => addUrl(t, rdf.type, BOOKMARK_TYPE_IRI),
-    (t) =>
-      addDatetime(t, dct.created, new Date(Date.UTC(2020, 9, 29, 3, 24, 0)))
-  );
-
-  bookmarksDataset = setThing(bookmarksDataset, bookmark2);
   return {
-    dataset: bookmarksDataset,
+    dataset: chain(
+      mockSolidDatasetFrom(bookmarksUrl),
+      (d) =>
+        setThing(
+          d,
+          chain(
+            mockThingFrom(`${bookmarksUrl}#1234`),
+            (t) => addStringNoLocale(t, dct.title, bookmark1Title),
+            (t) => addUrl(t, RECALLS_PROPERTY_IRI, bookmark1Recalls),
+            (t) => addUrl(t, rdf.type, BOOKMARK_TYPE_IRI),
+            (t) =>
+              addDatetime(
+                t,
+                dct.created,
+                new Date(Date.UTC(2020, 9, 28, 3, 24, 0))
+              )
+          )
+        ),
+      (d) =>
+        setThing(
+          d,
+          chain(
+            mockThingFrom(`${bookmarksUrl}#4567`),
+            (t) => addStringNoLocale(t, dct.title, bookmark2Title),
+            (t) => addUrl(t, RECALLS_PROPERTY_IRI, bookmark2Recalls),
+            (t) => addUrl(t, rdf.type, BOOKMARK_TYPE_IRI),
+            (t) =>
+              addDatetime(
+                t,
+                dct.created,
+                new Date(Date.UTC(2020, 9, 29, 3, 24, 0))
+              )
+          )
+        )
+    ),
     iri: bookmarksUrl,
   };
 }

--- a/__testUtils/mockPersonContactThing.js
+++ b/__testUtils/mockPersonContactThing.js
@@ -25,9 +25,9 @@ import { chain } from "../src/solidClientHelpers/utils";
 
 export const webIdUrl = "http://example.com/alice#me";
 
-export function mockPersonContactDataset() {
+export default function mockPersonContactThing(url = webIdUrl) {
   return chain(
-    mockThingFrom(webIdUrl),
+    mockThingFrom(url),
     (t) => addUrl(t, rdf.type, vcard.Individual),
     (t) => addUrl(t, foaf.openid, webIdUrl)
   );

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -25,14 +25,16 @@ import {
   asUrl,
   mockThingFrom,
 } from "@inrupt/solid-client";
-import { vcard, foaf, rdf } from "rdf-namespaces";
+import { vcard, foaf, rdf, space } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { packageProfile } from "../src/solidClientHelpers/profile";
 
-export const aliceWebIdUrl = "http://example.com/alice#me";
+export const aliceProfileUrl = "http://alice.example.com/alice";
+export const aliceWebIdUrl = "http://alice.example.com/alice#me";
 export const aliceName = "Alice";
 export const aliceNick = "A";
-export const alicePhoto = "http://example.com/alice.jpg";
+export const alicePhoto = "http://alice.example.com/alice.jpg";
+export const alicePodRoot = "http://alice.example.com/";
 
 const VCARD_WEBID_PREDICATE = "https://www.w3.org/2006/vcard/ns#WebId";
 
@@ -55,7 +57,8 @@ export function mockPersonDatasetAlice() {
     (t) => addStringNoLocale(t, vcard.nickname, aliceNick),
     (t) => addUrl(t, vcard.hasPhoto, alicePhoto),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, vcard.url, mockWebIdNodeAlice.webIdNodeUrl)
+    (t) => addUrl(t, vcard.url, mockWebIdNodeAlice.webIdNodeUrl),
+    (t) => addUrl(t, space.storage, alicePodRoot)
   );
 }
 
@@ -63,9 +66,10 @@ export function mockProfileAlice() {
   return packageProfile(aliceWebIdUrl, mockPersonDatasetAlice());
 }
 
-export const bobWebIdUrl = "http://example.com/bob#me";
+export const bobWebIdUrl = "http://bob.example.com/bob#me";
 export const bobName = "Bob";
 export const bobNick = "B";
+export const bobPodRoot = "http://bob.example.com/";
 
 export function mockPersonDatasetBob() {
   return chain(
@@ -73,7 +77,8 @@ export function mockPersonDatasetBob() {
     (t) => addStringNoLocale(t, foaf.name, bobName),
     (t) => addStringNoLocale(t, foaf.nick, bobNick),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, foaf.openid, bobWebIdUrl)
+    (t) => addUrl(t, foaf.openid, bobWebIdUrl),
+    (t) => addUrl(t, space.storage, bobPodRoot)
   );
 }
 

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -31,9 +31,12 @@ import { packageProfile } from "../src/solidClientHelpers/profile";
 
 const VCARD_WEBID_PREDICATE = "https://www.w3.org/2006/vcard/ns#WebId";
 
-export function mockWebIdNode(webId) {
+export function mockWebIdNode(
+  webId,
+  nodeUrl = "https://example.org/contacts/Person/1234/index.ttl#4567"
+) {
   const webIdNode = chain(
-    mockThingFrom("https://example.org/contacts/Person/1234/index.ttl#4567"),
+    mockThingFrom(nodeUrl),
     (t) => addUrl(t, rdf.type, VCARD_WEBID_PREDICATE),
     (t) => addUrl(t, vcard.value, webId)
   );

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -29,13 +29,6 @@ import { vcard, foaf, rdf, space } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { packageProfile } from "../src/solidClientHelpers/profile";
 
-export const aliceProfileUrl = "http://alice.example.com/alice";
-export const aliceWebIdUrl = "http://alice.example.com/alice#me";
-export const aliceName = "Alice";
-export const aliceNick = "A";
-export const alicePhoto = "http://alice.example.com/alice.jpg";
-export const alicePodRoot = "http://alice.example.com/";
-
 const VCARD_WEBID_PREDICATE = "https://www.w3.org/2006/vcard/ns#WebId";
 
 export function mockWebIdNode(webId) {
@@ -48,7 +41,14 @@ export function mockWebIdNode(webId) {
   return { webIdNode, webIdNodeUrl: url };
 }
 
-const mockWebIdNodeAlice = mockWebIdNode(aliceWebIdUrl);
+export const aliceProfileUrl = "http://alice.example.com/alice";
+export const aliceWebIdUrl = "http://alice.example.com/alice#me";
+export const aliceName = "Alice";
+export const aliceNick = "A";
+export const alicePhoto = "http://alice.example.com/alice.jpg";
+export const alicePodRoot = "http://alice.example.com/";
+export const aliceAlternativeProfileUrl = "https://alice2.example.org/card";
+export const aliceAlternativeWebIdUrl = "https://alice2.example.org/card#me";
 
 export function mockPersonDatasetAlice() {
   return chain(
@@ -57,7 +57,7 @@ export function mockPersonDatasetAlice() {
     (t) => addStringNoLocale(t, vcard.nickname, aliceNick),
     (t) => addUrl(t, vcard.hasPhoto, alicePhoto),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, vcard.url, mockWebIdNodeAlice.webIdNodeUrl),
+    (t) => addUrl(t, vcard.url, aliceAlternativeWebIdUrl),
     (t) => addUrl(t, space.storage, alicePodRoot)
   );
 }
@@ -66,10 +66,13 @@ export function mockProfileAlice() {
   return packageProfile(aliceWebIdUrl, mockPersonDatasetAlice());
 }
 
+export const bobProfileUrl = "http://bob.example.com/bob";
 export const bobWebIdUrl = "http://bob.example.com/bob#me";
 export const bobName = "Bob";
 export const bobNick = "B";
 export const bobPodRoot = "http://bob.example.com/";
+export const bobAlternateProfileUrl = "https://bob2.example.org/card";
+export const bobAlternateWebIdUrl = "https://bob2.example.org/card#me";
 
 export function mockPersonDatasetBob() {
   return chain(
@@ -77,7 +80,7 @@ export function mockPersonDatasetBob() {
     (t) => addStringNoLocale(t, foaf.name, bobName),
     (t) => addStringNoLocale(t, foaf.nick, bobNick),
     (t) => addUrl(t, rdf.type, foaf.Person),
-    (t) => addUrl(t, foaf.openid, bobWebIdUrl),
+    (t) => addUrl(t, foaf.openid, bobAlternateWebIdUrl),
     (t) => addUrl(t, space.storage, bobPodRoot)
   );
 }

--- a/__testUtils/mockSession.js
+++ b/__testUtils/mockSession.js
@@ -113,3 +113,5 @@ export function mockAuthenticatedSessionWithNoAccessToAnotherUsersPod() {
     },
   };
 }
+
+export const mockAuthenticatedSession = mockAuthenticatedSessionWithNoAccessToPod;

--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -37,6 +37,7 @@ import { useRedirectIfLoggedOut } from "../../src/effects/auth";
 import styles from "./styles";
 import { fetchProfile } from "../../src/solidClientHelpers/profile";
 import useContacts from "../../src/hooks/useContacts";
+import useContactsContainerUrl from "../../src/hooks/useContactsContainerUrl";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 export const EXISTING_WEBID_ERROR_MESSAGE =
@@ -47,6 +48,7 @@ export const FETCH_PROFILE_FAILED_ERROR_MESSAGE =
 
 export function handleSubmit({
   addressBook,
+  addressBookContainerUrl,
   setAgentId,
   setIsLoading,
   alertError,
@@ -84,6 +86,7 @@ export function handleSubmit({
         const contact = { webId, fn: name };
         const { response, error } = await saveContact(
           addressBook,
+          addressBookContainerUrl,
           contact,
           types,
           fetch
@@ -98,7 +101,7 @@ export function handleSubmit({
       } else {
         alertError(NO_NAME_ERROR_MESSAGE);
       }
-    } catch {
+    } catch (error) {
       alertError(FETCH_PROFILE_FAILED_ERROR_MESSAGE);
     }
     setIsLoading(false);
@@ -119,6 +122,7 @@ export default function AddContact() {
     bem("container"),
     bem("container-view", menuOpen ? "menu-open" : null)
   );
+  const addressBookContainerUrl = useContactsContainerUrl();
   const [addressBook] = useAddressBook();
   const [isLoading, setIsLoading] = useState(false);
   const [agentId, setAgentId] = useState("");
@@ -135,6 +139,7 @@ export default function AddContact() {
 
   const onSubmit = handleSubmit({
     addressBook,
+    addressBookContainerUrl,
     setAgentId,
     setIsLoading,
     alertError,

--- a/components/bookmark/index.jsx
+++ b/components/bookmark/index.jsx
@@ -25,7 +25,7 @@ import PropTypes from "prop-types";
 import { createStyles, makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
 import clsx from "clsx";
-import { getUrlAll } from "@inrupt/solid-client";
+import { getThingAll, getUrl } from "@inrupt/solid-client";
 import styles from "./styles";
 import {
   addBookmark,
@@ -80,7 +80,9 @@ export const toggleBookmarkHandler = ({
 };
 
 const isBookmarked = (iri, dataset) => {
-  const listOfRecallsUrls = getUrlAll(dataset, RECALLS_PROPERTY_IRI);
+  const listOfRecallsUrls = getThingAll(dataset).map((t) =>
+    getUrl(t, RECALLS_PROPERTY_IRI)
+  );
   return listOfRecallsUrls.includes(iri);
 };
 

--- a/components/bookmarksList/__snapshots__/index.test.jsx.snap
+++ b/components/bookmarksList/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BookmarksList it renders a list of bookmarks 1`] = `
+exports[`BookmarksList renders a list of bookmarks 1`] = `
 <DocumentFragment>
   <div
     class="PodBrowser-page-header"
@@ -164,7 +164,7 @@ exports[`BookmarksList it renders a list of bookmarks 1`] = `
 </DocumentFragment>
 `;
 
-exports[`BookmarksList it renders a spinner if bookmarks are loading 1`] = `
+exports[`BookmarksList renders a spinner if bookmarks are loading 1`] = `
 <DocumentFragment>
   <div
     class="PodBrowser-loading-indicator-container PodBrowser-loading-indicator-container--center"

--- a/components/bookmarksList/index.test.jsx
+++ b/components/bookmarksList/index.test.jsx
@@ -26,12 +26,10 @@ import mockBookmarks from "../../__testUtils/mockBookmarks";
 import mockBookmarksContextProvider from "../../__testUtils/mockBookmarksContextProvider";
 
 describe("BookmarksList", () => {
-  test("it renders a spinner if bookmarks are loading", async () => {
-    const bookmarks = null;
-    const setBookmarks = jest.fn();
+  it("renders a spinner if bookmarks are loading", () => {
     const BookmarksContextProvider = mockBookmarksContextProvider({
-      bookmarks,
-      setBookmarks,
+      bookmarks: null,
+      setBookmarks: jest.fn(),
     });
     const { asFragment } = renderWithTheme(
       <BookmarksContextProvider>
@@ -40,7 +38,8 @@ describe("BookmarksList", () => {
     );
     expect(asFragment()).toMatchSnapshot();
   });
-  test("it renders a list of bookmarks", async () => {
+
+  it("renders a list of bookmarks", () => {
     const bookmarks = mockBookmarks();
     const setBookmarks = jest.fn();
     const BookmarksContextProvider = mockBookmarksContextProvider({

--- a/components/contactsList/__snapshots__/index.test.jsx.snap
+++ b/components/contactsList/__snapshots__/index.test.jsx.snap
@@ -164,7 +164,7 @@ exports[`ContactsList renders page when people is loaded 1`] = `
               role="cell"
             >
               <a
-                href="/contacts/http%3A%2F%2Fexample.com%2Falice%23me"
+                href="/contacts/http%3A%2F%2Falice.example.com%2Falice%23me"
               >
                 Alice
               </a>
@@ -197,7 +197,7 @@ exports[`ContactsList renders page when people is loaded 1`] = `
               role="cell"
             >
               <a
-                href="/contacts/http%3A%2F%2Fexample.com%2Fbob%23me"
+                href="/contacts/http%3A%2F%2Fbob.example.com%2Fbob%23me"
               >
                 Bob
               </a>

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -30,7 +30,11 @@ import {
   PageHeader,
   Table as PrismTable,
 } from "@inrupt/prism-react-components";
-import { getSourceUrl, getStringNoLocale } from "@inrupt/solid-client";
+import {
+  getSourceUrl,
+  getStringNoLocale,
+  getThing,
+} from "@inrupt/solid-client";
 import { Table, TableColumn, useSession } from "@inrupt/solid-ui-react";
 import { vcard, foaf } from "rdf-namespaces";
 import SortedTableCarat from "../sortedTableCarat";
@@ -44,7 +48,7 @@ import useProfiles from "../../src/hooks/useProfiles";
 import ContactsListSearch from "./contactsListSearch";
 import ProfileLink from "../profileLink";
 import { SearchProvider } from "../../src/contexts/searchContext";
-import { deleteContact, getWebId } from "../../src/addressBook";
+import { deleteContact, getWebIdUrl } from "../../src/addressBook";
 import ContactsDrawer from "./contactsDrawer";
 import ContactsEmptyState from "./contactsEmptyState";
 
@@ -105,16 +109,13 @@ function ContactsList() {
 
   useEffect(() => {
     if (selectedContactIndex === null) return;
-    const name = getStringNoLocale(
-      people[selectedContactIndex].dataset,
-      formattedNamePredicate
-    );
+    const contactDataset = people[selectedContactIndex].dataset;
+    const contactThingUrl = people[selectedContactIndex].iri;
+    const contactThing = getThing(contactDataset, contactThingUrl);
+    const name = getStringNoLocale(contactThing, formattedNamePredicate);
     setSelectedContactName(name);
     (async () => {
-      const webId = getWebId(
-        people[selectedContactIndex].dataset,
-        people[selectedContactIndex].iri
-      );
+      const webId = getWebIdUrl(contactDataset, contactThingUrl);
       setSelectedContactWebId(webId);
     })();
   }, [selectedContactIndex, formattedNamePredicate, people, fetch]);

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -111,7 +111,10 @@ function ContactsList() {
     );
     setSelectedContactName(name);
     (async () => {
-      const webId = getWebId(people[selectedContactIndex].dataset, fetch);
+      const webId = getWebId(
+        people[selectedContactIndex].dataset,
+        people[selectedContactIndex].iri
+      );
       setSelectedContactWebId(webId);
     })();
   }, [selectedContactIndex, formattedNamePredicate, people, fetch]);

--- a/components/resourceDetails/resourceSharing/agentAccess/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/__snapshots__/index.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`AgentAccess renders 1`] = `
     <img
       alt="Alice"
       class="PodBrowser-img"
-      src="http://example.com/alice.jpg"
+      src="http://alice.example.com/alice.jpg"
     />
   </div>
   <p
@@ -570,7 +570,7 @@ exports[`AgentAccess user tries to change access for themselves checkboxes are d
     <img
       alt="Alice"
       class="PodBrowser-img"
-      src="http://example.com/alice.jpg"
+      src="http://alice.example.com/alice.jpg"
     />
   </div>
   <p

--- a/package-lock.json
+++ b/package-lock.json
@@ -988,9 +988,9 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.0.0.tgz",
-      "integrity": "sha512-Fk2xyVh/3g90DImLETFzonAtMhqtXOJwTEEwMY6mHFTcGf0Ob2BYtlGUrFe9o1ZxgycIUPtDrlsZjiXLvbm/1A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.3.0.tgz",
+      "integrity": "sha512-ykWSdNrggngpTToiMSiLteqCMgZcCjJ5wMmOQvt/Lf607ir4L9+2BmOERMcDrCtigtzfjXiuW9wg17VSiENYAQ==",
       "requires": {
         "@rdfjs/dataset": "^1.0.1",
         "@types/n3": "^1.1.6",
@@ -13130,9 +13130,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "n3": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.6.4.tgz",
-      "integrity": "sha512-qiiBhW2nJ59cfQzi0nvZs5tSXkXgDXedIy3zNNuKjTwE8Bcvv95DTFJpOY9geg6of5T7z6cg+ZWcaHIij3svrA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.7.0.tgz",
+      "integrity": "sha512-8R0Qj545WnVLQxOfxxyFKzOpO13hF3jhSMJfO0FNqvbsPZDiR9ZDmGGjXAlcoZDf/88OsCYd7rHML284vm1h6A==",
       "requires": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -14403,9 +14403,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "queue-microtask": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.0.tgz",
-      "integrity": "sha512-J95OVUiS4b8qqmpqhCodN8yPpHG2mpZUPQ8tDGyIY0VhM+kBHszOuvsMJVGNQ1OH2BnTFbqz45i+2jGpDw9H0w=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@datapunt/matomo-tracker-react": "^0.3.1",
     "@inrupt/prism-react-components": "^0.10.16",
-    "@inrupt/solid-client": "^1.0.0",
+    "@inrupt/solid-client": "^1.3.0",
     "@inrupt/solid-ui-react": "^1.7.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -188,7 +188,7 @@ function getAllowApplyPolicy(policyUrl, mode) {
 }
 
 function ensureAccessControl(policyUrl, datasetWithAcr, changed) {
-  const accessControls = acp.getControlAll(datasetWithAcr);
+  const accessControls = acp.getAllControl(datasetWithAcr);
   const existingAccessControl = accessControls.find((ac) =>
     acp.getPolicyUrlAll(ac).find((url) => policyUrl === url)
   );
@@ -201,7 +201,7 @@ function ensureAccessControl(policyUrl, datasetWithAcr, changed) {
 }
 
 function ensureApplyControl(policyUrl, datasetWithAcr, changed) {
-  const accessControls = acp.getControlAll(datasetWithAcr);
+  const accessControls = acp.getAllControl(datasetWithAcr);
   const existingAccessControl = accessControls.find((ac) =>
     acp.getPolicyUrlAll(ac).find((url) => policyUrl === url)
   );

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -423,7 +423,7 @@ export async function saveContact(
 
   const contactThing = defineThing(
     {
-      url: `${getSourceUrl(contact)}#this`, // TODO: Ugly hack, should remove
+      url: `${getSourceUrl(contact)}#this`,
     },
     (t) =>
       addStringNoLocale(t, vcard.fn, contactSchema.fn || contactSchema.name),

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -29,7 +29,7 @@ import {
   deleteFile,
   getSolidDataset,
   getSourceUrl,
-  getStringNoLocaleAll,
+  getStringNoLocale,
   getThing,
   getThingAll,
   getUrl,
@@ -133,13 +133,13 @@ export async function getGroups(containerIri, fetch) {
   const { dataset } = groupsResponse;
   const groupsThingUrl = `${getSourceUrl(dataset)}#this`; // TODO: Ugly hack, should remove
   const groupsThing = getThing(dataset, groupsThingUrl);
-  const names = getStringNoLocaleAll(groupsThing, vcard.fn);
   const iris = getUrlAll(groupsThing, vcardExtras("includesGroup"));
 
-  const groups = iris.map((iri, i) => {
+  const groups = iris.map((iri) => {
+    const groupThing = getThing(dataset, iri);
     return {
       iri,
-      name: names[i],
+      name: getStringNoLocale(groupThing, vcard.fn),
     };
   });
 

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -189,8 +189,9 @@ describe("createContact", () => {
     const things = getThingAll(dataset);
     const webId = things[0]; // always the first thing in this dataset
     const addressesThing = things[3];
-    const emailsAndPhones = things.flatMap((t) =>
-      getStringNoLocaleAll(t, vcard.value)
+    const emailsAndPhones = things.reduce(
+      (memo, t) => memo.concat(getStringNoLocaleAll(t, vcard.value)),
+      []
     );
 
     expect(getStringNoLocale(webId, vcard.fn)).toEqual("Test Person");

--- a/src/contexts/bookmarksContext/index.jsx
+++ b/src/contexts/bookmarksContext/index.jsx
@@ -24,7 +24,7 @@ import PropTypes from "prop-types";
 import useBookmarks from "../../hooks/useBookmarks";
 
 export const defaultBookmarksContext = {
-  bookmarks: [],
+  bookmarks: null,
   setBookmarks: () => {},
 };
 

--- a/src/hooks/useAddressBook/index.test.js
+++ b/src/hooks/useAddressBook/index.test.js
@@ -26,16 +26,19 @@ import mockSession, {
 import mockSessionContextProvider from "../../../__testUtils/mockSessionContextProvider";
 import useAddressBook from "./index";
 import { getResource } from "../../solidClientHelpers/resource";
-import { contactsContainerIri, saveNewAddressBook } from "../../addressBook";
+import * as addressBookFns from "../../addressBook";
+import useContactsContainerUrl from "../useContactsContainerUrl";
 
 jest.mock("../../solidClientHelpers/resource");
-jest.mock("../../addressBook/index");
+
+jest.mock("../useContactsContainerUrl");
+const mockedContactsContainerUrl = useContactsContainerUrl;
 
 describe("useAddressBook", () => {
   const contactsIri = "http://example.com/contacts/";
 
   beforeEach(() => {
-    contactsContainerIri.mockReturnValue(contactsIri);
+    mockedContactsContainerUrl.mockReturnValue(contactsIri);
   });
 
   describe("with an unauthenticated user", () => {
@@ -66,7 +69,10 @@ describe("useAddressBook", () => {
           wrapper,
         });
         await waitForNextUpdate();
-        expect(getResource).toHaveBeenCalledWith(contactsIri, session.fetch);
+        expect(getResource).toHaveBeenCalledWith(
+          addressBookFns.getContactsIndexIri(contactsIri),
+          session.fetch
+        );
       });
 
       it("should return the address book resource", async () => {
@@ -105,7 +111,7 @@ describe("useAddressBook", () => {
 
       it("should return a new address book resource", async () => {
         const dataset = 1337;
-        saveNewAddressBook.mockResolvedValue({
+        jest.spyOn(addressBookFns, "saveNewAddressBook").mockResolvedValue({
           response: {
             index: dataset,
           },
@@ -122,7 +128,9 @@ describe("useAddressBook", () => {
 
       it("should return error if anything goes wrong when creating new address book", async () => {
         const error = "Something went wrong";
-        saveNewAddressBook.mockResolvedValue({ error });
+        jest
+          .spyOn(addressBookFns, "saveNewAddressBook")
+          .mockResolvedValue({ error });
         const { result, waitForNextUpdate } = renderHook(
           () => useAddressBook(),
           {

--- a/src/hooks/useContactsContainerUrl/index.js
+++ b/src/hooks/useContactsContainerUrl/index.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { useEffect, useState } from "react";
+import { useSession } from "@inrupt/solid-ui-react";
+import useAuthenticatedProfile from "../useAuthenticatedProfile";
+import { contactsContainerIri } from "../../addressBook";
+
+export default function useContactsContainerUrl() {
+  const [addressBookContainer, setAddressBookContainer] = useState(null);
+  const { session } = useSession();
+  const { data: profile } = useAuthenticatedProfile();
+
+  useEffect(() => {
+    if (!session.info.isLoggedIn || !profile) return;
+    const { pods } = profile;
+    setAddressBookContainer(contactsContainerIri(pods[0]));
+  }, [profile, session.info.isLoggedIn]);
+
+  return addressBookContainer;
+}

--- a/src/hooks/useContactsContainerUrl/index.test.js
+++ b/src/hooks/useContactsContainerUrl/index.test.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { renderHook } from "@testing-library/react-hooks";
+import { useSession } from "@inrupt/solid-ui-react";
+import {
+  mockAuthenticatedSession,
+  mockUnauthenticatedSession,
+} from "../../../__testUtils/mockSession";
+import useAuthenticatedProfile from "../useAuthenticatedProfile";
+import {
+  alicePodRoot,
+  mockProfileAlice,
+} from "../../../__testUtils/mockPersonResource";
+import useContactsContainerUrl from "./index";
+import { joinPath } from "../../stringHelpers";
+
+jest.mock("../useAuthenticatedProfile");
+const mockedAuthenticatedProfileHook = useAuthenticatedProfile;
+
+jest.mock("@inrupt/solid-ui-react");
+const mockedSessionHook = useSession;
+
+describe("useContactsContainerUrl", () => {
+  beforeEach(() => {
+    mockedSessionHook.mockReturnValue({
+      session: mockAuthenticatedSession(),
+    });
+  });
+  beforeEach(() => {
+    mockedAuthenticatedProfileHook.mockReturnValue({
+      data: mockProfileAlice(),
+    });
+  });
+
+  it("returns the URL to the contacts container", () => {
+    const { result } = renderHook(() => useContactsContainerUrl());
+    expect(result.current).toEqual(joinPath(alicePodRoot, "contacts/"));
+  });
+
+  it("returns null if not logged in", () => {
+    mockedSessionHook.mockReturnValue({
+      session: mockUnauthenticatedSession(),
+    });
+    const { result } = renderHook(() => useContactsContainerUrl());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns null if profile is not authenticated yet", () => {
+    mockedAuthenticatedProfileHook.mockReturnValue({ data: null });
+    const { result } = renderHook(() => useContactsContainerUrl());
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/hooks/usePoliciesContainer/index.js
+++ b/src/hooks/usePoliciesContainer/index.js
@@ -22,7 +22,7 @@
 import { useEffect, useState } from "react";
 import { useSession } from "@inrupt/solid-ui-react";
 // eslint-disable-next-line camelcase
-import { acp_v1 } from "@inrupt/solid-client/dist";
+import { acp_v1 } from "@inrupt/solid-client";
 import useAuthenticatedProfile from "../useAuthenticatedProfile";
 import { getPoliciesContainerUrl } from "../../solidClientHelpers/policies";
 import { getOrCreateContainer } from "../../solidClientHelpers/resource";

--- a/src/solidClientHelpers/utils.js
+++ b/src/solidClientHelpers/utils.js
@@ -122,29 +122,6 @@ export function createResponder() {
   return { respond, error };
 }
 
-export function normalizeDataset(dataset, iri) {
-  const rawType = getUrlAll(
-    dataset,
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
-  );
-
-  const mtime = getDecimal(dataset, namespace.mtime);
-  const modified = getDatetime(dataset, namespace.modified);
-  const size = getInteger(dataset, namespace.size);
-  const contains = getUrlAll(dataset, ldp.contains);
-  const types = displayTypes(rawType);
-
-  return {
-    contains,
-    iri,
-    modified,
-    mtime,
-    size,
-    types,
-    dataset,
-  };
-}
-
 export function chain(object, ...operations) {
   return operations.reduce((acc, transform) => {
     return transform(acc);
@@ -167,10 +144,6 @@ export function defineThing(options, ...operations) {
 
 export function defineDataset(options, ...operations) {
   return setThing(createSolidDataset(), defineThing(options, ...operations));
-}
-
-export function changeThing(thing, ...operations) {
-  return chain(thing, ...operations);
 }
 
 /**

--- a/src/solidClientHelpers/utils.js
+++ b/src/solidClientHelpers/utils.js
@@ -24,9 +24,6 @@
 import {
   createSolidDataset,
   createThing,
-  getDatetime,
-  getDecimal,
-  getInteger,
   getSourceUrl,
   getThing,
   getUrlAll,

--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -30,7 +30,6 @@ import { ldp, rdf } from "rdf-namespaces";
 import {
   chain,
   chainPromise,
-  changeThing,
   createResponder,
   datasetIsContainer,
   defineDataset,
@@ -41,7 +40,6 @@ import {
   getTypes,
   isContainerIri,
   namespace,
-  normalizeDataset,
   sharedStart,
 } from "./utils";
 
@@ -99,20 +97,6 @@ function createDataset(url, type = "http://www.w3.org/ns/ldp#BasicContainer") {
 
   return setThing(createSolidDataset(), publicContainer);
 }
-
-describe("changeThing", () => {
-  test("it takes a thing and reduces it with an arbitrary list of operations", () => {
-    const { createThing } = solidClientFns;
-    const op1 = jest.fn((x) => x);
-    const op2 = jest.fn((x) => x);
-    const thing = createThing({ name: "this" });
-
-    changeThing(thing, op1, op2);
-
-    expect(op1).toHaveBeenCalledWith(thing);
-    expect(op2).toHaveBeenCalledWith(thing);
-  });
-});
 
 describe("createResponder", () => {
   test("it returns a function to respond with a data or with an error message", () => {
@@ -275,36 +259,6 @@ describe("namespace", () => {
 
       expect(value).toEqual(expectedValue);
     });
-  });
-});
-
-describe("normalizeDataset", () => {
-  test("it returns a normalized dataset", () => {
-    const containerIri = "https://user.dev.inrupt.net/public/";
-    const litDataset = createDataset(containerIri);
-    const { iri, types, mtime, modified, size, contains } = normalizeDataset(
-      litDataset,
-      containerIri
-    );
-    expect(iri).toEqual(containerIri);
-    expect(types).toContain("BasicContainer");
-    expect(types).toContain("Container");
-    expect(mtime).toEqual(1591131561.195);
-    expect(modified).toEqual(new Date(Date.UTC(2020, 5, 2, 15, 59, 21)));
-    expect(size).toEqual(4096);
-    expect(contains).toContain("https://user.dev.inrupt.net/public/games/");
-  });
-
-  test("it uses full type if no human-friendly name found", () => {
-    const containerIri = "https://user.dev.inrupt.net/public/";
-    const litDataset = createDataset(
-      containerIri,
-      "http://www.w3.org/ns/ldp#UnknownType"
-    );
-    const { types } = normalizeDataset(litDataset, containerIri);
-
-    expect(types).toContain("http://www.w3.org/ns/ldp#UnknownType");
-    expect(types).toContain("Container");
   });
 });
 

--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -43,61 +43,6 @@ import {
   sharedStart,
 } from "./utils";
 
-const TIMESTAMP = new Date(Date.UTC(2020, 5, 2, 15, 59, 21));
-
-function createDataset(url, type = "http://www.w3.org/ns/ldp#BasicContainer") {
-  const {
-    // eslint-disable-next-line no-shadow
-    addUrl,
-    createSolidDataset,
-    createThing,
-    setDatetime,
-    setDecimal,
-    setInteger,
-    // eslint-disable-next-line no-shadow
-    setThing,
-  } = solidClientFns;
-  let publicContainer = createThing({ url });
-
-  publicContainer = addUrl(
-    publicContainer,
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-    type
-  );
-
-  publicContainer = addUrl(
-    publicContainer,
-    "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-    "http://www.w3.org/ns/ldp#Container"
-  );
-
-  publicContainer = setDatetime(
-    publicContainer,
-    "http://purl.org/dc/terms/modified",
-    TIMESTAMP
-  );
-
-  publicContainer = addUrl(
-    publicContainer,
-    "http://www.w3.org/ns/ldp#contains",
-    "https://user.dev.inrupt.net/public/games/"
-  );
-
-  publicContainer = setDecimal(
-    publicContainer,
-    "http://www.w3.org/ns/posix/stat#mtime",
-    1591131561.195
-  );
-
-  publicContainer = setInteger(
-    publicContainer,
-    "http://www.w3.org/ns/posix/stat#size",
-    4096
-  );
-
-  return setThing(createSolidDataset(), publicContainer);
-}
-
 describe("createResponder", () => {
   test("it returns a function to respond with a data or with an error message", () => {
     const { respond, error } = createResponder();


### PR DESCRIPTION
# Upgrading @inrupt/solid-client@1.3.0 (up from @1.0.0)

This upgrade revealed some misuses of Solid Client in older modules (e.g. using `getUrl` with a `SolidDataset` instead of a `Thing`). This PR fixes all of these faulty uses.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
