### PR TITLE
Set/Reset Profile data-testid's

### DIFF
--- a/components/profile/contactInfoTable/index.jsx
+++ b/components/profile/contactInfoTable/index.jsx
@@ -62,11 +62,12 @@ import { chain } from "../../../src/solidClientHelpers/utils";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
-const TESTCAFE_ID_DELETE_BUTTON = "profile-address-delete-button";
-const TESTCAFE_ID_EXISTING_VALUE = "profile-address-existing-value";
-const TESTCAFE_ID_NEW_BUTTON = "profile-address-new-button";
-export const TESTCAFE_ID_NEW_TYPE = "profile-address-new-type";
-const TESTCAFE_ID_NEW_VALUE = "profile-address-new-value";
+const TESTCAFE_ID_DELETE_BUTTON = "profile-<TYPE>-delete-button";
+const TESTCAFE_ID_EXISTING_TYPE = "profile-<TYPE>-existing-type";
+const TESTCAFE_ID_EXISTING_VALUE = "profile-<TYPE>-existing-value";
+const TESTCAFE_ID_ADD_BUTTON = "profile-<TYPE>-add-button";
+export const TESTCAFE_ID_NEW_TYPE = "profile-<TYPE>-new-type";
+const TESTCAFE_ID_NEW_VALUE = "profile-<TYPE>-new-value";
 
 const CONTACT_TYPE_LABEL_MAP = {
   [vcard.Home]: "Home",
@@ -129,7 +130,7 @@ export function setupRemoveRow(profile, property, saveHandler, dataset) {
   };
 }
 
-export function setupDeleteButtonCell(editing, removeRow, bem) {
+export function setupDeleteButtonCell(editing, typestr, removeRow, bem) {
   return () => {
     const { thing: rowThing } = useThing();
 
@@ -142,7 +143,7 @@ export function setupDeleteButtonCell(editing, removeRow, bem) {
         onClick={() => removeRow(rowThing)}
         className={bem("button", "action")}
         type="button"
-        data-testid={TESTCAFE_ID_DELETE_BUTTON}
+        data-testid={TESTCAFE_ID_DELETE_BUTTON.replace("<TYPE>", typestr)}
       >
         Delete
       </button>
@@ -156,13 +157,17 @@ export function setupRowProps(bem) {
   });
 }
 
-export function setupColumnTypeBody() {
+export function setupColumnTypeBody(typestr) {
   // eslint-disable-next-line react/prop-types
+  const classes = useStyles();
   return ({ value }) => {
     const existingTypeValue = CONTACT_TYPE_LABEL_MAP[value] || value;
-    return <Typography title={value}>{existingTypeValue}</Typography>;
-  };
-}
+    const datatestid=TESTCAFE_ID_EXISTING_TYPE.replace("<TYPE>", typestr);
+    return (
+      <Typography title={value} data-testid={datatestid}>{existingTypeValue}</Typography>
+    );
+  }
+};
 
 export function setupOnSave(setDataset) {
   return (savedDataset) => {
@@ -170,7 +175,7 @@ export function setupOnSave(setDataset) {
   };
 }
 
-export function setupColumnValueBody(editing, bem, onSave) {
+export function setupColumnValueBody(editing, typestr, bem, onSave) {
   return () => (
     <Typography>
       <Value
@@ -179,7 +184,7 @@ export function setupColumnValueBody(editing, bem, onSave) {
         dataType="url"
         inputProps={{
           className: bem("input"),
-          "data-testid": TESTCAFE_ID_EXISTING_VALUE,
+          "data-testid": TESTCAFE_ID_EXISTING_VALUE.replace("<TYPE>", typestr),
         }}
         property={vcard.value}
         onSave={onSave}
@@ -192,7 +197,7 @@ export function setupOnChange(setFn) {
   return (e) => setFn(e.target.value);
 }
 
-export default function ContactTable({ editing, property }) {
+export default function ContactTable({ editing, property, typestr }) {
   const tableClass = PrismTable.useTableClass("table", "inherits");
   const classes = useStyles();
   const bem = useBem(classes);
@@ -223,11 +228,11 @@ export default function ContactTable({ editing, property }) {
 
   const removeRow = setupRemoveRow(profile, property, saveHandler, dataset);
 
-  const DeleteButtonCell = setupDeleteButtonCell(editing, removeRow, bem);
+  const DeleteButtonCell = setupDeleteButtonCell(editing, typestr, removeRow, bem);
   const getRowProps = setupRowProps(bem);
-  const columnTypeBody = setupColumnTypeBody();
+  const columnTypeBody = setupColumnTypeBody(typestr);
   const onSave = setupOnSave(setDataset);
-  const columnValueBody = setupColumnValueBody(editing, bem, onSave);
+  const columnValueBody = setupColumnValueBody(editing, typestr, bem, onSave);
   const newContactTypeOnChange = setupOnChange(setNewContactType);
   const newContactValueOnChange = setupOnChange(setNewContactValue);
 
@@ -270,12 +275,10 @@ export default function ContactTable({ editing, property }) {
                 <Select
                   value={newContactType}
                   onChange={newContactTypeOnChange}
-                  inputProps={{
-                    "data-testid": TESTCAFE_ID_NEW_TYPE,
-                  }}
+                  data-testid={TESTCAFE_ID_NEW_TYPE.replace("<TYPE>", typestr)}
                 >
                   {Object.keys(CONTACT_TYPE_LABEL_MAP).map((iri) => (
-                    <MenuItem key={iri} value={iri}>
+                    <MenuItem key={iri} value={iri} >
                       {CONTACT_TYPE_LABEL_MAP[iri]}
                     </MenuItem>
                   ))}
@@ -289,7 +292,7 @@ export default function ContactTable({ editing, property }) {
                 value={newContactValue}
                 onChange={newContactValueOnChange}
                 className={bem("input")}
-                data-testid={TESTCAFE_ID_NEW_VALUE}
+                data-testid={TESTCAFE_ID_NEW_VALUE.replace("<TYPE>", typestr)}
               />
             </Box>
 
@@ -298,7 +301,7 @@ export default function ContactTable({ editing, property }) {
                 type="button"
                 onClick={addContactDetail}
                 className={bem("button", "action")}
-                data-testid={TESTCAFE_ID_NEW_BUTTON}
+                data-testid={TESTCAFE_ID_ADD_BUTTON.replace("<TYPE>", typestr)}
               >
                 Add
               </button>

--- a/components/profile/index.jsx
+++ b/components/profile/index.jsx
@@ -122,7 +122,7 @@ export default function Profile(props) {
               </Box>
 
               <Box mt={1}>
-                <InputLabel>Company</InputLabel>
+                <InputLabel>Organization</InputLabel>
                 <Text
                   property={vcardExtras("organization-name")}
                   edit={editing}
@@ -137,7 +137,10 @@ export default function Profile(props) {
 
             <Box mt={4}>
               <InputLabel>Email Addresses</InputLabel>
-              <ContactInfoTable property={vcard.hasEmail} editing={editing} />
+              <ContactInfoTable 
+                property={vcard.hasEmail} 
+                editing={editing} 
+                typestr={"email"} />
             </Box>
 
             <Box mt={4}>
@@ -145,6 +148,7 @@ export default function Profile(props) {
               <ContactInfoTable
                 property={vcard.hasTelephone}
                 editing={editing}
+                typestr={"phone"}
               />
             </Box>
           </CombinedDataProvider>


### PR DESCRIPTION
Set and/or reset the data-testid's used on the Profile page to differentiate between email addresses and phone numbers.
Rename Company to Organization.

<!-- When adding a new feature: -->

# New feature description

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
