### PR TITLE
feat: Reference WebIDs in the vCard format

### DIFF
--- a/shapes/contact/example/person/2d73ccc1-9d76-4398-8840-3c23a8ddf04c/index.ttl
+++ b/shapes/contact/example/person/2d73ccc1-9d76-4398-8840-3c23a8ddf04c/index.ttl
@@ -14,12 +14,6 @@ prefix vcard:      <http://www.w3.org/2006/vcard/ns#>
 :this
     a vcard:Individual ;
     vcard:fn "Arne H - work colleague, friend and soccer striker" ;
-    vcard:url [
-        a vcard:WebID;
-        vcard:value "https://megoth-demo1.inrupt.net/profile/card#me"
-    ] ,
+    vcard:hasWebID "https://megoth-demo1.inrupt.net/profile/card#me" ;
     # Perhaps other forms of dereferencable URL's (but not email!)...
-    [
-        a vcard:DID;
-        vcard:value "did:sovrin:34537453453-2432424-23424324"
-    ] .
+    vcard:hasDID "did:sovrin:34537453453-2432424-23424324" .

--- a/shapes/contact/example/person/347429c1-e6b5-40c0-bd6f-61ba1265d357/index.ttl
+++ b/shapes/contact/example/person/347429c1-e6b5-40c0-bd6f-61ba1265d357/index.ttl
@@ -7,11 +7,4 @@ prefix vcard:  <http://www.w3.org/2006/vcard/ns#>
 :this
     a vcard:Individual ;
     vcard:fn "Vincent T - work colleague" ;
-    vcard:url :16112499761464744406237652592 .
-
-#
-# Using a named node (as opposed to a Blank Node).
-#
-:16112499761464744406237652592
-    a vcard:WebId ;
-    vcard:value <https://vincentt.inrupt.net/profile/card#me> .
+    vcard:hasWebID <https://vincentt.inrupt.net/profile/card#me> .

--- a/shapes/contact/example/person/76344edd-b1c7-67c2-ec3e-89ab5494e233/index.ttl
+++ b/shapes/contact/example/person/76344edd-b1c7-67c2-ec3e-89ab5494e233/index.ttl
@@ -7,11 +7,4 @@ prefix vcard:  <http://www.w3.org/2006/vcard/ns#>
 :this
     a vcard:Individual ;
     vcard:fn "Tommy - friend and goalkeeper extraordinaire" ;
-    vcard:url :56456268332379795455777077312 .
-
-#
-# Using a named node (as opposed to a Blank Node).
-#
-:56456268332379795455777077312
-    a vcard:WebId ;
-    vcard:value <https://tommy.inrupt.net/profile/card#me> .
+    vcard:hasWebID <https://tommy.inrupt.net/profile/card#me> .

--- a/shapes/contact/person.shex
+++ b/shapes/contact/person.shex
@@ -17,8 +17,8 @@ PREFIX rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 vcard:Individual {
     vcard:fn xsd:string {1} ;
 
-    # vcard:WebId is a custom term
-    vcard:url vcard:WebId {1};
+    # vcard:hasWebID is a custom term
+    vcard:hasWebID xsd:anyURI {1};
 
     # Not sure if we use this anymore
     vcard:hasUID xsd:string ? ;
@@ -37,15 +37,6 @@ vcard:Individual {
     vcard:inAddressBook vcard:AddressBook + ;
     # vcard:inAddressBook is a custom term
     # vcard:AddressBook is a custom class
-}
-
-# We store the preferred WebID for each person. The use of vcard:WebId
-# refer to the Individual's WebIDs, but the idea is that we could expand it
-# to refer to other type of unique identifiers later
-# vcard:WebId is a custom term
-# Big question - SHOULD something as fundamental as WebID be defined in vCard?
-vcard:WebId {
-    vcard:value xsd:string {1};
 }
 
 vcard:Address {


### PR DESCRIPTION
# Reference WebIDs in vCard

It would be great to be able to reference WebIDs in vCard. It would allow to spread them more widely and give them recognition as a thing people use to identify themselves.

Remains the question on which I have close to 0 knowledge. How do we get it through to:
- The vCard Format Specification - https://tools.ietf.org/html/rfc6350
- The W3C ontology - www.w3.org/2006/vcard/ns#

## Deletion

I don't think there is any need for a WebID class and if there was, it would not be defined in vCard. In the end a WebID is just an URI and if standard properties were to be found on WebIDs, it would not be vCard's role to define or maintain them.

On the other hand, the property vcard:hasWebID is definitely something I'd like to see.