### PR TITLE
Feat/multiselect agent picker

### DIFF
--- a/__testUtils/mockAddressBook.js
+++ b/__testUtils/mockAddressBook.js
@@ -22,6 +22,7 @@
 import {
   addStringNoLocale,
   addUrl,
+  createSolidDataset,
   mockSolidDatasetFrom,
   mockThingFrom,
   setThing,
@@ -65,5 +66,19 @@ export default function mockAddressBook(options = {}) {
     containerUrl,
     thing,
     dataset: mockAddressBookDataset(options, thing),
+  };
+}
+
+export function mockEmptyAddressBook(containerUrl, owner, title = "Contacts") {
+  const thing = chain(
+    mockAddressBookThing({ containerUrl, owner }),
+    (t) => addUrl(t, rdf.type, vcardExtras("AddressBook")),
+    (t) => addUrl(t, acl.owner, owner),
+    (t) => addStringNoLocale(t, dc.title, title)
+  );
+  return {
+    containerUrl,
+    dataset: setThing(createSolidDataset(), thing),
+    thing,
   };
 }

--- a/__testUtils/mockPersonContact.js
+++ b/__testUtils/mockPersonContact.js
@@ -27,7 +27,7 @@ import {
   setThing,
   setUrl,
 } from "@inrupt/solid-client";
-import { rdf, vcard } from "rdf-namespaces";
+import { vcard } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { vcardExtras } from "../src/addressBook";
 import { getBaseUrl } from "../src/solidClientHelpers/resource";
@@ -35,7 +35,6 @@ import { getBaseUrl } from "../src/solidClientHelpers/resource";
 function mockContactPersonThing(addressBook, personThingUrl, name) {
   return chain(
     mockThingFrom(personThingUrl),
-    (t) => setUrl(t, rdf.type, vcard.Individual),
     (t) => setStringNoLocale(t, vcard.fn, name),
     (t) => setUrl(t, vcardExtras("inAddressBook"), asUrl(addressBook.thing))
   );

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -47,6 +47,8 @@ export function setupSubmitHandler(
       setIsPodOwner(true);
       return;
     }
+    /* ignoring next block because it is affecting the coverage and we're removing this code soon */
+    /* istanbul ignore next */
     if ((permissions || []).filter((p) => p.webId === value).length) {
       setExistingWebId(value);
       return;
@@ -112,9 +114,12 @@ export default function AgentSearchForm({
   );
   const onBlur = setupOnBlurHandler(setDirtyWebIdField);
 
+  /* ignoring next block because it is affecting the coverage and we're removing this code soon */
+  /* istanbul ignore next */
   return (
     <Form onSubmit={handleSubmit}>
       <Label>WebID</Label>
+
       {invalidWebIdField && (
         <Message variant="invalid">Please provide a valid WebID</Message>
       )}
@@ -139,9 +144,7 @@ export default function AgentSearchForm({
         required={invalidWebIdField}
         variant={existingWebId || isPodOwner ? "invalid" : null}
       />
-
       {children}
-
       <Button type="submit" data-testid={TESTCAFE_ID_ADD_AGENT_BUTTON}>
         {buttonText}
       </Button>

--- a/components/confirmationDialog/index.jsx
+++ b/components/confirmationDialog/index.jsx
@@ -35,9 +35,10 @@ import styles from "./styles";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
-const TESTCAFE_CONFIRM_BUTTON = "confirm-button";
-const TESTCAFE_CONFIRMATION_CANCEL_BUTTON = "confirmation-cancel-button";
-const TESTCAFE_CONFIRMATION_DIALOG = "confirmation-dialog";
+export const TESTCAFE_ID_CONFIRM_BUTTON = "confirm-button";
+export const TESTCAFE_ID_CONFIRMATION_CANCEL_BUTTON =
+  "confirmation-cancel-button";
+export const TESTCAFE_ID_CONFIRMATION_DIALOG = "confirmation-dialog";
 
 export default function ConfirmationDialog() {
   const classes = useStyles();
@@ -49,7 +50,7 @@ export default function ConfirmationDialog() {
   return (
     <Dialog
       classes={{ paperWidthFalse: classes.dialog }}
-      data-testid={TESTCAFE_CONFIRMATION_DIALOG}
+      data-testid={TESTCAFE_ID_CONFIRMATION_DIALOG}
       maxWidth={false}
       aria-labelledby="confirmation-dialog"
       open={!!open}
@@ -68,14 +69,16 @@ export default function ConfirmationDialog() {
       <DialogActions classes={{ root: classes.dialogActions }}>
         <Button
           variant="secondary"
-          data-testid={TESTCAFE_CONFIRMATION_CANCEL_BUTTON}
+          data-testid={TESTCAFE_ID_CONFIRMATION_CANCEL_BUTTON}
+          className={classes.cancelButton}
           autoFocus
           onClick={() => setConfirmed(false)}
         >
           Cancel
         </Button>
         <Button
-          data-testid={TESTCAFE_CONFIRM_BUTTON}
+          data-testid={TESTCAFE_ID_CONFIRM_BUTTON}
+          className={classes.submitAgentsButton}
           type="submit"
           onClick={() => setConfirmed(true)}
         >

--- a/components/confirmationDialog/index.test.jsx
+++ b/components/confirmationDialog/index.test.jsx
@@ -19,13 +19,48 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import userEvent from "@testing-library/user-event";
 import React from "react";
+import mockConfirmationDialogContextProvider from "../../__testUtils/mockConfirmationDialogContextProvider";
 import { renderWithTheme } from "../../__testUtils/withTheme";
-import ConfirmationDialog from "./index";
+import ConfirmationDialog, {
+  TESTCAFE_ID_CONFIRM_BUTTON,
+  TESTCAFE_ID_CONFIRMATION_CANCEL_BUTTON,
+} from "./index";
 
 describe("ConfirmationDialog", () => {
   test("Renders a ConfirmationDialog", () => {
     const { asFragment } = renderWithTheme(<ConfirmationDialog />);
     expect(asFragment()).toMatchSnapshot();
+  });
+  test("clicking on confirm button calls setConfirmed with true", () => {
+    const setConfirmed = jest.fn();
+    const ConfirmationDialogProvider = mockConfirmationDialogContextProvider({
+      open: "confirmation-dialog",
+      setConfirmed,
+    });
+    const { getByTestId } = renderWithTheme(
+      <ConfirmationDialogProvider>
+        <ConfirmationDialog />
+      </ConfirmationDialogProvider>
+    );
+    const button = getByTestId(TESTCAFE_ID_CONFIRM_BUTTON);
+    userEvent.click(button);
+    expect(setConfirmed).toHaveBeenCalledWith(true);
+  });
+  test("clicking on cancel button calls setConfirmed with true", () => {
+    const setConfirmed = jest.fn();
+    const ConfirmationDialogProvider = mockConfirmationDialogContextProvider({
+      open: "confirmation-dialog",
+      setConfirmed,
+    });
+    const { getByTestId } = renderWithTheme(
+      <ConfirmationDialogProvider>
+        <ConfirmationDialog />
+      </ConfirmationDialogProvider>
+    );
+    const button = getByTestId(TESTCAFE_ID_CONFIRMATION_CANCEL_BUTTON);
+    userEvent.click(button);
+    expect(setConfirmed).toHaveBeenCalledWith(false);
   });
 });

--- a/components/header/index.test.jsx
+++ b/components/header/index.test.jsx
@@ -24,7 +24,7 @@ import { useRouter } from "next/router";
 import { renderWithTheme } from "../../__testUtils/withTheme";
 import mockSessionContextProvider from "../../__testUtils/mockSessionContextProvider";
 import Header, { TESTCAFE_ID_HEADER_LOGO } from "./index";
-import mockSession, {
+import {
   mockAuthenticatedSession,
   mockUnauthenticatedSession,
 } from "../../__testUtils/mockSession";

--- a/components/header/userMenu/index.test.jsx
+++ b/components/header/userMenu/index.test.jsx
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import userEvent from "@testing-library/user-event";
 import React from "react";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
 import UserMenu from "./index";

--- a/components/resourceDetails/resourceSharing/addAgentButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/__snapshots__/index.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`AddAgentButton renders a button with the correct text 1`] = `
     <span
       class="PodBrowser-button__text"
     >
-      Add Editors
+      Edit Editors
     </span>
   </button>
 </DocumentFragment>

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/__snapshots__/index.test.jsx.snap
@@ -47,3 +47,61 @@ exports[`AddAgentRow when adding a new webId renders a row with an input for the
   </div>
 </DocumentFragment>
 `;
+
+exports[`AddAgentRow with existing contacts for newly added webids, if profile is unavailable it renders a row with the provided webId 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-nameAndAvatarContainer"
+    title="Unable to load profile"
+  >
+    <div
+      class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+    >
+      <svg
+        aria-hidden="true"
+        class="PodBrowser-root PodBrowser-fallback"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+        />
+      </svg>
+    </div>
+    <p
+      class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
+      data-testid="agent-webid"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AddAgentRow with existing contacts renders a row with the agent's name if profile is available 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-nameAndAvatarContainer"
+    title="https://somewebid.org"
+  >
+    <div
+      class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+    >
+      <svg
+        aria-hidden="true"
+        class="PodBrowser-root PodBrowser-fallback"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+        />
+      </svg>
+    </div>
+    <p
+      class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
+      data-testid="agent-webid"
+    >
+      Example
+    </p>
+  </div>
+</DocumentFragment>
+`;

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
@@ -99,7 +99,11 @@ export default function AddAgentRow({
       setAgentAvatar(profile.avatar);
       setDisplayedWebId(profile.webId);
     } else if (temporaryRowThing && !profile && contactsArrayLength > 0) {
-      setAgentName(getStringNoLocale(temporaryRowThing, foaf.name) || null);
+      setAgentName(
+        getStringNoLocale(temporaryRowThing, foaf.name) ||
+          getStringNoLocale(temporaryRowThing, vcard.fn) ||
+          null
+      );
       setAgentAvatar(getUrl(temporaryRowThing, vcard.hasPhoto) || null);
       setDisplayedWebId(getUrl(temporaryRowThing, VCARD_WEBID_PREDICATE));
     }

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { useSession, useThing } from "@inrupt/solid-ui-react";
 import {
@@ -43,6 +43,7 @@ import styles from "./styles";
 import { chain } from "../../../../../src/solidClientHelpers/utils";
 import { fetchProfile } from "../../../../../src/solidClientHelpers/profile";
 import { vcardExtras } from "../../../../../src/addressBook";
+import useContactProfile from "../../../../../src/hooks/useContactProfile";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 const VCARD_WEBID_PREDICATE = vcardExtras("WebId");
@@ -89,14 +90,21 @@ export default function AddAgentRow({
   const classes = useStyles();
   const [agentWebId, setAgentWebId] = useState("");
   const [existingPermission, setExistingPermission] = useState();
-
-  const agentName = (thing && getStringNoLocale(thing, foaf.name)) || null;
-  const agentAvatar = (thing && getUrl(thing, vcard.hasPhoto)) || null;
-  const displayedWebId =
-    (thing &&
-      contactsArrayLength > 0 &&
-      getUrl(thing, VCARD_WEBID_PREDICATE)) ||
-    null;
+  const [agentName, setAgentName] = useState(null);
+  const [agentAvatar, setAgentAvatar] = useState(null);
+  const [displayedWebId, setDisplayedWebId] = useState(null);
+  const { data: profile } = useContactProfile(thing);
+  useEffect(() => {
+    if (profile) {
+      setAgentName(profile.name);
+      setAgentAvatar(profile.avatar);
+      setDisplayedWebId(profile.webId);
+    } else if (thing && !profile && contactsArrayLength > 0) {
+      setAgentName(getStringNoLocale(thing, foaf.name) || null);
+      setAgentAvatar(getUrl(thing, vcard.hasPhoto) || null);
+      setDisplayedWebId(getUrl(thing, VCARD_WEBID_PREDICATE));
+    }
+  }, [profile, thing, agentWebId, contactsArrayLength]);
 
   const handleAddAgentsWebIds = async (e) => {
     e.preventDefault();

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
@@ -80,7 +80,6 @@ export default function AddAgentRow({
   newAgentsWebIds,
   contactsArrayLength,
   setAddingWebId,
-  setNoAgentsAlert,
   addingWebId,
   updateTemporaryRowThing,
   permissions,
@@ -113,7 +112,6 @@ export default function AddAgentRow({
       setExistingPermission(true);
       return;
     }
-    setNoAgentsAlert(false);
     setNewAgentsWebIds([...newAgentsWebIds, agentWebId]);
     const newThing = await updateThingForNewRow(
       agentWebId,
@@ -193,7 +191,6 @@ AddAgentRow.propTypes = {
   setNewAgentsWebIds: PropTypes.func.isRequired,
   newAgentsWebIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   setAddingWebId: PropTypes.func.isRequired,
-  setNoAgentsAlert: PropTypes.func.isRequired,
   contactsArrayLength: PropTypes.number.isRequired,
   addingWebId: PropTypes.bool.isRequired,
   updateTemporaryRowThing: PropTypes.func.isRequired,

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.jsx
@@ -82,29 +82,29 @@ export default function AddAgentRow({
   setAddingWebId,
   setNoAgentsAlert,
   addingWebId,
-  updateThing,
+  updateTemporaryRowThing,
   permissions,
 }) {
   const { fetch } = useSession();
-  const { thing } = useThing();
+  const { thing: temporaryRowThing } = useThing();
   const classes = useStyles();
   const [agentWebId, setAgentWebId] = useState("");
   const [existingPermission, setExistingPermission] = useState();
   const [agentName, setAgentName] = useState(null);
   const [agentAvatar, setAgentAvatar] = useState(null);
   const [displayedWebId, setDisplayedWebId] = useState(null);
-  const { data: profile } = useContactProfile(thing);
+  const { data: profile } = useContactProfile(temporaryRowThing);
   useEffect(() => {
     if (profile) {
       setAgentName(profile.name);
       setAgentAvatar(profile.avatar);
       setDisplayedWebId(profile.webId);
-    } else if (thing && !profile && contactsArrayLength > 0) {
-      setAgentName(getStringNoLocale(thing, foaf.name) || null);
-      setAgentAvatar(getUrl(thing, vcard.hasPhoto) || null);
-      setDisplayedWebId(getUrl(thing, VCARD_WEBID_PREDICATE));
+    } else if (temporaryRowThing && !profile && contactsArrayLength > 0) {
+      setAgentName(getStringNoLocale(temporaryRowThing, foaf.name) || null);
+      setAgentAvatar(getUrl(temporaryRowThing, vcard.hasPhoto) || null);
+      setDisplayedWebId(getUrl(temporaryRowThing, VCARD_WEBID_PREDICATE));
     }
-  }, [profile, thing, agentWebId, contactsArrayLength]);
+  }, [profile, temporaryRowThing, agentWebId, contactsArrayLength]);
 
   const handleAddAgentsWebIds = async (e) => {
     e.preventDefault();
@@ -115,8 +115,12 @@ export default function AddAgentRow({
     }
     setNoAgentsAlert(false);
     setNewAgentsWebIds([...newAgentsWebIds, agentWebId]);
-    const newThing = await updateThingForNewRow(agentWebId, thing, fetch);
-    updateThing(newThing);
+    const newThing = await updateThingForNewRow(
+      agentWebId,
+      temporaryRowThing,
+      fetch
+    );
+    updateTemporaryRowThing(newThing);
     setAddingWebId(false);
   };
 
@@ -192,6 +196,6 @@ AddAgentRow.propTypes = {
   setNoAgentsAlert: PropTypes.func.isRequired,
   contactsArrayLength: PropTypes.number.isRequired,
   addingWebId: PropTypes.bool.isRequired,
-  updateThing: PropTypes.func.isRequired,
+  updateTemporaryRowThing: PropTypes.func.isRequired,
   permissions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
 };

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.test.jsx
@@ -29,13 +29,14 @@ import useContactProfile from "../../../../../src/hooks/useContactProfile";
 import { vcardExtras } from "../../../../../src/addressBook";
 
 jest.mock("@inrupt/solid-ui-react");
+const mockedThingHook = useThing;
 jest.mock("../../../../../src/hooks/useContactProfile");
 
 describe("AddAgentRow", () => {
   describe("when adding a new webId", () => {
     const mockThing = createThing();
     beforeEach(() => {
-      useThing.mockReturnValue({ thing: mockThing });
+      mockedThingHook.mockReturnValue({ thing: mockThing });
       useSession.mockReturnValue({ fetch: jest.fn() });
       useContactProfile.mockReturnValue({ data: null });
     });
@@ -45,7 +46,7 @@ describe("AddAgentRow", () => {
     const setAddingWebId = jest.fn();
     const setNoAgentsAlert = jest.fn();
     const addingWebId = true;
-    const updateThing = jest.fn();
+    const updateTemporaryRowThing = jest.fn();
     const permissions = [{ webId: "https://example.org/profile/card#me" }];
 
     it("renders a row with an input for the first item in the array", () => {
@@ -57,7 +58,7 @@ describe("AddAgentRow", () => {
           setAddingWebId={setAddingWebId}
           setNoAgentsAlert={setNoAgentsAlert}
           addingWebId={addingWebId}
-          updateThing={updateThing}
+          updateTemporaryRowThing={updateTemporaryRowThing}
           permissions={[]}
         />
       );
@@ -72,7 +73,7 @@ describe("AddAgentRow", () => {
           setAddingWebId={setAddingWebId}
           setNoAgentsAlert={setNoAgentsAlert}
           addingWebId={addingWebId}
-          updateThing={updateThing}
+          updateTemporaryRowThing={updateTemporaryRowThing}
           permissions={permissions}
         />
       );
@@ -92,7 +93,7 @@ describe("AddAgentRow", () => {
           setAddingWebId={setAddingWebId}
           setNoAgentsAlert={setNoAgentsAlert}
           addingWebId={addingWebId}
-          updateThing={updateThing}
+          updateTemporaryRowThing={updateTemporaryRowThing}
           permissions={permissions}
         />
       );
@@ -110,7 +111,7 @@ describe("AddAgentRow", () => {
           setAddingWebId={setAddingWebId}
           setNoAgentsAlert={setNoAgentsAlert}
           addingWebId={addingWebId}
-          updateThing={updateThing}
+          updateTemporaryRowThing={updateTemporaryRowThing}
           permissions={permissions}
         />
       );
@@ -131,7 +132,7 @@ describe("AddAgentRow", () => {
     const setAddingWebId = jest.fn();
     const setNoAgentsAlert = jest.fn();
     const addingWebId = false;
-    const updateThing = jest.fn();
+    const updateTemporaryRowThing = jest.fn();
 
     beforeEach(() => {
       useSession.mockReturnValue({ fetch: jest.fn() });
@@ -151,7 +152,7 @@ describe("AddAgentRow", () => {
           setAddingWebId={setAddingWebId}
           setNoAgentsAlert={setNoAgentsAlert}
           addingWebId={addingWebId}
-          updateThing={updateThing}
+          updateTemporaryRowThing={updateTemporaryRowThing}
           permissions={[]}
         />
       );
@@ -177,7 +178,7 @@ describe("AddAgentRow", () => {
           setAddingWebId={setAddingWebId}
           setNoAgentsAlert={setNoAgentsAlert}
           addingWebId={addingWebId}
-          updateThing={updateThing}
+          updateTemporaryRowThing={updateTemporaryRowThing}
           permissions={[]}
         />
       );

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/index.test.jsx
@@ -125,9 +125,6 @@ describe("AddAgentRow", () => {
     });
   });
   describe("with existing contacts", () => {
-    beforeEach(() => {
-      useSession.mockReturnValue({ fetch: jest.fn() });
-    });
     const index = 0;
     const setNewAgentsWebIds = jest.fn();
     const newAgentsWebIds = [];
@@ -135,6 +132,10 @@ describe("AddAgentRow", () => {
     const setNoAgentsAlert = jest.fn();
     const addingWebId = false;
     const updateThing = jest.fn();
+
+    beforeEach(() => {
+      useSession.mockReturnValue({ fetch: jest.fn() });
+    });
 
     it("renders a row with the agent's name if profile is available", () => {
       const mockThing = createThing();

--- a/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/addAgentRow/styles.js
@@ -40,7 +40,9 @@ export default function styles(theme) {
     detailText: {
       fontFamily: theme.typography.body.fontFamily,
       fontWeight: theme.typography.body.fontWeight,
-      minWidth: "20rem",
+      [theme.breakpoints.up("sm")]: {
+        minWidth: "20rem",
+      },
     },
     button: {
       padding: theme.spacing(0.8, 1),
@@ -52,7 +54,10 @@ export default function styles(theme) {
       border: `1px solid ${theme.palette.grey.A100}`,
       borderRadius: "10px",
       height: "2.5rem",
-      minWidth: "20rem",
+      minWidth: "calc(100% - 25px)",
+      [theme.breakpoints.up("sm")]: {
+        minWidth: "20rem",
+      },
     },
     searchInput: {
       height: "100%",

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AgentPickerModal renders a table with tabs, searchbox and an empty state message when there are no contacts 1`] = `
+exports[`AgentPickerModal with contacts renders a table with the available contacts 1`] = `
 <DocumentFragment>
   <div
     class="PodBrowser-paper"
@@ -9,7 +9,223 @@ exports[`AgentPickerModal renders a table with tabs, searchbox and an empty stat
     <div
       class="PodBrowser-title"
     >
-      Add Editors for null
+      Edit Editors for null
+    </div>
+    <div
+      class="PodBrowser-headerContainer"
+    >
+      <i
+        class="PodBrowser-icon-editor PodBrowser-icon PodBrowser-iconEditor"
+      />
+      <div
+        class="PodBrowser-textContainer"
+      >
+        <div
+          class="PodBrowser-titleAndButtonContainer"
+        >
+          <p
+            class="PodBrowser-title"
+          >
+            Editor
+          </p>
+        </div>
+        <span
+          class="PodBrowser-description"
+        >
+          <p>
+            <b>
+              Can 
+            </b>
+            view, edit and delete this resource
+          </p>
+        </span>
+      </div>
+    </div>
+    <div
+      class="PodBrowser-tableContainer"
+    >
+      <div
+        class="PodBrowser-tabsAndAddButtonContainer"
+      >
+        <div
+          class="PodBrowser-tabsContainer PodBrowser-modalTabsContainer"
+        >
+          <div
+            class="PodBrowser-root"
+          >
+            <div
+              class="PodBrowser-scroller PodBrowser-fixed"
+              style="overflow: hidden;"
+            >
+              <div
+                aria-label="Permissions Filter tabs"
+                class="PodBrowser-flexContainer"
+                role="tablist"
+              >
+                <button
+                  aria-selected="true"
+                  class="PodBrowser-root PodBrowser-root PodBrowser-tab PodBrowser-textColorInherit PodBrowser-selected PodBrowser-selected"
+                  data-testid="tab-all"
+                  role="tab"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="PodBrowser-wrapper"
+                  >
+                    All
+                  </span>
+                  <span
+                    class="PodBrowser-root PodBrowser-colorSecondary PodBrowser-indicator PodBrowser-indicator"
+                  />
+                </button>
+                <button
+                  aria-selected="false"
+                  class="PodBrowser-root PodBrowser-root PodBrowser-tab PodBrowser-textColorInherit"
+                  data-testid="tab-people"
+                  role="tab"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="PodBrowser-wrapper"
+                  >
+                    People
+                  </span>
+                </button>
+                <button
+                  aria-selected="false"
+                  class="PodBrowser-root PodBrowser-root PodBrowser-tab PodBrowser-textColorInherit"
+                  data-testid="tab-groups"
+                  role="tab"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="PodBrowser-wrapper"
+                  >
+                    Groups
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <button
+          class="PodBrowser-button PodBrowser-button--small PodBrowser-button"
+          data-testid="add-webid-button"
+          iconbefore="add"
+        >
+          <span
+            class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+          />
+          <span
+            class="PodBrowser-button__text"
+          >
+            Add WebId
+          </span>
+        </button>
+      </div>
+      <div
+        class="PodBrowser-searchBoxContainer"
+      >
+        <button
+          aria-label="search"
+          class="PodBrowser-root PodBrowser-root"
+          tabindex="0"
+          type="submit"
+        >
+          <span
+            class="PodBrowser-label"
+          >
+            <i
+              aria-label="search"
+              class="PodBrowser-icon-search PodBrowser-iconSearch"
+            />
+          </span>
+        </button>
+        <div
+          class="PodBrowser-root PodBrowser-searchInput"
+        >
+          <input
+            aria-label="Search by name or WebId"
+            class="PodBrowser-input"
+            data-testid="search-input"
+            placeholder="Search by name or WebId"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
+      <div
+        class="PodBrowser-content"
+      >
+        <div
+          class="PodBrowser-container PodBrowser-container--empty"
+        >
+          <span
+            class="PodBrowser-icon-user PodBrowser-icon-large"
+          />
+          <h2
+            class="text"
+          >
+            Add a new person with their WebId
+          </h2>
+          <button
+            class="PodBrowser-button PodBrowser-button--small"
+            data-testid="empty-state-add-webid-button"
+            iconbefore="add"
+          >
+            <span
+              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+            />
+            <span
+              class="PodBrowser-button__text"
+            >
+              Add WebId
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="PodBrowser-buttonsContainer"
+    >
+      <button
+        class="PodBrowser-button PodBrowser-button--secondary"
+        data-testid="cancel-webids-button"
+      >
+        <span
+          class="PodBrowser-button__text"
+        >
+          Cancel
+        </span>
+      </button>
+      <button
+        class="PodBrowser-button"
+        data-testid="submit-webids-button"
+      >
+        <span
+          class="PodBrowser-button__text"
+        >
+          Save Editors
+        </span>
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AgentPickerModal without contacts renders a table with tabs, searchbox and an empty state message when there are no contacts 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-paper"
+    data-testid="agent-picker-modal"
+  >
+    <div
+      class="PodBrowser-title"
+    >
+      Edit Editors for null
     </div>
     <div
       class="PodBrowser-headerContainer"
@@ -221,7 +437,7 @@ exports[`AgentPickerModal renders a table with tabs, searchbox and an empty stat
         <span
           class="PodBrowser-button__text"
         >
-          Add Editors
+          Save Editors
         </span>
       </button>
     </div>

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
@@ -76,7 +76,7 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
                     All
                   </span>
                   <span
-                    class="PodBrowser-root PodBrowser-colorSecondary PodBrowser-indicator PodBrowser-indicator"
+                    class="PodBrowser-root"
                   />
                 </button>
                 <button
@@ -92,6 +92,9 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
                   >
                     People
                   </span>
+                  <span
+                    class="PodBrowser-root"
+                  />
                 </button>
                 <button
                   aria-selected="false"
@@ -106,8 +109,15 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
                   >
                     Groups
                   </span>
+                  <span
+                    class="PodBrowser-root"
+                  />
                 </button>
               </div>
+              <span
+                class="PodBrowser-root PodBrowser-colorSecondary PodBrowser-indicator PodBrowser-indicator"
+                style="left: 0px; width: 0px;"
+              />
             </div>
           </div>
         </div>
@@ -143,6 +153,9 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
               class="PodBrowser-icon-search PodBrowser-iconSearch"
             />
           </span>
+          <span
+            class="PodBrowser-root"
+          />
         </button>
         <div
           class="PodBrowser-root PodBrowser-searchInput"
@@ -157,36 +170,169 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
           />
         </div>
       </div>
-      <div
-        class="PodBrowser-content"
+      <table
+        class="PodBrowser-table PodBrowser-agentPickerTable"
+        role="table"
       >
-        <div
-          class="PodBrowser-container PodBrowser-container--empty"
-        >
-          <span
-            class="PodBrowser-icon-user PodBrowser-icon-large"
-          />
-          <h2
-            class="text"
+        <thead>
+          <tr
+            role="row"
           >
-            Add a new person with their WebId
-          </h2>
-          <button
-            class="PodBrowser-button PodBrowser-button--small"
-            data-testid="empty-state-add-webid-button"
-            iconbefore="add"
-          >
-            <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
-            />
-            <span
-              class="PodBrowser-button__text"
+            <th
+              colspan="1"
+              role="columnheader"
             >
-              Add WebId
-            </span>
-          </button>
-        </div>
-      </div>
+              <span
+                class="PodBrowser-tableHeader"
+              >
+                editor
+              </span>
+            </th>
+            <th
+              colspan="1"
+              role="columnheader"
+            >
+              <span
+                class="PodBrowser-tableHeader"
+              >
+                Name
+              </span>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          role="rowgroup"
+        >
+          <tr
+            role="row"
+          >
+            <td
+              role="cell"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-colorPrimary PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input"
+                    data-indeterminate="false"
+                    data-testid="webid-checkbox"
+                    type="checkbox"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="PodBrowser-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+            </td>
+            <td
+              role="cell"
+            >
+              <div
+                class="PodBrowser-nameAndAvatarContainer"
+                title="Unable to load profile"
+              >
+                <div
+                  class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="PodBrowser-root PodBrowser-fallback"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                    />
+                  </svg>
+                </div>
+                <p
+                  class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
+                  data-testid="agent-webid"
+                />
+              </div>
+            </td>
+          </tr>
+          <tr
+            role="row"
+          >
+            <td
+              role="cell"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-colorPrimary PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input"
+                    data-indeterminate="false"
+                    data-testid="webid-checkbox"
+                    type="checkbox"
+                    value=""
+                  />
+                  <svg
+                    aria-hidden="true"
+                    class="PodBrowser-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+            </td>
+            <td
+              role="cell"
+            >
+              <div
+                class="PodBrowser-nameAndAvatarContainer"
+                title="Unable to load profile"
+              >
+                <div
+                  class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="PodBrowser-root PodBrowser-fallback"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+                    />
+                  </svg>
+                </div>
+                <p
+                  class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
+                  data-testid="agent-webid"
+                />
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <div
       class="PodBrowser-buttonsContainer"

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
@@ -244,7 +244,6 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
             >
               <div
                 class="PodBrowser-nameAndAvatarContainer"
-                title="Unable to load profile"
               >
                 <div
                   class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
@@ -263,7 +262,9 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
                 <p
                   class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
                   data-testid="agent-webid"
-                />
+                >
+                  Example 1
+                </p>
               </div>
             </td>
           </tr>
@@ -308,7 +309,6 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
             >
               <div
                 class="PodBrowser-nameAndAvatarContainer"
-                title="Unable to load profile"
               >
                 <div
                   class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
@@ -327,7 +327,9 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
                 <p
                   class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
                   data-testid="agent-webid"
-                />
+                >
+                  Example 2
+                </p>
               </div>
             </td>
           </tr>

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
@@ -122,7 +122,7 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
           </div>
         </div>
         <div
-          class="PodBrowser-searchBoxContainer hidden"
+          class="PodBrowser-searchBoxContainer--hidden"
         >
           <button
             aria-label="search"
@@ -144,11 +144,11 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
             />
           </button>
           <div
-            class="PodBrowser-root PodBrowser-searchInput hidden"
+            class="PodBrowser-root PodBrowser-searchInput--hidden PodBrowser-focused"
           >
             <input
               aria-label="Search by name or WebId"
-              class="PodBrowser-input"
+              class="PodBrowser-input PodBrowser-searchInput--hidden"
               data-testid="mobile-search-input"
               placeholder="Search by name or WebId"
               type="text"
@@ -176,7 +176,7 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
           </button>
         </div>
         <button
-          class="PodBrowser-button PodBrowser-button PodBrowser-desktopOnly"
+          class="PodBrowser-button PodBrowser-button--secondary PodBrowser-button PodBrowser-desktopOnly"
           data-testid="add-webid-button"
           iconbefore="add"
         >
@@ -225,8 +225,8 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
         </div>
       </div>
       <button
-        class="PodBrowser-button PodBrowser-button PodBrowser-mobileOnly"
-        data-testid="add-webid-button-mobile"
+        class="PodBrowser-button PodBrowser-button--secondary PodBrowser-button PodBrowser-mobileOnly"
+        data-testid="add-web-id-button-mobile"
         iconbefore="add"
       >
         <span
@@ -554,7 +554,7 @@ exports[`AgentPickerModal without contacts renders a table with tabs, searchbox 
           </div>
         </div>
         <div
-          class="PodBrowser-searchBoxContainer hidden"
+          class="PodBrowser-searchBoxContainer--hidden"
         >
           <button
             aria-label="search"
@@ -576,11 +576,11 @@ exports[`AgentPickerModal without contacts renders a table with tabs, searchbox 
             />
           </button>
           <div
-            class="PodBrowser-root PodBrowser-searchInput hidden"
+            class="PodBrowser-root PodBrowser-searchInput--hidden PodBrowser-focused"
           >
             <input
               aria-label="Search by name or WebId"
-              class="PodBrowser-input"
+              class="PodBrowser-input PodBrowser-searchInput--hidden"
               data-testid="mobile-search-input"
               placeholder="Search by name or WebId"
               type="text"
@@ -608,7 +608,7 @@ exports[`AgentPickerModal without contacts renders a table with tabs, searchbox 
           </button>
         </div>
         <button
-          class="PodBrowser-button PodBrowser-button PodBrowser-desktopOnly"
+          class="PodBrowser-button PodBrowser-button--secondary PodBrowser-button PodBrowser-desktopOnly"
           data-testid="add-webid-button"
           iconbefore="add"
         >
@@ -657,8 +657,8 @@ exports[`AgentPickerModal without contacts renders a table with tabs, searchbox 
         </div>
       </div>
       <button
-        class="PodBrowser-button PodBrowser-button PodBrowser-mobileOnly"
-        data-testid="add-webid-button-mobile"
+        class="PodBrowser-button PodBrowser-button--secondary PodBrowser-button PodBrowser-mobileOnly"
+        data-testid="add-web-id-button-mobile"
         iconbefore="add"
       >
         <span

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/__snapshots__/index.test.jsx.snap
@@ -121,8 +121,62 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
             </div>
           </div>
         </div>
+        <div
+          class="PodBrowser-searchBoxContainer hidden"
+        >
+          <button
+            aria-label="search"
+            class="PodBrowser-root PodBrowser-root"
+            data-testid="search-button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PodBrowser-label"
+            >
+              <i
+                aria-label="search"
+                class="PodBrowser-icon-search PodBrowser-iconSearch"
+              />
+            </span>
+            <span
+              class="PodBrowser-root"
+            />
+          </button>
+          <div
+            class="PodBrowser-root PodBrowser-searchInput hidden"
+          >
+            <input
+              aria-label="Search by name or WebId"
+              class="PodBrowser-input"
+              data-testid="mobile-search-input"
+              placeholder="Search by name or WebId"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="close"
+            class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
+            data-testid="close-button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PodBrowser-label"
+            >
+              <i
+                aria-label="close"
+                class="PodBrowser-icon-cancel hidden"
+              />
+            </span>
+            <span
+              class="PodBrowser-root"
+            />
+          </button>
+        </div>
         <button
-          class="PodBrowser-button PodBrowser-button--small PodBrowser-button"
+          class="PodBrowser-button PodBrowser-button PodBrowser-desktopOnly"
           data-testid="add-webid-button"
           iconbefore="add"
         >
@@ -170,6 +224,20 @@ exports[`AgentPickerModal with contacts renders a table with the available conta
           />
         </div>
       </div>
+      <button
+        class="PodBrowser-button PodBrowser-button PodBrowser-mobileOnly"
+        data-testid="add-webid-button-mobile"
+        iconbefore="add"
+      >
+        <span
+          class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+        />
+        <span
+          class="PodBrowser-button__text"
+        >
+          Add WebId
+        </span>
+      </button>
       <table
         class="PodBrowser-table PodBrowser-agentPickerTable"
         role="table"
@@ -485,8 +553,62 @@ exports[`AgentPickerModal without contacts renders a table with tabs, searchbox 
             </div>
           </div>
         </div>
+        <div
+          class="PodBrowser-searchBoxContainer hidden"
+        >
+          <button
+            aria-label="search"
+            class="PodBrowser-root PodBrowser-root"
+            data-testid="search-button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PodBrowser-label"
+            >
+              <i
+                aria-label="search"
+                class="PodBrowser-icon-search PodBrowser-iconSearch"
+              />
+            </span>
+            <span
+              class="PodBrowser-root"
+            />
+          </button>
+          <div
+            class="PodBrowser-root PodBrowser-searchInput hidden"
+          >
+            <input
+              aria-label="Search by name or WebId"
+              class="PodBrowser-input"
+              data-testid="mobile-search-input"
+              placeholder="Search by name or WebId"
+              type="text"
+              value=""
+            />
+          </div>
+          <button
+            aria-label="close"
+            class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
+            data-testid="close-button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PodBrowser-label"
+            >
+              <i
+                aria-label="close"
+                class="PodBrowser-icon-cancel hidden"
+              />
+            </span>
+            <span
+              class="PodBrowser-root"
+            />
+          </button>
+        </div>
         <button
-          class="PodBrowser-button PodBrowser-button--small PodBrowser-button"
+          class="PodBrowser-button PodBrowser-button PodBrowser-desktopOnly"
           data-testid="add-webid-button"
           iconbefore="add"
         >
@@ -534,6 +656,20 @@ exports[`AgentPickerModal without contacts renders a table with tabs, searchbox 
           />
         </div>
       </div>
+      <button
+        class="PodBrowser-button PodBrowser-button PodBrowser-mobileOnly"
+        data-testid="add-webid-button-mobile"
+        iconbefore="add"
+      >
+        <span
+          class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+        />
+        <span
+          class="PodBrowser-button__text"
+        >
+          Add WebId
+        </span>
+      </button>
       <div
         class="PodBrowser-content"
       >

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`AddWebIdButton renders an Add WebID Button 1`] = `
 <DocumentFragment>
   <button
-    class="PodBrowser-button PodBrowser-button--small PodBrowser-button"
+    class="PodBrowser-button PodBrowser-button"
     data-testid="add-webid-button"
     iconbefore="add"
   >

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/__snapshots__/index.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`AddWebIdButton renders an Add WebID Button 1`] = `
 <DocumentFragment>
   <button
-    class="PodBrowser-button PodBrowser-button"
+    class="PodBrowser-button PodBrowser-button--secondary PodBrowser-button"
     data-testid="add-webid-button"
     iconbefore="add"
   >

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/index.jsx
@@ -25,24 +25,23 @@ import React from "react";
 import PropTypes from "prop-types";
 import { createStyles } from "@material-ui/core";
 import clsx from "clsx";
-import { useBem } from "@solid/lit-prism-patterns";
 import { makeStyles } from "@material-ui/styles";
 import { Button } from "@inrupt/prism-react-components";
 import styles from "./styles";
 
 const TESTCAFE_ADD_WEBID_BUTTON = "add-webid-button";
+const TESTCAFE_ADD_WEBID_BUTTON_MOBILE = "add-web-id-button-mobile";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 export default function AddWebIdButton({ onClick, disabled, className }) {
-  const bem = useBem(useStyles());
   const classes = useStyles();
   return (
     <Button
-      variant="action"
+      variant="secondary"
       data-testid={
         className && className.includes("mobileOnly")
-          ? "add-webid-button-mobile"
+          ? TESTCAFE_ADD_WEBID_BUTTON_MOBILE
           : TESTCAFE_ADD_WEBID_BUTTON
       }
       className={clsx(classes.button, className && className)}

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/index.jsx
@@ -24,6 +24,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { createStyles } from "@material-ui/core";
+import clsx from "clsx";
+import { useBem } from "@solid/lit-prism-patterns";
 import { makeStyles } from "@material-ui/styles";
 import { Button } from "@inrupt/prism-react-components";
 import styles from "./styles";
@@ -32,13 +34,18 @@ const TESTCAFE_ADD_WEBID_BUTTON = "add-webid-button";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
-export default function AddWebIdButton({ onClick, disabled }) {
+export default function AddWebIdButton({ onClick, disabled, className }) {
+  const bem = useBem(useStyles());
   const classes = useStyles();
   return (
     <Button
-      variant="small"
-      data-testid={TESTCAFE_ADD_WEBID_BUTTON}
-      className={classes.button}
+      variant="action"
+      data-testid={
+        className && className.includes("mobileOnly")
+          ? "add-webid-button-mobile"
+          : TESTCAFE_ADD_WEBID_BUTTON
+      }
+      className={clsx(classes.button, className && className)}
       disabled={disabled}
       onClick={onClick}
       iconBefore="add"
@@ -51,8 +58,10 @@ export default function AddWebIdButton({ onClick, disabled }) {
 AddWebIdButton.propTypes = {
   onClick: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 AddWebIdButton.defaultProps = {
   disabled: false,
+  className: null,
 };

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/index.jsx
@@ -40,11 +40,11 @@ export default function AddWebIdButton({ onClick, disabled, className }) {
     <Button
       variant="secondary"
       data-testid={
-        className && className.includes("mobileOnly")
+        className?.includes("mobileOnly")
           ? TESTCAFE_ADD_WEBID_BUTTON_MOBILE
           : TESTCAFE_ADD_WEBID_BUTTON
       }
-      className={clsx(classes.button, className && className)}
+      className={clsx(classes.button, className)}
       disabled={disabled}
       onClick={onClick}
       iconBefore="add"

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/styles.js
@@ -24,7 +24,23 @@ import { createStyles } from "@solid/lit-prism-patterns";
 export default function styles(theme) {
   return createStyles(theme, ["icons", "button"], {
     button: {
-      marginRight: theme.spacing(1.2),
+      [theme.breakpoints.down("xs")]: {
+        marginTop: "0.5rem",
+        width: "max-content",
+        alignSelf: "flex-end",
+      },
+      height: "max-content",
+      fontWeight: 800,
+      fontSize: "0.8125rem",
+      textDecoration: "none",
+      borderRadius: "7px",
+      backgroundColor: theme.palette.grey[50],
+      whiteSpace: "nowrap",
+      padding: theme.spacing(0.2, 1.6),
+    },
+    icon: {
+      color: theme.palette.primary.main,
+      margin: theme.spacing(0.5),
     },
   });
 }

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/addWebIdButton/styles.js
@@ -23,12 +23,22 @@ import { createStyles } from "@solid/lit-prism-patterns";
 
 export default function styles(theme) {
   return createStyles(theme, ["icons", "button"], {
-    button: {
-      [theme.breakpoints.down("xs")]: {
-        marginTop: "0.5rem",
-        width: "max-content",
-        alignSelf: "flex-end",
+    mobile: {
+      [theme.breakpoints.up("sm")]: {
+        display: "none",
       },
+      display: "flex",
+    },
+    desktop: {
+      [theme.breakpoints.up("sm")]: {
+        display: "flex",
+      },
+      display: "none",
+    },
+    button: {
+      marginTop: "0.5rem",
+      width: "max-content",
+      alignSelf: "flex-end",
       height: "max-content",
       fontWeight: 800,
       fontSize: "0.8125rem",
@@ -36,7 +46,12 @@ export default function styles(theme) {
       borderRadius: "7px",
       backgroundColor: theme.palette.grey[50],
       whiteSpace: "nowrap",
+      alignItems: "center",
       padding: theme.spacing(0.2, 1.6),
+      [theme.breakpoints.up("sm")]: {
+        marginTop: "unset",
+        alignSelf: "center",
+      },
     },
     icon: {
       color: theme.palette.primary.main,

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -57,8 +57,8 @@ import { GROUP_CONTACT } from "../../../../../src/models/contact/group";
 import {
   PERSON_CONTACT,
   findPersonContactInAddressBook,
+  savePerson,
 } from "../../../../../src/models/contact/person";
-import { saveContact } from "../../../../../src/models/contact";
 import useAddressBook from "../../../../../src/hooks/useAddressBook";
 
 export const handleSubmit = ({
@@ -143,7 +143,7 @@ export const handleSaveContact = async (iri, addressBook, fetch) => {
     if (name) {
       const contact = { webId, fn: name };
       // TODO: we will likely need to update this if we also want to create and save groups
-      await saveContact(addressBook, contact, PERSON_CONTACT, fetch);
+      await savePerson(addressBook, contact, PERSON_CONTACT, fetch);
     }
   } catch (e) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -44,6 +44,7 @@ import { getResourceName } from "../../../../../src/solidClientHelpers/resource"
 import PolicyHeader from "../../policyHeader";
 import AgentsTableTabs from "../../agentsTableTabs";
 import AgentsSearchBar from "../../agentsSearchBar";
+import MobileAgentsSearchBar from "../../mobileAgentsSearchBar";
 import AddAgentRow from "../addAgentRow";
 import AgentPickerEmptyState from "../agentPickerEmptyState";
 import styles from "./styles";
@@ -357,9 +358,21 @@ export default function AgentPickerModal({ type, text, onClose, setLoading }) {
               groups: GROUP_CONTACT,
             }}
           />
-          <AddWebIdButton onClick={handleAddRow} disabled={addingWebId} />
+          <MobileAgentsSearchBar handleFilterChange={handleFilterChange} />
+
+          <AddWebIdButton
+            onClick={handleAddRow}
+            disabled={addingWebId}
+            className={classes.desktopOnly}
+          />
         </div>
         <AgentsSearchBar handleFilterChange={handleFilterChange} />
+
+        <AddWebIdButton
+          onClick={handleAddRow}
+          disabled={addingWebId}
+          className={classes.mobileOnly}
+        />
         {!contacts && !error && (
           <Container variant="empty">
             <CircularProgress />

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -104,10 +104,10 @@ export const handleConfirmation = ({
   handleSubmitNewWebIds,
 }) => {
   return (confirmationSetup, confirmed) => {
-    if (open !== dialogId) return;
-    if (confirmationSetup && confirmed === null) return;
     setConfirmationSetup(true);
 
+    if (open !== dialogId) return;
+    if (confirmationSetup && confirmed === null) return;
     if (confirmationSetup && confirmed) {
       handleSubmitNewWebIds();
     }
@@ -211,7 +211,6 @@ export default function AgentPickerModal({ type, text, onClose }) {
     const { value } = e.target;
     setGlobalFilter(value || undefined);
   };
-
   const handleSubmitNewWebIds = handleSubmit({
     newAgentsWebIds,
     webIdsToDelete,
@@ -226,7 +225,7 @@ export default function AgentPickerModal({ type, text, onClose }) {
   });
 
   const handleClickOpenDialog = () => {
-    if (!newAgentsWebIds.length) {
+    if (!newAgentsWebIds.length && !webIdsToDelete.length) {
       setNoAgentsAlert(true);
       return;
     }
@@ -256,7 +255,7 @@ export default function AgentPickerModal({ type, text, onClose }) {
     handleSubmitNewWebIds,
   });
 
-  const updateThing = (newThing) => {
+  const updateTemporaryRowThing = (newThing) => {
     const { dataset: addressBookDataset } = addressBook;
     const newItem = {
       thing: newThing,
@@ -382,7 +381,7 @@ export default function AgentPickerModal({ type, text, onClose }) {
                   setAddingWebId={setAddingWebId}
                   addingWebId={addingWebId}
                   setNoAgentsAlert={setNoAgentsAlert}
-                  updateThing={updateThing}
+                  updateTemporaryRowThing={updateTemporaryRowThing}
                   permissions={permissions}
                 />
               )}

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -189,6 +189,7 @@ export default function AgentPickerModal({ type, text, onClose }) {
   const [newAgentsWebIds, setNewAgentsWebIds] = useState([]);
   const [webIdsToDelete, setWebIdsToDelete] = useState([]);
   const [contactsArray, setContactsArray] = useState([]);
+  const [filteredContacts, setFilteredContacts] = useState([]);
   const [addingWebId, setAddingWebId] = useState(false);
   const [noAgentsAlert, setNoAgentsAlert] = useState(false);
   const [globalFilter, setGlobalFilter] = useState("");
@@ -277,13 +278,16 @@ export default function AgentPickerModal({ type, text, onClose }) {
       };
     });
     setContactsArray(contactsArrayForTable);
+  }, [contacts, addressBook]);
+
+  useEffect(() => {
     if (selectedTabValue) {
-      const filteredContacts = contactsArrayForTable.filter(({ thing }) =>
+      const filtered = contactsArray.filter(({ thing }) =>
         selectedTabValue.isOfType(thing)
       );
-      setContactsArray(filteredContacts);
+      setFilteredContacts(filtered);
     }
-  }, [contacts, addressBook, selectedTabValue]);
+  }, [contactsArray, selectedTabValue]);
 
   useEffect(() => {
     onConfirmation(confirmationSetup, confirmed);
@@ -300,6 +304,8 @@ export default function AgentPickerModal({ type, text, onClose }) {
     };
     setContactsArray([newItem, ...contactsArray]);
   };
+
+  const contactsForTable = selectedTabValue ? filteredContacts : contactsArray;
 
   const toggleCheckbox = (e, index, value) => {
     if (index === 0 && addingWebId) return null;
@@ -345,9 +351,9 @@ export default function AgentPickerModal({ type, text, onClose }) {
             <CircularProgress />
           </Container>
         )}
-        {!!contacts && !!contactsArray.length && (
+        {!!contacts && !!contactsForTable.length && (
           <Table
-            things={contactsArray}
+            things={contactsForTable}
             className={clsx(bem("table"), bem("agentPickerTable"))}
             filter={globalFilter}
           >
@@ -393,10 +399,10 @@ export default function AgentPickerModal({ type, text, onClose }) {
             />
           </Table>
         )}
-        {!!contacts && !contactsArray.length && !selectedTabValue && (
+        {!!contacts && !contactsForTable.length && !selectedTabValue && (
           <AgentPickerEmptyState onClick={handleAddRow} />
         )}
-        {!!contacts && !contactsArray.length && selectedTabValue && (
+        {!!contacts && !contactsForTable.length && selectedTabValue && (
           <span className={classes.emptyStateTextContainer}>
             <p>
               {`No ${

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -79,19 +79,17 @@ export const handleSubmit = ({
       setNoAgentsAlert(true);
       return;
     }
-    webIdsToDelete.forEach(async (agentWebId) => {
-      await accessControl.removeAgentFromNamedPolicy(agentWebId, type);
-      mutatePermissions();
-    });
-    newAgentsWebIds.forEach(async (agentWebId) => {
-      await accessControl.addAgentToNamedPolicy(agentWebId, type);
-      mutatePermissions();
-    });
-    Promise.allSettled(
-      newAgentsWebIds.map(async (agentWebId) =>
+    Promise.allSettled([
+      ...webIdsToDelete?.map(async (agentWebId) =>
+        accessControl.removeAgentFromNamedPolicy(agentWebId, type)
+      ),
+      ...newAgentsWebIds?.map(async (agentWebId) =>
+        accessControl.addAgentToNamedPolicy(agentWebId, type)
+      ),
+      ...newAgentsWebIds?.map(async (agentWebId) =>
         saveAgentToContacts(agentWebId, contacts, addressBook, fetch)
-      )
-    );
+      ),
+    ]).then(() => mutatePermissions());
     onClose();
   };
 };
@@ -362,7 +360,7 @@ export default function AgentPickerModal({ type, text, onClose }) {
         {!!contacts && !!contactsArray.length && (
           <Table
             things={contactsArray}
-            className={clsx(bem("table"), classes.agentPickerTable)}
+            className={clsx(bem("table"), bem("agentPickerTable"))}
             filter={globalFilter}
           >
             <TableColumn
@@ -409,7 +407,7 @@ export default function AgentPickerModal({ type, text, onClose }) {
           <span className={classes.emptyStateTextContainer}>
             <p>
               {`No ${
-                selectedTabValue.container === "Person" ? "people " : "groups "
+                selectedTabValue === PERSON_CONTACT ? "people " : "groups "
               } found`}
             </p>
           </span>

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -166,7 +166,7 @@ export const handleSaveContact = async (iri, addressBook, fetch) => {
     if (name) {
       const contact = { webId, fn: name };
       // TODO: we will likely need to update this if we also want to create and save groups
-      await savePerson(addressBook, contact, PERSON_CONTACT, fetch);
+      await savePerson(addressBook, contact, fetch);
     }
   } catch (e) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -196,6 +196,7 @@ export default function AgentPickerModal({ type, text, onClose, setLoading }) {
     GROUP_CONTACT,
     PERSON_CONTACT,
   ]);
+
   const webIdsInPermissions = permissions.map((p) => p.webId);
 
   const bem = useBem(useStyles());

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -354,7 +354,12 @@ export default function AgentPickerModal({ type, text, onClose }) {
             <TableColumn
               property={VCARD_WEBID_PREDICATE}
               dataType="url"
-              header={<span className={classes.tableHeader}>Editor</span>}
+              header={
+                // eslint-disable-next-line react/jsx-wrap-multilines
+                <span className={classes.tableHeader}>
+                  {type.slice(0, type.length - 1)}
+                </span>
+              }
               body={({ value, row: { index } }) => (
                 <WebIdCheckbox
                   value={value}

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.jsx
@@ -310,7 +310,7 @@ export default function AgentPickerModal({ type, text, onClose, setLoading }) {
       );
       setFilteredContacts(filtered);
     }
-  }, [contactsArray, selectedTabValue]);
+  }, [contactsArray, selectedTabValue, globalFilter]);
 
   useEffect(() => {
     onConfirmation(confirmationSetup, confirmed);
@@ -324,6 +324,9 @@ export default function AgentPickerModal({ type, text, onClose, setLoading }) {
       thing: emptyThing,
       dataset: addressBookDataset,
     };
+    if (selectedTabValue) {
+      setFilteredContacts([newItem, ...filteredContacts]);
+    }
     setContactsArray([newItem, ...contactsArray]);
   };
 
@@ -423,7 +426,7 @@ export default function AgentPickerModal({ type, text, onClose, setLoading }) {
         {!!contacts && !contactsForTable.length && !selectedTabValue && (
           <AgentPickerEmptyState onClick={handleAddRow} />
         )}
-        {!!contacts && !contactsForTable.length && selectedTabValue && (
+        {!!contacts && !contactsForTable.length && !!selectedTabValue && (
           <span className={classes.emptyStateTextContainer}>
             <p>
               {`No ${

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.test.jsx
@@ -29,6 +29,7 @@ import AgentPickerModal, {
   handleSubmit,
 } from "./index";
 import * as AddressBookFns from "../../../../../src/addressBook";
+import * as personModelFunctions from "../../../../../src/models/contact/person";
 import { renderWithTheme } from "../../../../../__testUtils/withTheme";
 import mockAccessControl from "../../../../../__testUtils/mockAccessControl";
 import mockPersonContact from "../../../../../__testUtils/mockPersonContact";
@@ -786,7 +787,7 @@ describe("handleSaveContact", () => {
       .mockResolvedValue({ name, avatar, webId });
 
     jest
-      .spyOn(AddressBookFns, "findPersonContactInAddressBook")
+      .spyOn(personModelFunctions, "findPersonContactInAddressBook")
       .mockResolvedValue([iri]);
 
     expect(jest.spyOn(AddressBookFns, "saveContact")).not.toHaveBeenCalled();
@@ -802,7 +803,7 @@ describe("handleSaveContact", () => {
       .mockResolvedValue({ name, avatar, webId });
 
     jest
-      .spyOn(AddressBookFns, "findPersonContactInAddressBook")
+      .spyOn(personModelFunctions, "findPersonContactInAddressBook")
       .mockResolvedValue([]);
 
     expect(jest.spyOn(AddressBookFns, "saveContact")).not.toHaveBeenCalled();

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.test.jsx
@@ -44,9 +44,16 @@ import useAddressBook from "../../../../../src/hooks/useAddressBook";
 import useContacts from "../../../../../src/hooks/useContacts";
 
 jest.mock("../../../../../src/hooks/useAddressBook");
+const mockedUseAddressBook = useAddressBook;
+
 jest.mock("../../../../../src/hooks/useNamedPolicyPermissions");
+const mockedUseNamedPolicyPermissions = useNamedPolicyPermissions;
+
 jest.mock("../../../../../src/hooks/usePermissionsWithProfiles");
+const mockedUsePermissionsWithProfiles = usePermissionsWithProfiles;
+
 jest.mock("../../../../../src/hooks/useContacts");
+const mockedUseContacts = useContacts;
 
 const permissions = [
   {
@@ -292,7 +299,7 @@ describe("handleSaveContact", () => {
 
 describe("AgentPickerModal without contacts", () => {
   beforeEach(() => {
-    useAddressBook.mockReturnValue({ data: mockAddressBook() });
+    mockedUseAddressBook.mockReturnValue({ data: mockAddressBook() });
   });
   const onClose = jest.fn();
   const accessControl = mockAccessControl();
@@ -301,17 +308,17 @@ describe("AgentPickerModal without contacts", () => {
     const name = "Example";
     const avatar = "https://someavatar.com";
     const webId = "https://somewebid.com";
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
     jest
       .spyOn(ProfileFns, "fetchProfile")
       .mockResolvedValue({ name, avatar, webId });
 
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: permissions,
     });
     const { getByTestId, findByTestId, findByText } = renderWithTheme(
@@ -335,13 +342,13 @@ describe("AgentPickerModal without contacts", () => {
     expect(agentWebId).not.toBeNull();
   });
   it("updates the temporary row with webId only when profile is unavailable", async () => {
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: permissions,
     });
     const webId = "https://somewebid.com";
@@ -370,13 +377,13 @@ describe("AgentPickerModal without contacts", () => {
     expect(agentWebId).not.toBeNull();
   });
   it("renders a table with tabs, searchbox and an empty state message when there are no contacts", () => {
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [],
     });
     const { asFragment, getByTestId } = renderWithTheme(
@@ -390,13 +397,13 @@ describe("AgentPickerModal without contacts", () => {
     expect(getByTestId("empty-state-add-webid-button")).not.toBeNull();
   });
   it("opens a confirmation dialog", async () => {
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: permissions,
     });
     const setOpen = jest.fn();
@@ -444,13 +451,13 @@ describe("AgentPickerModal without contacts", () => {
     expect(setOpen).toHaveBeenCalledWith("add-new-permissions");
   });
   it("renders the correct confimation message for more than 1 agent", async () => {
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: permissions,
     });
     const setOpen = jest.fn();
@@ -506,13 +513,13 @@ describe("AgentPickerModal without contacts", () => {
     expect(setOpen).toHaveBeenCalledWith("add-new-permissions");
   });
   it("cannot uncheck checkbox for the agent being added", async () => {
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: permissions,
     });
     const setOpen = jest.fn();
@@ -552,14 +559,14 @@ describe("AgentPickerModal without contacts", () => {
     expect(checkBox).toBeChecked();
   });
   it("renders a warning when trying to submit a webId that is already in the policy", async () => {
-    useContacts.mockReturnValue({ data: [] });
+    mockedUseContacts.mockReturnValue({ data: [] });
 
     const webId = "https://somewebid.com";
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [{ webId }],
     });
 
@@ -590,12 +597,12 @@ describe("AgentPickerModal without contacts", () => {
 describe("AgentPickerModal with contacts", () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    useAddressBook.mockReturnValue({ data: mockAddressBook() });
+    mockedUseAddressBook.mockReturnValue({ data: mockAddressBook() });
   });
 
   const onClose = jest.fn();
   it("renders a table with the available contacts", () => {
-    useContacts.mockReturnValue({
+    mockedUseContacts.mockReturnValue({
       data: [
         mockPersonContact(
           mockAddressBook(),
@@ -609,11 +616,11 @@ describe("AgentPickerModal with contacts", () => {
         ),
       ],
     });
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [],
     });
     const { asFragment, queryAllByTestId } = renderWithTheme(
@@ -631,7 +638,7 @@ describe("AgentPickerModal with contacts", () => {
   it("search bar filters by name", () => {
     const containerUrl = "https://example.com/contacts/";
     const emptyAddressBook = mockAddressBook({ containerUrl });
-    useContacts.mockReturnValue({
+    mockedUseContacts.mockReturnValue({
       data: [
         mockPersonContact(
           emptyAddressBook,
@@ -646,11 +653,11 @@ describe("AgentPickerModal with contacts", () => {
         mockGroupContact(emptyAddressBook, "Group 1", { id: "1234" }),
       ],
     });
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [],
     });
     const {
@@ -676,7 +683,7 @@ describe("AgentPickerModal with contacts", () => {
   it("clicking the tabs filters by person or group contact", () => {
     const containerUrl = "https://example.com/contacts/";
     const emptyAddressBook = mockAddressBook({ containerUrl });
-    useContacts.mockReturnValue({
+    mockedUseContacts.mockReturnValue({
       data: [
         mockPersonContact(
           emptyAddressBook,
@@ -691,11 +698,11 @@ describe("AgentPickerModal with contacts", () => {
         mockGroupContact(emptyAddressBook, "Group 1", { id: "1234" }),
       ],
     });
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [],
     });
     const { getByTestId, queryAllByTestId } = renderWithTheme(
@@ -716,7 +723,7 @@ describe("AgentPickerModal with contacts", () => {
   it("clicking on group tab with no results renders correct empty state text", () => {
     const containerUrl = "https://example.com/contacts/";
     const emptyAddressBook = mockAddressBook({ containerUrl });
-    useContacts.mockReturnValue({
+    mockedUseContacts.mockReturnValue({
       data: [
         mockPersonContact(
           emptyAddressBook,
@@ -730,11 +737,11 @@ describe("AgentPickerModal with contacts", () => {
         ),
       ],
     });
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [],
     });
     const { getByTestId, queryAllByTestId, queryByText } = renderWithTheme(
@@ -753,14 +760,14 @@ describe("AgentPickerModal with contacts", () => {
   it("clicking on people tab with no results renders correct empty state text", () => {
     const containerUrl = "https://example.com/contacts/";
     const emptyAddressBook = mockAddressBook({ containerUrl });
-    useContacts.mockReturnValue({
+    mockedUseContacts.mockReturnValue({
       data: [mockGroupContact(emptyAddressBook, "Group 1", { id: "1234" })],
     });
-    useNamedPolicyPermissions.mockReturnValue({
+    mockedUseNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
     });
-    usePermissionsWithProfiles.mockReturnValue({
+    mockedUsePermissionsWithProfiles.mockReturnValue({
       permissionsWithProfiles: [],
     });
     const { getByTestId, queryAllByTestId, queryByText } = renderWithTheme(

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/index.test.jsx
@@ -31,16 +31,21 @@ import AgentPickerModal, {
 import * as AddressBookFns from "../../../../../src/addressBook";
 import { renderWithTheme } from "../../../../../__testUtils/withTheme";
 import mockAccessControl from "../../../../../__testUtils/mockAccessControl";
-import mockPersonContactThing from "../../../../../__testUtils/mockPersonContactThing";
-
+import mockPersonContact from "../../../../../__testUtils/mockPersonContact";
+import mockGroupContact from "../../../../../__testUtils/mockGroupContact";
+import mockAddressBook from "../../../../../__testUtils/mockAddressBook";
 import AccessControlContext from "../../../../../src/contexts/accessControlContext";
 import * as ProfileFns from "../../../../../src/solidClientHelpers/profile";
 import ConfirmationDialogContext from "../../../../../src/contexts/confirmationDialogContext";
 import useNamedPolicyPermissions from "../../../../../src/hooks/useNamedPolicyPermissions";
 import usePermissionsWithProfiles from "../../../../../src/hooks/usePermissionsWithProfiles";
+import useAddressBook from "../../../../../src/hooks/useAddressBook";
+import useContacts from "../../../../../src/hooks/useContacts";
 
+jest.mock("../../../../../src/hooks/useAddressBook");
 jest.mock("../../../../../src/hooks/useNamedPolicyPermissions");
 jest.mock("../../../../../src/hooks/usePermissionsWithProfiles");
+jest.mock("../../../../../src/hooks/useContacts");
 
 const permissions = [
   {
@@ -101,10 +106,23 @@ const permissions = [
   },
 ];
 
-describe("AgentPickerModal", () => {
+describe("AgentPickerModal without contacts", () => {
+  beforeEach(() => {
+    useAddressBook.mockReturnValue({ data: mockAddressBook() });
+  });
   const onClose = jest.fn();
   const accessControl = mockAccessControl();
+
   it("updates the temporary row with profile data when available", async () => {
+    const name = "Example";
+    const avatar = "https://someavatar.com";
+    const webId = "https://somewebid.com";
+    useContacts.mockReturnValue({ data: [] });
+
+    jest
+      .spyOn(ProfileFns, "fetchProfile")
+      .mockResolvedValue({ name, avatar, webId });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -114,18 +132,13 @@ describe("AgentPickerModal", () => {
     });
     const { getByTestId, findByTestId, findByText } = renderWithTheme(
       <AccessControlContext.Provider value={{ accessControl }}>
-        <AgentPickerModal type="editors" text="Add Editors" onClose={onClose} />
+        <AgentPickerModal
+          type="editors"
+          text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+          onClose={onClose}
+        />
       </AccessControlContext.Provider>
     );
-
-    const name = "Example";
-    const avatar = "https://someavatar.com";
-    const webId = "https://somewebid.com";
-
-    jest
-      .spyOn(ProfileFns, "fetchProfile")
-      .mockResolvedValueOnce({ name, avatar, webId });
-
     const addWebIdButton = getByTestId("add-webid-button");
     userEvent.click(addWebIdButton);
     const input = await findByTestId("webid-input");
@@ -138,6 +151,8 @@ describe("AgentPickerModal", () => {
     expect(agentWebId).not.toBeNull();
   });
   it("updates the temporary row with webId only when profile is unavailable", async () => {
+    useContacts.mockReturnValue({ data: [] });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -148,11 +163,15 @@ describe("AgentPickerModal", () => {
     const webId = "https://somewebid.com";
     jest
       .spyOn(ProfileFns, "fetchProfile")
-      .mockRejectedValueOnce({ error: "error" });
+      .mockRejectedValue({ error: "error" });
 
     const { getByTestId, findByText, findByTestId } = renderWithTheme(
       <AccessControlContext.Provider value={{ accessControl }}>
-        <AgentPickerModal type="editors" text="Add Editors" onClose={onClose} />
+        <AgentPickerModal
+          type="editors"
+          text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+          onClose={onClose}
+        />
       </AccessControlContext.Provider>
     );
 
@@ -166,8 +185,9 @@ describe("AgentPickerModal", () => {
 
     expect(agentWebId).not.toBeNull();
   });
-  // update this when we actually pass the contacts to the table
   it("renders a table with tabs, searchbox and an empty state message when there are no contacts", () => {
+    useContacts.mockReturnValue({ data: [] });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -176,12 +196,18 @@ describe("AgentPickerModal", () => {
       permissionsWithProfiles: [],
     });
     const { asFragment, getByTestId } = renderWithTheme(
-      <AgentPickerModal type="editors" text="Add Editors" onClose={onClose} />
+      <AgentPickerModal
+        type="editors"
+        text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+        onClose={onClose}
+      />
     );
     expect(asFragment()).toMatchSnapshot();
     expect(getByTestId("empty-state-add-webid-button")).not.toBeNull();
   });
   it("renders a warning when trying to submit without adding a webId", () => {
+    useContacts.mockReturnValue({ data: [] });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -191,7 +217,11 @@ describe("AgentPickerModal", () => {
     });
     const { getByTestId, getByRole } = renderWithTheme(
       <AccessControlContext.Provider value={{ accessControl }}>
-        <AgentPickerModal type="editors" text="Add Editors" onClose={onClose} />
+        <AgentPickerModal
+          type="editors"
+          text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+          onClose={onClose}
+        />
       </AccessControlContext.Provider>
     );
 
@@ -203,6 +233,8 @@ describe("AgentPickerModal", () => {
     expect(getByRole("alert")).not.toBeNull();
   });
   it("opens a confirmation dialog", async () => {
+    useContacts.mockReturnValue({ data: [] });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -233,7 +265,7 @@ describe("AgentPickerModal", () => {
         <AccessControlContext.Provider value={{ accessControl }}>
           <AgentPickerModal
             type="editors"
-            text="Add Editors"
+            text={{ editText: "Edit Editors", saveText: "Save Editors" }}
             onClose={onClose}
           />
         </AccessControlContext.Provider>
@@ -255,6 +287,8 @@ describe("AgentPickerModal", () => {
     expect(setOpen).toHaveBeenCalledWith("add-new-permissions");
   });
   it("renders the correct confimation message for more than 1 agent", async () => {
+    useContacts.mockReturnValue({ data: [] });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -280,7 +314,7 @@ describe("AgentPickerModal", () => {
         <AccessControlContext.Provider value={{ accessControl }}>
           <AgentPickerModal
             type="editors"
-            text="Add Editors"
+            text={{ editText: "Edit Editors", saveText: "Save Editors" }}
             onClose={onClose}
           />
         </AccessControlContext.Provider>
@@ -315,6 +349,8 @@ describe("AgentPickerModal", () => {
     expect(setOpen).toHaveBeenCalledWith("add-new-permissions");
   });
   it("cannot uncheck checkbox for the agent being added", async () => {
+    useContacts.mockReturnValue({ data: [] });
+
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
       mutate: jest.fn(),
@@ -340,7 +376,7 @@ describe("AgentPickerModal", () => {
         <AccessControlContext.Provider value={{ accessControl }}>
           <AgentPickerModal
             type="editors"
-            text="Add Editors"
+            text={{ editText: "Edit Editors", saveText: "Save Editors" }}
             onClose={onClose}
           />
         </AccessControlContext.Provider>
@@ -359,6 +395,8 @@ describe("AgentPickerModal", () => {
     expect(checkBox).toBeChecked();
   });
   it("renders a warning when trying to submit a webId that is already in the policy", async () => {
+    useContacts.mockReturnValue({ data: [] });
+
     const webId = "https://somewebid.com";
     useNamedPolicyPermissions.mockReturnValue({
       data: permissions,
@@ -370,7 +408,11 @@ describe("AgentPickerModal", () => {
 
     const { getByTestId, findByText, findByTestId } = renderWithTheme(
       <AccessControlContext.Provider value={{ accessControl }}>
-        <AgentPickerModal type="editors" text="Add Editors" onClose={onClose} />
+        <AgentPickerModal
+          type="editors"
+          text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+          onClose={onClose}
+        />
       </AccessControlContext.Provider>
     );
 
@@ -387,11 +429,205 @@ describe("AgentPickerModal", () => {
     });
   });
 });
+
+describe("AgentPickerModal with contacts", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useAddressBook.mockReturnValue({ data: mockAddressBook() });
+  });
+
+  const onClose = jest.fn();
+  it("renders a table with the available contacts", () => {
+    useContacts.mockReturnValue({
+      data: [
+        mockPersonContact(
+          mockAddressBook(),
+          "https://example.org/contacts/Person/1234/",
+          "Example 1"
+        ),
+        mockPersonContact(
+          mockAddressBook(),
+          "https://example.org/contacts/Person/3456/",
+          "Example 2"
+        ),
+      ],
+    });
+    useNamedPolicyPermissions.mockReturnValue({
+      data: permissions,
+      mutate: jest.fn(),
+    });
+    usePermissionsWithProfiles.mockReturnValue({
+      permissionsWithProfiles: [],
+    });
+    const { asFragment, queryAllByTestId } = renderWithTheme(
+      <AgentPickerModal
+        type="editors"
+        text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+        onClose={onClose}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    waitFor(() => {
+      expect(queryAllByTestId("agent-webid")).toHaveLength(2);
+    });
+  });
+  it("search bar filters by name", () => {
+    const containerUrl = "https://example.com/contacts/";
+    const emptyAddressBook = mockAddressBook({ containerUrl });
+    useContacts.mockReturnValue({
+      data: [
+        mockPersonContact(
+          emptyAddressBook,
+          "https://example.org/contacts/Person/1234/",
+          "Example 1"
+        ),
+        mockPersonContact(
+          emptyAddressBook,
+          "https://example.org/contacts/Person/3456/",
+          "Example 2"
+        ),
+        mockGroupContact(emptyAddressBook, "Group 1", { id: "1234" }),
+      ],
+    });
+    useNamedPolicyPermissions.mockReturnValue({
+      data: permissions,
+      mutate: jest.fn(),
+    });
+    usePermissionsWithProfiles.mockReturnValue({
+      permissionsWithProfiles: [],
+    });
+    const {
+      getByTestId,
+      queryAllByTestId,
+      findByText,
+      queryByText,
+    } = renderWithTheme(
+      <AgentPickerModal
+        type="editors"
+        text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+        onClose={onClose}
+      />
+    );
+    const searchBar = getByTestId("search-input");
+    userEvent.type(searchBar, "Example 1");
+    expect(queryAllByTestId("agent-webid")).toHaveLength(1);
+    expect(findByText("Example 1")).not.toBeNull();
+    expect(queryByText("Example 2")).toBeNull();
+    userEvent.clear(searchBar);
+    expect(queryAllByTestId("agent-webid")).toHaveLength(3);
+  });
+  it("clicking the tabs filters by person or group contact", () => {
+    const containerUrl = "https://example.com/contacts/";
+    const emptyAddressBook = mockAddressBook({ containerUrl });
+    useContacts.mockReturnValue({
+      data: [
+        mockPersonContact(
+          emptyAddressBook,
+          "https://example.org/contacts/Person/1234/",
+          "Example 1"
+        ),
+        mockPersonContact(
+          emptyAddressBook,
+          "https://example.org/contacts/Person/3456/",
+          "Example 2"
+        ),
+        mockGroupContact(emptyAddressBook, "Group 1", { id: "1234" }),
+      ],
+    });
+    useNamedPolicyPermissions.mockReturnValue({
+      data: permissions,
+      mutate: jest.fn(),
+    });
+    usePermissionsWithProfiles.mockReturnValue({
+      permissionsWithProfiles: [],
+    });
+    const { getByTestId, queryAllByTestId } = renderWithTheme(
+      <AgentPickerModal
+        type="editors"
+        text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+        onClose={onClose}
+      />
+    );
+    const peopleTab = getByTestId("tab-people");
+    userEvent.click(peopleTab);
+    expect(queryAllByTestId("agent-webid")).toHaveLength(2);
+    const groupsTab = getByTestId("tab-groups");
+    userEvent.click(groupsTab);
+    // TODO: we will call this testid differently when we have groups
+    expect(queryAllByTestId("agent-webid")).toHaveLength(1);
+  });
+  it("clicking on group tab with no results renders correct empty state text", () => {
+    const containerUrl = "https://example.com/contacts/";
+    const emptyAddressBook = mockAddressBook({ containerUrl });
+    useContacts.mockReturnValue({
+      data: [
+        mockPersonContact(
+          emptyAddressBook,
+          "https://example.org/contacts/Person/1234/",
+          "Example 1"
+        ),
+        mockPersonContact(
+          emptyAddressBook,
+          "https://example.org/contacts/Person/3456/",
+          "Example 2"
+        ),
+      ],
+    });
+    useNamedPolicyPermissions.mockReturnValue({
+      data: permissions,
+      mutate: jest.fn(),
+    });
+    usePermissionsWithProfiles.mockReturnValue({
+      permissionsWithProfiles: [],
+    });
+    const { getByTestId, queryAllByTestId, queryByText } = renderWithTheme(
+      <AgentPickerModal
+        type="editors"
+        text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+        onClose={onClose}
+      />
+    );
+    const groupsTab = getByTestId("tab-groups");
+    userEvent.click(groupsTab);
+    // TODO: we will call this testid differently when we have groups
+    expect(queryAllByTestId("agent-webid")).toHaveLength(0);
+    expect(queryByText("No groups found")).not.toBeNull();
+  });
+  it("clicking on people tab with no results renders correct empty state text", () => {
+    const containerUrl = "https://example.com/contacts/";
+    const emptyAddressBook = mockAddressBook({ containerUrl });
+    useContacts.mockReturnValue({
+      data: [mockGroupContact(emptyAddressBook, "Group 1", { id: "1234" })],
+    });
+    useNamedPolicyPermissions.mockReturnValue({
+      data: permissions,
+      mutate: jest.fn(),
+    });
+    usePermissionsWithProfiles.mockReturnValue({
+      permissionsWithProfiles: [],
+    });
+    const { getByTestId, queryAllByTestId, queryByText } = renderWithTheme(
+      <AgentPickerModal
+        type="editors"
+        text={{ editText: "Edit Editors", saveText: "Save Editors" }}
+        onClose={onClose}
+      />
+    );
+    const peopleTab = getByTestId("tab-people");
+    userEvent.click(peopleTab);
+    // TODO: we will call this testid differently when we have groups
+    expect(queryAllByTestId("agent-webid")).toHaveLength(0);
+    expect(queryByText("No people found")).not.toBeNull();
+  });
+});
+
 describe("handleConfirmation", () => {
   const dialogId = "dialogId";
   const setOpen = jest.fn();
   const handleSubmitNewWebIds = jest.fn();
   const setConfirmed = jest.fn();
+  const setTitle = jest.fn();
+  const setContent = jest.fn();
   const setConfirmationSetup = jest.fn();
   const open = dialogId;
 
@@ -400,16 +636,20 @@ describe("handleConfirmation", () => {
     dialogId,
     setConfirmationSetup,
     setOpen,
+    setContent,
+    setTitle,
     setConfirmed,
     handleSubmitNewWebIds,
   });
 
-  it("returns a handler which calls a function that the webIds when user confirms dialog", () => {
+  it("returns a handler which calls a function that submits the webIds when user confirms dialog", () => {
     handler(true, true);
 
     expect(handleSubmitNewWebIds).toHaveBeenCalled();
     expect(setConfirmed).toHaveBeenCalledWith(null);
     expect(setConfirmationSetup).toHaveBeenCalledWith(true);
+    expect(setTitle).toHaveBeenCalledWith(null);
+    expect(setContent).toHaveBeenCalledWith(null);
   });
   it("returns a handler that exits when user cancels the operation", () => {
     handler(true, false);
@@ -429,7 +669,13 @@ describe("handleSubmit", () => {
   const webId = "https://example.org";
   const setNoAgentsAlert = jest.fn();
   const accessControl = mockAccessControl();
-  const people = [mockPersonContactThing()];
+  const contacts = [
+    mockPersonContact(
+      mockAddressBook(),
+      "https://example.org/contacts/Person/1234/",
+      "Example 1"
+    ),
+  ];
   const addressBook = mockSolidDatasetFrom("https://example.org/addressBook");
   const mutatePermissions = jest.fn();
   const saveAgentToContacts = jest.fn();
@@ -440,9 +686,10 @@ describe("handleSubmit", () => {
   it("returns a handler that submits the new webIds", async () => {
     const handler = handleSubmit({
       newAgentsWebIds: [webId],
+      webIdsToDelete: [],
       setNoAgentsAlert,
       accessControl,
-      people,
+      contacts,
       addressBook,
       mutatePermissions,
       saveAgentToContacts,
@@ -464,12 +711,40 @@ describe("handleSubmit", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("returns a handler that submits the webIdsToDelete", async () => {
+    const handler = handleSubmit({
+      newAgentsWebIds: [],
+      webIdsToDelete: [webId],
+      setNoAgentsAlert,
+      accessControl,
+      contacts,
+      addressBook,
+      mutatePermissions,
+      saveAgentToContacts,
+      onClose,
+      type,
+      fetch,
+    });
+    handler();
+
+    await waitFor(() => {
+      expect(accessControl.removeAgentFromNamedPolicy).toHaveBeenCalledWith(
+        webId,
+        type
+      );
+    });
+
+    expect(mutatePermissions).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
   it("calls setNoAgentsAlert when array of agents if empty", () => {
     const handler = handleSubmit({
       newAgentsWebIds: [],
+      webIdsToDelete: [],
       setNoAgentsAlert,
       accessControl,
-      people,
+      contacts,
       addressBook,
       mutatePermissions,
       saveAgentToContacts,
@@ -485,17 +760,23 @@ describe("handleSubmit", () => {
 
 describe("handleSaveContact", () => {
   const iri = "https://example.org";
-  const people = [mockPersonContactThing()];
+  const contacts = [
+    mockPersonContact(
+      mockAddressBook(),
+      "https://example.org/contacts/Person/1234/",
+      "Example 1"
+    ),
+  ];
   const addressBookUrl = "http://example.com/contacts/index.ttl";
   const addressBook = mockSolidDatasetFrom(addressBookUrl);
   const fetch = jest.fn();
   it("exits if no iri", () => {
-    handleSaveContact(null, people, addressBook, fetch);
+    handleSaveContact(null, contacts, addressBook, fetch);
 
     expect(jest.spyOn(AddressBookFns, "saveContact")).not.toHaveBeenCalled();
   });
   it("cancels the operation if webId is already in contacts", () => {
-    handleSaveContact(iri, people, addressBook, fetch);
+    handleSaveContact(iri, contacts, addressBook, fetch);
     const name = "Example";
     const avatar = "https://someavatar.com";
     const webId = iri;
@@ -505,13 +786,13 @@ describe("handleSaveContact", () => {
       .mockResolvedValue({ name, avatar, webId });
 
     jest
-      .spyOn(AddressBookFns, "findContactInAddressBook")
+      .spyOn(AddressBookFns, "findPersonContactInAddressBook")
       .mockResolvedValue([iri]);
 
     expect(jest.spyOn(AddressBookFns, "saveContact")).not.toHaveBeenCalled();
   });
   it("saves the contact", () => {
-    handleSaveContact(iri, people, addressBook, fetch);
+    handleSaveContact(iri, contacts, addressBook, fetch);
     const name = "Example";
     const avatar = "https://someavatar.com";
     const webId = iri;
@@ -521,7 +802,7 @@ describe("handleSaveContact", () => {
       .mockResolvedValue({ name, avatar, webId });
 
     jest
-      .spyOn(AddressBookFns, "findContactInAddressBook")
+      .spyOn(AddressBookFns, "findPersonContactInAddressBook")
       .mockResolvedValue([]);
 
     expect(jest.spyOn(AddressBookFns, "saveContact")).not.toHaveBeenCalled();

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
@@ -85,6 +85,7 @@ export default function styles(theme) {
       display: "flex",
       margin: 0,
       padding: theme.spacing(0.5),
+      textTransform: "capitalize",
     },
     modalTabsContainer: {
       borderBottom: "none !important", // overriding the default border bottom so we can set it to the whole width of the container

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
@@ -29,16 +29,13 @@ const MOBILE_TABLE_MIN_HEIGHT = 300;
 export default function styles(theme) {
   return createStyles(theme, ["icons", "button", "table"], {
     paper: {
-      [theme.breakpoints.down("xs")]: {
-        minWidth: "100vw",
-        minHeight: "100vh",
-        width: "100vw",
-        height: "100vh",
-        padding: theme.spacing(2, 1.4, 3),
+      [theme.breakpoints.up("sm")]: {
+        minWidth: MODAL_MIN_WIDTH,
+        minHeight: MODAL_MIN_HEIGHT,
+        height: "auto",
+        width: MODAL_MIN_WIDTH,
+        padding: theme.spacing(2, 4, 3),
       },
-      minWidth: MODAL_MIN_WIDTH,
-      minHeight: MODAL_MIN_HEIGHT,
-      width: MODAL_MIN_WIDTH,
       display: "flex",
       flexDirection: "column",
       position: "absolute",
@@ -46,15 +43,20 @@ export default function styles(theme) {
       borderRadius: theme.shape.borderRadius,
       boxShadow:
         "0 9px 46px 8px rgba(0,0,0,0.12), 0 24px 38px 3px rgba(0,0,0,0.14), 0 11px 15px -7px rgba(0,0,0,0.2)",
-      padding: theme.spacing(2, 4, 3),
+      minWidth: "100vw",
+      minHeight: "100vh",
+      width: "100vw",
+      height: "100vh",
+      padding: theme.spacing(2, 1.4, 3),
     },
     title: {
       ...theme.typography.h1,
       marginBottom: theme.spacing(1.2),
     },
     tableContainer: {
-      [theme.breakpoints.down("xs")]: {
-        minHeight: MOBILE_TABLE_MIN_HEIGHT,
+      minHeight: MOBILE_TABLE_MIN_HEIGHT,
+      [theme.breakpoints.up("xs")]: {
+        minHeight: "unset",
       },
       display: "flex",
       flexDirection: "column",
@@ -88,6 +90,9 @@ export default function styles(theme) {
       "&& tbody tr": {
         borderBottom: `1px solid ${theme.palette.grey.A100}`,
       },
+      "&& tbody td": {
+        maxWidth: "100%",
+      },
       "&& tbody :last-child": {
         borderBottom: "none",
       },
@@ -108,42 +113,45 @@ export default function styles(theme) {
       alignItems: "center",
     },
     buttonsContainer: {
-      [theme.breakpoints.down("xs")]: {
-        display: "flex",
-        position: "relative",
-        alignItems: "center",
-        flexDirection: "column-reverse",
-        width: "100%",
-        maxWidth: "100%",
-        padding: 0,
-      },
       display: "flex",
-      position: "absolute",
+      flexDirection: "column-reverse",
+      position: "relative",
       bottom: 0,
-      width: MODAL_MIN_WIDTH - theme.spacing(2.4) * 2 - theme.spacing(4), // substracting the padding of the buttons and the left and right padding of the modal
-      padding: theme.spacing(2.4),
+      width: "100%",
+      padding: 0,
+      alignItems: "center",
       justifyContent: "space-between",
+      [theme.breakpoints.up("sm")]: {
+        display: "flex",
+        position: "absolute",
+        flexDirection: "row",
+        width: MODAL_MIN_WIDTH - theme.spacing(2.4) * 2 - theme.spacing(4), // substracting the padding of the buttons and the left and right padding of the modal
+        maxWidth: "100%",
+        padding: theme.spacing(2.4),
+      },
     },
     cancelButton: {
-      [theme.breakpoints.down("xs")]: {
-        textAlign: "center",
-        width: "100%",
-      },
+      textAlign: "center",
+      width: "100%",
       fontSize: theme.typography.body1.fontSize,
       fontWeight: theme.typography.body1.fontWeight,
       padding: theme.spacing(1.4, 1.8),
       backgroundColor: "transparent",
+      [theme.breakpoints.up("sm")]: {
+        width: "max-content",
+      },
     },
     submitAgentsButton: {
-      [theme.breakpoints.down("xs")]: {
-        textAlign: "center",
-        width: "100%",
-      },
+      textAlign: "center",
+      width: "100%",
       fontSize: theme.typography.body1.fontSize,
       fontWeight: theme.typography.body1.fontWeight,
       color: theme.palette.common.white,
       backgroundColor: theme.palette.primary.main,
       padding: theme.spacing(1.4, 1.8),
+      [theme.breakpoints.up("sm")]: {
+        width: "max-content",
+      },
     },
     capitalizedText: {
       textTransform: "capitalize",
@@ -154,17 +162,18 @@ export default function styles(theme) {
       padding: theme.spacing(0.7, 1.4),
       textAlign: "center",
     },
+    // hopefully we can remove these once we figure out how to test the Hidden component from MUI so we can use that instead
     mobileOnly: {
-      [theme.breakpoints.down("xs")]: {
-        display: "block",
-      },
-      display: "none",
-    },
-    desktopOnly: {
-      [theme.breakpoints.down("xs")]: {
+      [theme.breakpoints.up("sm")]: {
         display: "none",
       },
       display: "flex",
+    },
+    desktopOnly: {
+      [theme.breakpoints.up("sm")]: {
+        display: "flex",
+      },
+      display: "none",
     },
   });
 }

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
@@ -24,10 +24,18 @@ import { createStyles } from "@solid/lit-prism-patterns";
 const MODAL_MIN_WIDTH = 680;
 const MODAL_MIN_HEIGHT = 680;
 const TABLE_MAX_HEIGHT = 460;
+const MOBILE_TABLE_MIN_HEIGHT = 300;
 
 export default function styles(theme) {
   return createStyles(theme, ["icons", "button", "table"], {
     paper: {
+      [theme.breakpoints.down("xs")]: {
+        minWidth: "100vw",
+        minHeight: "100vh",
+        width: "100vw",
+        height: "100vh",
+        padding: theme.spacing(2, 1.4, 3),
+      },
       minWidth: MODAL_MIN_WIDTH,
       minHeight: MODAL_MIN_HEIGHT,
       width: MODAL_MIN_WIDTH,
@@ -45,6 +53,9 @@ export default function styles(theme) {
       marginBottom: theme.spacing(1.2),
     },
     tableContainer: {
+      [theme.breakpoints.down("xs")]: {
+        minHeight: MOBILE_TABLE_MIN_HEIGHT,
+      },
       display: "flex",
       flexDirection: "column",
       backgroundColor: theme.palette.common.white,
@@ -97,12 +108,42 @@ export default function styles(theme) {
       alignItems: "center",
     },
     buttonsContainer: {
+      [theme.breakpoints.down("xs")]: {
+        display: "flex",
+        position: "relative",
+        alignItems: "center",
+        flexDirection: "column-reverse",
+        width: "100%",
+        maxWidth: "100%",
+        padding: 0,
+      },
       display: "flex",
       position: "absolute",
       bottom: 0,
       width: MODAL_MIN_WIDTH - theme.spacing(2.4) * 2 - theme.spacing(4), // substracting the padding of the buttons and the left and right padding of the modal
       padding: theme.spacing(2.4),
       justifyContent: "space-between",
+    },
+    cancelButton: {
+      [theme.breakpoints.down("xs")]: {
+        textAlign: "center",
+        width: "100%",
+      },
+      fontSize: theme.typography.body1.fontSize,
+      fontWeight: theme.typography.body1.fontWeight,
+      padding: theme.spacing(1.4, 1.8),
+      backgroundColor: "transparent",
+    },
+    submitAgentsButton: {
+      [theme.breakpoints.down("xs")]: {
+        textAlign: "center",
+        width: "100%",
+      },
+      fontSize: theme.typography.body1.fontSize,
+      fontWeight: theme.typography.body1.fontWeight,
+      color: theme.palette.common.white,
+      backgroundColor: theme.palette.primary.main,
+      padding: theme.spacing(1.4, 1.8),
     },
     capitalizedText: {
       textTransform: "capitalize",
@@ -112,6 +153,18 @@ export default function styles(theme) {
       flexDirection: "column",
       padding: theme.spacing(0.7, 1.4),
       textAlign: "center",
+    },
+    mobileOnly: {
+      [theme.breakpoints.down("xs")]: {
+        display: "block",
+      },
+      display: "none",
+    },
+    desktopOnly: {
+      [theme.breakpoints.down("xs")]: {
+        display: "none",
+      },
+      display: "flex",
     },
   });
 }

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
@@ -98,7 +98,7 @@ export default function styles(theme) {
     },
     buttonsContainer: {
       display: "flex",
-      position: "fixed",
+      position: "absolute",
       bottom: 0,
       width: MODAL_MIN_WIDTH - theme.spacing(2.4) * 2 - theme.spacing(4), // substracting the padding of the buttons and the left and right padding of the modal
       padding: theme.spacing(2.4),

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/styles.js
@@ -23,6 +23,7 @@ import { createStyles } from "@solid/lit-prism-patterns";
 
 const MODAL_MIN_WIDTH = 680;
 const MODAL_MIN_HEIGHT = 680;
+const TABLE_MAX_HEIGHT = 460;
 
 export default function styles(theme) {
   return createStyles(theme, ["icons", "button", "table"], {
@@ -50,6 +51,9 @@ export default function styles(theme) {
       borderRadius: theme.shape.borderRadius,
       border: `1px solid ${theme.palette.grey.A100}`,
       marginBottom: theme.spacing(2.4),
+      height: "100%",
+      maxHeight: TABLE_MAX_HEIGHT,
+      overflowY: "auto",
     },
     tabsAndAddButtonContainer: {
       display: "flex",
@@ -57,22 +61,30 @@ export default function styles(theme) {
       justifyContent: "space-between",
       borderBottom: `1px solid ${theme.palette.grey.A100}`,
     },
-    table: {
-      width: "100%",
-      padding: theme.spacing(1.6),
+    agentPickerTable: {
+      width: `calc(100% - ${theme.spacing(1.6) * 2}px)`,
+      boxSizing: "border-box",
+      marginLeft: theme.spacing(1.6),
+      marginRight: theme.spacing(1.6),
       "&& thead > tr": {
         minWidth: "100%",
         fontSize: theme.typography.caption.fontSize,
-        padding: theme.spacing(0.5),
         alignItems: "center",
         borderBottom: `1px solid ${theme.palette.grey.A100}`,
         fontWeight: theme.typography.body1.fontWeight,
         color: theme.palette.text.primary,
       },
+      "&& tbody tr": {
+        borderBottom: `1px solid ${theme.palette.grey.A100}`,
+      },
+      "&& tbody :last-child": {
+        borderBottom: "none",
+      },
     },
     tableHeader: {
       display: "flex",
       margin: 0,
+      padding: theme.spacing(0.5),
     },
     modalTabsContainer: {
       borderBottom: "none !important", // overriding the default border bottom so we can set it to the whole width of the container
@@ -93,6 +105,12 @@ export default function styles(theme) {
     },
     capitalizedText: {
       textTransform: "capitalize",
+    },
+    emptyStateTextContainer: {
+      display: "flex",
+      flexDirection: "column",
+      padding: theme.spacing(0.7, 1.4),
+      textAlign: "center",
     },
   });
 }

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WebIdCheckbox renders a checkbox with the corrext value 1`] = `
+<DocumentFragment>
+  <span
+    aria-disabled="false"
+    class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-colorPrimary PodBrowser-colorPrimary"
+  >
+    <span
+      class="PodBrowser-label"
+    >
+      <input
+        class="PodBrowser-input"
+        data-indeterminate="false"
+        data-testid="webid-checkbox"
+        type="checkbox"
+        value="https://somewebid.com"
+      />
+      <svg
+        aria-hidden="true"
+        class="PodBrowser-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M19 5v14H5V5h14m0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"
+        />
+      </svg>
+    </span>
+    <span
+      class="PodBrowser-root"
+    />
+  </span>
+</DocumentFragment>
+`;

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/index.jsx
@@ -41,14 +41,17 @@ export default function WebIdCheckbox({
   const { thing } = useThing();
   const { data: profile } = useContactProfile(thing);
 
-  let webIdValue;
-  if (!value && profile) {
-    webIdValue = profile.webId;
-  } else if (value) {
-    webIdValue = value;
-  } else if (!value && index === 0) {
-    webIdValue = "";
-  }
+  const getWebIdValue = () => {
+    let webIdValue;
+    if (!value && profile) {
+      webIdValue = profile.webId;
+    } else if (value) {
+      webIdValue = value;
+    } else if (!value && index === 0) {
+      webIdValue = "";
+    }
+    return webIdValue;
+  };
 
   return (
     <Checkbox
@@ -56,14 +59,14 @@ export default function WebIdCheckbox({
       type="checkbox"
       color="primary"
       size="medium"
-      value={webIdValue}
+      value={getWebIdValue()}
       checked={
         (index === 0 && addingWebId) ||
-        newAgentsWebIds.includes(webIdValue) ||
-        (webIdsInPermissions.includes(webIdValue) &&
-          !webIdsToDelete.includes(webIdValue))
+        newAgentsWebIds.includes(getWebIdValue()) ||
+        (webIdsInPermissions.includes(getWebIdValue()) &&
+          !webIdsToDelete.includes(getWebIdValue()))
       }
-      onChange={(e) => toggleCheckbox(e, index, webIdValue)}
+      onChange={(e) => toggleCheckbox(e, index, getWebIdValue())}
     />
   );
 }

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/index.jsx
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable react/forbid-prop-types */
+
+import React from "react";
+import { useThing } from "@inrupt/solid-ui-react";
+import PropTypes from "prop-types";
+import { Checkbox } from "@material-ui/core";
+import useContactProfile from "../../../../../../src/hooks/useContactProfile";
+
+export const TESTCAFE_ID_WEBID_CHECKBOX = "webid-checkbox";
+
+export default function WebIdCheckbox({
+  value,
+  index,
+  addingWebId,
+  toggleCheckbox,
+  newAgentsWebIds,
+  webIdsInPermissions,
+  webIdsToDelete,
+}) {
+  const { thing } = useThing();
+  const { data: profile } = useContactProfile(thing);
+
+  let webIdValue;
+  if (!value && profile) {
+    webIdValue = profile.webId;
+  } else if (value) {
+    webIdValue = value;
+  } else if (!value && index === 0) {
+    webIdValue = "";
+  }
+
+  return (
+    <Checkbox
+      inputProps={{ "data-testid": TESTCAFE_ID_WEBID_CHECKBOX }}
+      type="checkbox"
+      color="primary"
+      size="medium"
+      value={webIdValue}
+      checked={
+        (index === 0 && addingWebId) ||
+        newAgentsWebIds.includes(webIdValue) ||
+        (webIdsInPermissions.includes(webIdValue) &&
+          !webIdsToDelete.includes(webIdValue))
+      }
+      onChange={(e) => toggleCheckbox(e, index, webIdValue)}
+    />
+  );
+}
+
+WebIdCheckbox.propTypes = {
+  value: PropTypes.string,
+  index: PropTypes.number.isRequired,
+  addingWebId: PropTypes.bool,
+  toggleCheckbox: PropTypes.func,
+  newAgentsWebIds: PropTypes.arrayOf(PropTypes.string),
+  webIdsInPermissions: PropTypes.arrayOf(PropTypes.string),
+  webIdsToDelete: PropTypes.arrayOf(PropTypes.string),
+};
+
+WebIdCheckbox.defaultProps = {
+  value: null,
+  addingWebId: false,
+  toggleCheckbox: () => {},
+  newAgentsWebIds: [],
+  webIdsInPermissions: [],
+  webIdsToDelete: [],
+};

--- a/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/agentPickerModal/webIdCheckbox/index.test.jsx
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { renderWithTheme } from "../../../../../../__testUtils/withTheme";
+import useContactProfile from "../../../../../../src/hooks/useContactProfile";
+import WebIdCheckbox, { TESTCAFE_ID_WEBID_CHECKBOX } from "./index";
+
+jest.mock("../../../../../../src/hooks/useContactProfile");
+
+const webId = "https://somewebid.com";
+
+describe("WebIdCheckbox", () => {
+  const value = webId;
+  const index = 1;
+  const addingWebId = false;
+  const toggleCheckbox = jest.fn();
+  const newAgentsWebIds = [];
+  const webIdsInPermissions = [];
+  const webIdsToDelete = [];
+  test("renders a checkbox with the corrext value", () => {
+    useContactProfile.mockReturnValue({ data: null });
+
+    const { asFragment, getByTestId } = renderWithTheme(
+      <WebIdCheckbox
+        value={value}
+        index={index}
+        addingWebId={addingWebId}
+        toggleCheckbox={toggleCheckbox}
+        newAgentsWebIds={newAgentsWebIds}
+        webIdsInPermissions={webIdsInPermissions}
+        webIdsToDelete={webIdsToDelete}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    const checkbox = getByTestId(TESTCAFE_ID_WEBID_CHECKBOX);
+    expect(checkbox).toBeDefined();
+    expect(checkbox).toHaveAttribute("value", webId);
+  });
+  test("checkbox has the correct value if profile is available", () => {
+    useContactProfile.mockReturnValue({
+      data: { webId: "https://example.org" },
+    });
+    const { getByTestId } = renderWithTheme(
+      <WebIdCheckbox
+        value={null}
+        index={index}
+        addingWebId={addingWebId}
+        toggleCheckbox={toggleCheckbox}
+        newAgentsWebIds={newAgentsWebIds}
+        webIdsInPermissions={webIdsInPermissions}
+        webIdsToDelete={webIdsToDelete}
+      />
+    );
+    const checkbox = getByTestId(TESTCAFE_ID_WEBID_CHECKBOX);
+    expect(checkbox).toBeDefined();
+    expect(checkbox).toHaveAttribute("value", "https://example.org");
+  });
+  test("checkbox has a null value if value is unavailable and it's the first row", () => {
+    useContactProfile.mockReturnValue({
+      data: null,
+    });
+    const { getByTestId } = renderWithTheme(
+      <WebIdCheckbox
+        value={null}
+        index={0}
+        addingWebId={addingWebId}
+        toggleCheckbox={toggleCheckbox}
+        newAgentsWebIds={newAgentsWebIds}
+        webIdsInPermissions={webIdsInPermissions}
+        webIdsToDelete={webIdsToDelete}
+      />
+    );
+    const checkbox = getByTestId(TESTCAFE_ID_WEBID_CHECKBOX);
+    expect(checkbox).toBeDefined();
+    expect(checkbox).toHaveAttribute("value", "");
+  });
+  test("checkbox is checked if agent is already in permissions", () => {
+    useContactProfile.mockReturnValue({
+      data: { webId },
+    });
+    const { getByTestId } = renderWithTheme(
+      <WebIdCheckbox
+        value={null}
+        index={0}
+        addingWebId={addingWebId}
+        toggleCheckbox={toggleCheckbox}
+        newAgentsWebIds={newAgentsWebIds}
+        webIdsInPermissions={[webId]}
+        webIdsToDelete={webIdsToDelete}
+      />
+    );
+    const checkbox = getByTestId(TESTCAFE_ID_WEBID_CHECKBOX);
+    expect(checkbox).toBeDefined();
+    expect(checkbox).toBeChecked();
+  });
+  test("calls toggleCheckbox on click with the correct values", () => {
+    useContactProfile.mockReturnValue({
+      data: { webId },
+    });
+    const { getByTestId } = renderWithTheme(
+      <WebIdCheckbox
+        value={null}
+        index={index}
+        addingWebId={addingWebId}
+        toggleCheckbox={toggleCheckbox}
+        newAgentsWebIds={newAgentsWebIds}
+        webIdsInPermissions={[webId]}
+        webIdsToDelete={webIdsToDelete}
+      />
+    );
+    const checkbox = getByTestId(TESTCAFE_ID_WEBID_CHECKBOX);
+    userEvent.click(checkbox);
+    expect(toggleCheckbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      index,
+      webId
+    );
+  });
+});

--- a/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
@@ -38,11 +38,8 @@ const BUTTON_TEXT_MAP = {
   blocked: { editText: "Edit Blocked", saveText: "Save Blocked" },
 };
 
-export default function AddAgentButton({ type }) {
-  const {
-    data: namedPermissions,
-    mutate: mutatePermissions,
-  } = useNamedPolicyPermissions(type);
+export default function AddAgentButton({ type, setLoading }) {
+  const { data: namedPermissions } = useNamedPolicyPermissions(type);
   const { permissionsWithProfiles: permissions } = usePermissionsWithProfiles(
     namedPermissions
   );
@@ -86,7 +83,7 @@ export default function AddAgentButton({ type }) {
           type={type}
           text={BUTTON_TEXT_MAP[type]}
           onClose={handleClose}
-          mutatePermissions={mutatePermissions}
+          setLoading={setLoading}
           permissions={permissions}
         />
       </Modal>
@@ -96,4 +93,9 @@ export default function AddAgentButton({ type }) {
 
 AddAgentButton.propTypes = {
   type: PropTypes.string.isRequired,
+  setLoading: PropTypes.func,
+};
+
+AddAgentButton.defaultProps = {
+  setLoading: () => {},
 };

--- a/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
@@ -24,19 +24,18 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Modal } from "@material-ui/core";
-import { useBem } from "@solid/lit-prism-patterns";
 import { Button } from "@inrupt/prism-react-components";
 import AgentPickerModal from "./agentPickerModal";
 import useNamedPolicyPermissions from "../../../../src/hooks/useNamedPolicyPermissions";
 import usePermissionsWithProfiles from "../../../../src/hooks/usePermissionsWithProfiles";
 
 const TESTCAFE_ID_ADD_AGENT_BUTTON = "add-agent-button";
-const TESTCAFE_MODAL_OVERLAY = "modal-overlay";
+const TESTCAFE_ID_MODAL_OVERLAY = "modal-overlay";
 
 const BUTTON_TEXT_MAP = {
-  editors: { text: "Add Editors" },
-  viewers: { text: "Add Viewers" },
-  blocked: { text: "Block" },
+  editors: { editText: "Edit Editors", saveText: "Save Editors" },
+  viewers: { editText: "Edit Viewers", saveText: "Save Viewers" },
+  blocked: { editText: "Edit Blocked", saveText: "Save Blocked" },
 };
 
 export default function AddAgentButton({ type }) {
@@ -58,7 +57,7 @@ export default function AddAgentButton({ type }) {
     setOpen(false);
   };
 
-  const { text } = BUTTON_TEXT_MAP[type];
+  const { editText } = BUTTON_TEXT_MAP[type];
 
   return (
     <>
@@ -68,11 +67,11 @@ export default function AddAgentButton({ type }) {
         onClick={handleOpen}
         iconBefore="add"
       >
-        {text}
+        {editText}
       </Button>
 
       <Modal
-        data-testid={TESTCAFE_MODAL_OVERLAY}
+        data-testid={TESTCAFE_ID_MODAL_OVERLAY}
         open={open}
         style={{
           display: "flex",
@@ -80,12 +79,12 @@ export default function AddAgentButton({ type }) {
           justifyContent: "center",
         }}
         onClose={handleClose}
-        aria-labelledby={`${text} Modal`}
-        aria-describedby={`${text} for this resource`}
+        aria-labelledby={`${editText} Modal`}
+        aria-describedby={`${editText} for this resource`}
       >
         <AgentPickerModal
           type={type}
-          text={text}
+          text={BUTTON_TEXT_MAP[type]}
           onClose={handleClose}
           mutatePermissions={mutatePermissions}
           permissions={permissions}

--- a/components/resourceDetails/resourceSharing/agentAccessTable/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccessTable/__snapshots__/index.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`AgentAccessTable renders a list of permissions 1`] = `
             <span
               class="PodBrowser-button__text"
             >
-              Add Editors
+              Edit Editors
             </span>
           </button>
         </div>
@@ -268,7 +268,7 @@ exports[`AgentAccessTable renders an empty list of permissions 1`] = `
             <span
               class="PodBrowser-button__text"
             >
-              Add Editors
+              Edit Editors
             </span>
           </button>
         </div>

--- a/components/resourceDetails/resourceSharing/agentAccessTable/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccessTable/index.jsx
@@ -26,8 +26,14 @@ import React, { useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { useFilters, useGlobalFilter, useTable } from "react-table";
 import { useBem } from "@solid/lit-prism-patterns";
+import { Container } from "@inrupt/prism-react-components";
 import clsx from "clsx";
-import { Accordion, createStyles, Typography } from "@material-ui/core";
+import {
+  Accordion,
+  CircularProgress,
+  createStyles,
+  Typography,
+} from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import useNamedPolicyPermissions from "../../../../src/hooks/useNamedPolicyPermissions";
 import usePermissionsWithProfiles from "../../../../src/hooks/usePermissionsWithProfiles";
@@ -45,6 +51,7 @@ const TESTCAFE_ID_HIDE_BUTTON = "hide-button";
 export const TESTCAFE_ID_AGENT_ACCESS_TABLE = "agent-access-table";
 
 export default function AgentAccessTable({ type }) {
+  const [loading, setLoading] = useState(false);
   const {
     data: namedPermissions,
     mutate: mutatePermissions,
@@ -180,7 +187,7 @@ export default function AgentAccessTable({ type }) {
       <PolicyHeader type={type} isPolicyList>
         <AddAgentButton
           type={type}
-          mutatePermissions={mutatePermissions}
+          setLoading={setLoading}
           permissions={permissions}
         />
       </PolicyHeader>
@@ -195,7 +202,12 @@ export default function AgentAccessTable({ type }) {
             <AgentsSearchBar handleFilterChange={handleFilterChange} />
           </>
         )}
-        {permissions.length ? (
+        {loading && (
+          <Container variant="empty">
+            <CircularProgress />
+          </Container>
+        )}
+        {!loading && permissions.length ? (
           <table
             className={clsx(bem("table"), bem("agents-table"))}
             {...getTableProps()}
@@ -236,10 +248,10 @@ export default function AgentAccessTable({ type }) {
           </table>
         ) : (
           <span className={classes.emptyStateTextContainer}>
-            <p>{emptyStateText}</p>
+            {!loading && <p>{emptyStateText}</p>}
           </span>
         )}
-        {permissions.length > 3 && (
+        {!loading && permissions.length > 3 && (
           <div
             className={clsx(
               classes.showAllButtonContainer,

--- a/components/resourceDetails/resourceSharing/agentAccessTable/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccessTable/index.jsx
@@ -50,6 +50,7 @@ export default function AgentAccessTable({ type }) {
     mutate: mutatePermissions,
   } = useNamedPolicyPermissions(type);
 
+  // TODO: this will change when Groups are available, we will likely fetch profiles only for Individual permissions
   const { permissionsWithProfiles: permissions } = usePermissionsWithProfiles(
     namedPermissions
   );
@@ -164,10 +165,9 @@ export default function AgentAccessTable({ type }) {
     setGlobalFilter(value || undefined);
   };
 
-  /* istanbul ignore next */
   const handleTabChange = (e, newValue) => {
     setSelectedTabValue(newValue);
-    // TODO: this filter will change once we have groups - ignoring from test coverage until it is functional
+    // TODO: this will change when Groups are available since we will not have profiles for Groups
     setFilter("profile.types", newValue);
   };
 
@@ -190,6 +190,7 @@ export default function AgentAccessTable({ type }) {
             <AgentsTableTabs
               handleTabChange={handleTabChange}
               selectedTabValue={selectedTabValue}
+              tabsValues={{ all: "", people: "Person", groups: "Group" }}
             />
             <AgentsSearchBar handleFilterChange={handleFilterChange} />
           </>

--- a/components/resourceDetails/resourceSharing/agentsSearchBar/styles.js
+++ b/components/resourceDetails/resourceSharing/agentsSearchBar/styles.js
@@ -24,10 +24,10 @@ import { createStyles } from "@solid/lit-prism-patterns";
 export default function styles(theme) {
   return createStyles(theme, ["icons", "table"], {
     searchBoxContainer: {
-      [theme.breakpoints.down("xs")]: {
-        display: "none",
+      [theme.breakpoints.up("sm")]: {
+        display: "flex",
       },
-      display: "flex",
+      display: "none",
       margin: theme.spacing(0.7, 1.2),
       border: `1px solid ${theme.palette.grey.A100}`,
       borderRadius: "10px",

--- a/components/resourceDetails/resourceSharing/agentsTableTabs/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentsTableTabs/index.jsx
@@ -26,6 +26,7 @@ import PropTypes from "prop-types";
 import clsx from "clsx";
 import { makeStyles } from "@material-ui/styles";
 import { Tabs, Tab, createStyles } from "@material-ui/core";
+
 import styles from "./styles";
 
 export const TESTCAFE_ID_TAB_ALL = "tab-all";
@@ -36,17 +37,14 @@ const tabs = [
   {
     label: "All",
     testid: TESTCAFE_ID_TAB_ALL,
-    value: "",
   },
   {
     label: "People",
     testid: TESTCAFE_ID_TAB_PEOPLE,
-    value: "Person",
   },
   {
     label: "Groups",
     testid: TESTCAFE_ID_TAB_GROUPS,
-    value: "Group",
   },
 ];
 
@@ -54,6 +52,7 @@ export default function AgentsTableTabs({
   handleTabChange,
   selectedTabValue,
   className,
+  tabsValues,
 }) {
   const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
@@ -76,7 +75,7 @@ export default function AgentsTableTabs({
             }}
             label={tab.label}
             data-testid={tab.testid}
-            value={tab.value}
+            value={tabsValues[tab.label.toLowerCase()]}
           />
         ))}
       </Tabs>
@@ -86,7 +85,9 @@ export default function AgentsTableTabs({
 
 AgentsTableTabs.propTypes = {
   handleTabChange: PropTypes.func.isRequired,
-  selectedTabValue: PropTypes.string.isRequired,
+  selectedTabValue: PropTypes.oneOfType([PropTypes.shape(), PropTypes.string])
+    .isRequired,
+  tabsValues: PropTypes.shape().isRequired,
   className: PropTypes.string,
 };
 

--- a/components/resourceDetails/resourceSharing/agentsTableTabs/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentsTableTabs/index.test.jsx
@@ -36,6 +36,7 @@ describe("AgentTableTabs", () => {
       <AgentTableTabs
         handleTabChange={handleTabChange}
         selectedTabValue="Person"
+        tabsValues={{ all: "", people: "Person", groups: "Group" }}
       />
     );
     expect(getByTestId(TESTCAFE_ID_TAB_ALL)).toBeDefined();
@@ -48,6 +49,7 @@ describe("AgentTableTabs", () => {
       <AgentTableTabs
         handleTabChange={handleTabChange}
         selectedTabValue="Person"
+        tabsValues={{ all: "", people: "Person", groups: "Group" }}
       />
     );
 

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/__snapshots__/index.test.jsx.snap
@@ -1,62 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AgentSearchBar clicking the close icon hides the search bar 1`] = `
+exports[`MobileAgentSearchBar clicking the close icon hides the search bar 1`] = `
 <DocumentFragment>
   <div
-    class="PodBrowser-searchBoxContainer hidden"
-  >
-    <button
-      aria-label="search"
-      class="PodBrowser-root PodBrowser-root"
-      data-testid="search-button"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="PodBrowser-label"
-      >
-        <i
-          aria-label="search"
-          class="PodBrowser-icon-search PodBrowser-iconSearch"
-        />
-      </span>
-    </button>
-    <div
-      class="PodBrowser-root PodBrowser-searchInput hidden"
-    >
-      <input
-        aria-label="Search by name or WebId"
-        class="PodBrowser-input"
-        data-testid="mobile-search-input"
-        placeholder="Search by name or WebId"
-        type="text"
-        value=""
-      />
-    </div>
-    <button
-      aria-label="close"
-      class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
-      data-testid="close-button"
-      tabindex="0"
-      type="button"
-    >
-      <span
-        class="PodBrowser-label"
-      >
-        <i
-          aria-label="close"
-          class="PodBrowser-icon-cancel hidden"
-        />
-      </span>
-    </button>
-  </div>
-</DocumentFragment>
-`;
-
-exports[`AgentSearchBar clicking the icon expands the search bar 1`] = `
-<DocumentFragment>
-  <div
-    class="PodBrowser-searchBoxContainer hidden"
+    class="PodBrowser-searchBoxContainer--hidden"
   >
     <button
       aria-label="search"
@@ -78,11 +25,11 @@ exports[`AgentSearchBar clicking the icon expands the search bar 1`] = `
       />
     </button>
     <div
-      class="PodBrowser-root PodBrowser-searchInput hidden"
+      class="PodBrowser-root PodBrowser-searchInput--hidden PodBrowser-focused"
     >
       <input
         aria-label="Search by name or WebId"
-        class="PodBrowser-input"
+        class="PodBrowser-input PodBrowser-searchInput--hidden"
         data-testid="mobile-search-input"
         placeholder="Search by name or WebId"
         type="text"
@@ -112,10 +59,10 @@ exports[`AgentSearchBar clicking the icon expands the search bar 1`] = `
 </DocumentFragment>
 `;
 
-exports[`AgentSearchBar renders a search icon 1`] = `
+exports[`MobileAgentSearchBar clicking the icon expands the search bar 1`] = `
 <DocumentFragment>
   <div
-    class="PodBrowser-searchBoxContainer hidden"
+    class="PodBrowser-searchBoxContainer--hidden"
   >
     <button
       aria-label="search"
@@ -137,11 +84,70 @@ exports[`AgentSearchBar renders a search icon 1`] = `
       />
     </button>
     <div
-      class="PodBrowser-root PodBrowser-searchInput hidden"
+      class="PodBrowser-root PodBrowser-searchInput--hidden PodBrowser-focused"
     >
       <input
         aria-label="Search by name or WebId"
-        class="PodBrowser-input"
+        class="PodBrowser-input PodBrowser-searchInput--hidden"
+        data-testid="mobile-search-input"
+        placeholder="Search by name or WebId"
+        type="text"
+        value=""
+      />
+    </div>
+    <button
+      aria-label="close"
+      class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
+      data-testid="close-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="close"
+          class="PodBrowser-icon-cancel hidden"
+        />
+      </span>
+      <span
+        class="PodBrowser-root"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`MobileAgentSearchBar renders a search icon 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-searchBoxContainer--hidden"
+  >
+    <button
+      aria-label="search"
+      class="PodBrowser-root PodBrowser-root"
+      data-testid="search-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="search"
+          class="PodBrowser-icon-search PodBrowser-iconSearch"
+        />
+      </span>
+      <span
+        class="PodBrowser-root"
+      />
+    </button>
+    <div
+      class="PodBrowser-root PodBrowser-searchInput--hidden PodBrowser-focused"
+    >
+      <input
+        aria-label="Search by name or WebId"
+        class="PodBrowser-input PodBrowser-searchInput--hidden"
         data-testid="mobile-search-input"
         placeholder="Search by name or WebId"
         type="text"

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,172 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AgentSearchBar clicking the close icon hides the search bar 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-searchBoxContainer hidden"
+  >
+    <button
+      aria-label="search"
+      class="PodBrowser-root PodBrowser-root"
+      data-testid="search-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="search"
+          class="PodBrowser-icon-search PodBrowser-iconSearch"
+        />
+      </span>
+    </button>
+    <div
+      class="PodBrowser-root PodBrowser-searchInput hidden"
+    >
+      <input
+        aria-label="Search by name or WebId"
+        class="PodBrowser-input"
+        data-testid="mobile-search-input"
+        placeholder="Search by name or WebId"
+        type="text"
+        value=""
+      />
+    </div>
+    <button
+      aria-label="close"
+      class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
+      data-testid="close-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="close"
+          class="PodBrowser-icon-cancel hidden"
+        />
+      </span>
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AgentSearchBar clicking the icon expands the search bar 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-searchBoxContainer hidden"
+  >
+    <button
+      aria-label="search"
+      class="PodBrowser-root PodBrowser-root"
+      data-testid="search-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="search"
+          class="PodBrowser-icon-search PodBrowser-iconSearch"
+        />
+      </span>
+      <span
+        class="PodBrowser-root"
+      />
+    </button>
+    <div
+      class="PodBrowser-root PodBrowser-searchInput hidden"
+    >
+      <input
+        aria-label="Search by name or WebId"
+        class="PodBrowser-input"
+        data-testid="mobile-search-input"
+        placeholder="Search by name or WebId"
+        type="text"
+        value=""
+      />
+    </div>
+    <button
+      aria-label="close"
+      class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
+      data-testid="close-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="close"
+          class="PodBrowser-icon-cancel hidden"
+        />
+      </span>
+      <span
+        class="PodBrowser-root"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AgentSearchBar renders a search icon 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-searchBoxContainer hidden"
+  >
+    <button
+      aria-label="search"
+      class="PodBrowser-root PodBrowser-root"
+      data-testid="search-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="search"
+          class="PodBrowser-icon-search PodBrowser-iconSearch"
+        />
+      </span>
+      <span
+        class="PodBrowser-root"
+      />
+    </button>
+    <div
+      class="PodBrowser-root PodBrowser-searchInput hidden"
+    >
+      <input
+        aria-label="Search by name or WebId"
+        class="PodBrowser-input"
+        data-testid="mobile-search-input"
+        placeholder="Search by name or WebId"
+        type="text"
+        value=""
+      />
+    </div>
+    <button
+      aria-label="close"
+      class="PodBrowser-root PodBrowser-root PodBrowser-iconCloseHidden"
+      data-testid="close-button"
+      tabindex="0"
+      type="button"
+    >
+      <span
+        class="PodBrowser-label"
+      >
+        <i
+          aria-label="close"
+          class="PodBrowser-icon-cancel hidden"
+        />
+      </span>
+      <span
+        class="PodBrowser-root"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable react/forbid-prop-types */
+
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { useBem } from "@solid/lit-prism-patterns";
+import clsx from "clsx";
+import { makeStyles } from "@material-ui/styles";
+import { IconButton, InputBase, createStyles } from "@material-ui/core";
+import styles from "./styles";
+
+export const TESTCAFE_ID_MOBILE_SEARCH_INPUT = "mobile-search-input";
+export const TESTCAFE_ID_SEARCH_BUTTON = "search-button";
+export const TESTCAFE_ID_CLOSE_BUTTON = "close-button";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function MobileAgentsSearchBar({ handleFilterChange }) {
+  const bem = useBem(useStyles());
+  const [expanded, setExpanded] = useState(false);
+  const classes = useStyles();
+  return (
+    <div
+      className={clsx(
+        classes.searchBoxContainer,
+        expanded ? "expanded" : "hidden"
+      )}
+    >
+      <IconButton
+        data-testid={TESTCAFE_ID_SEARCH_BUTTON}
+        type="button"
+        aria-label="search"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <i
+          className={clsx(bem("icon-search"), bem("icon"), classes.iconSearch)}
+          aria-label="search"
+        />
+      </IconButton>
+      <InputBase
+        classes={{ root: classes.searchInput }}
+        className={expanded ? "expanded" : "hidden"}
+        placeholder="Search by name or WebId"
+        inputProps={{
+          "data-testid": TESTCAFE_ID_MOBILE_SEARCH_INPUT,
+          "aria-label": "Search by name or WebId",
+          onChange: handleFilterChange,
+        }}
+      />
+      <IconButton
+        type="button"
+        data-testid={TESTCAFE_ID_CLOSE_BUTTON}
+        aria-label="close"
+        classes={{
+          root: expanded ? classes.iconCloseExpanded : classes.iconCloseHidden,
+        }}
+        onClick={() => setExpanded(!expanded)}
+      >
+        <i
+          className={clsx(
+            bem("icon-cancel"),
+            bem("icon"),
+            classes.iconClose,
+            expanded ? "expanded" : "hidden"
+          )}
+          aria-label="close"
+        />
+      </IconButton>
+    </div>
+  );
+}
+
+MobileAgentsSearchBar.propTypes = {
+  handleFilterChange: PropTypes.func,
+};
+
+MobileAgentsSearchBar.defaultProps = {
+  handleFilterChange: () => {},
+};

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable react/forbid-prop-types */
 
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useBem } from "@solid/lit-prism-patterns";
 import clsx from "clsx";
@@ -39,12 +39,20 @@ export default function MobileAgentsSearchBar({ handleFilterChange }) {
   const bem = useBem(useStyles());
   const [expanded, setExpanded] = useState(false);
   const classes = useStyles();
+  const textInput = React.createRef();
+
+  useEffect(() => {
+    if (expanded) {
+      textInput.current.focus();
+    }
+  }, [expanded, textInput]);
+
   return (
     <div
-      className={clsx(
-        classes.searchBoxContainer,
-        expanded ? "expanded" : "hidden"
-      )}
+      className={
+        (bem("searchBoxContainer"),
+        bem("searchBoxContainer", expanded ? "expanded" : "hidden"))
+      }
     >
       <IconButton
         data-testid={TESTCAFE_ID_SEARCH_BUTTON}
@@ -58,13 +66,15 @@ export default function MobileAgentsSearchBar({ handleFilterChange }) {
         />
       </IconButton>
       <InputBase
-        classes={{ root: classes.searchInput }}
-        className={expanded ? "expanded" : "hidden"}
+        autoFocus
+        className={clsx(bem("searchInput", expanded ? "expanded" : "hidden"))}
         placeholder="Search by name or WebId"
         inputProps={{
+          className: clsx(bem("searchInput", expanded ? "expanded" : "hidden")),
           "data-testid": TESTCAFE_ID_MOBILE_SEARCH_INPUT,
           "aria-label": "Search by name or WebId",
           onChange: handleFilterChange,
+          ref: textInput,
         }}
       />
       <IconButton

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
@@ -49,10 +49,7 @@ export default function MobileAgentsSearchBar({ handleFilterChange }) {
 
   return (
     <div
-      className={
-        (bem("searchBoxContainer"),
-        bem("searchBoxContainer", expanded ? "expanded" : "hidden"))
-      }
+      className={bem("searchBoxContainer", expanded ? "expanded" : "hidden")}
     >
       <IconButton
         data-testid={TESTCAFE_ID_SEARCH_BUTTON}

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.test.jsx
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { waitFor } from "@testing-library/dom";
+import { renderWithTheme } from "../../../../__testUtils/withTheme";
+import MobileAgentsSearchBar, {
+  TESTCAFE_ID_MOBILE_SEARCH_INPUT,
+  TESTCAFE_ID_SEARCH_BUTTON,
+  TESTCAFE_ID_CLOSE_BUTTON,
+} from "./index";
+
+describe("AgentSearchBar", () => {
+  const handleFilterChange = jest.fn();
+  it("renders a search icon", () => {
+    const { asFragment, getByTestId } = renderWithTheme(
+      <MobileAgentsSearchBar handleFilterChange={handleFilterChange} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(getByTestId(TESTCAFE_ID_SEARCH_BUTTON)).toBeDefined();
+    expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).not.toBeVisible();
+  });
+  it("clicking the icon expands the search bar", () => {
+    const { asFragment, getByTestId } = renderWithTheme(
+      <MobileAgentsSearchBar handleFilterChange={handleFilterChange} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    const button = getByTestId(TESTCAFE_ID_SEARCH_BUTTON);
+    userEvent.click(button);
+    waitFor(() =>
+      expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).toBeVisible()
+    );
+  });
+  it("clicking the close icon hides the search bar", () => {
+    const { asFragment, getByTestId } = renderWithTheme(
+      <MobileAgentsSearchBar handleFilterChange={handleFilterChange} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    const searchButton = getByTestId(TESTCAFE_ID_SEARCH_BUTTON);
+    userEvent.click(searchButton);
+    const closeButton = getByTestId(TESTCAFE_ID_CLOSE_BUTTON);
+    userEvent.click(closeButton);
+
+    waitFor(() =>
+      expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).not.toBeVisible()
+    );
+  });
+  it("triggers handleFilterChange when typing into the search input", () => {
+    const { getByTestId } = renderWithTheme(
+      <MobileAgentsSearchBar handleFilterChange={handleFilterChange} />
+    );
+
+    const input = getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT);
+    userEvent.type(input, "A");
+
+    expect(handleFilterChange).toHaveBeenCalled();
+  });
+});

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.test.jsx
@@ -21,7 +21,6 @@
 
 import React from "react";
 import userEvent from "@testing-library/user-event";
-import { waitFor } from "@testing-library/dom";
 import { renderWithTheme } from "../../../../__testUtils/withTheme";
 import MobileAgentsSearchBar, {
   TESTCAFE_ID_MOBILE_SEARCH_INPUT,
@@ -29,7 +28,7 @@ import MobileAgentsSearchBar, {
   TESTCAFE_ID_CLOSE_BUTTON,
 } from "./index";
 
-describe("AgentSearchBar", () => {
+describe("MobileAgentSearchBar", () => {
   const handleFilterChange = jest.fn();
   it("renders a search icon", () => {
     const { asFragment, getByTestId } = renderWithTheme(
@@ -37,7 +36,9 @@ describe("AgentSearchBar", () => {
     );
     expect(asFragment()).toMatchSnapshot();
     expect(getByTestId(TESTCAFE_ID_SEARCH_BUTTON)).toBeDefined();
-    expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).not.toBeVisible();
+    expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).toHaveClass(
+      "PodBrowser-searchInput--hidden"
+    );
   });
   it("clicking the icon expands the search bar", () => {
     const { asFragment, getByTestId } = renderWithTheme(
@@ -46,8 +47,8 @@ describe("AgentSearchBar", () => {
     expect(asFragment()).toMatchSnapshot();
     const button = getByTestId(TESTCAFE_ID_SEARCH_BUTTON);
     userEvent.click(button);
-    waitFor(() =>
-      expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).toBeVisible()
+    expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).toHaveClass(
+      "PodBrowser-searchInput--expanded"
     );
   });
   it("clicking the close icon hides the search bar", () => {
@@ -59,9 +60,8 @@ describe("AgentSearchBar", () => {
     userEvent.click(searchButton);
     const closeButton = getByTestId(TESTCAFE_ID_CLOSE_BUTTON);
     userEvent.click(closeButton);
-
-    waitFor(() =>
-      expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).not.toBeVisible()
+    expect(getByTestId(TESTCAFE_ID_MOBILE_SEARCH_INPUT)).toHaveClass(
+      "PodBrowser-searchInput--hidden"
     );
   });
   it("triggers handleFilterChange when typing into the search input", () => {

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/styles.js
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/styles.js
@@ -21,19 +21,42 @@
 
 import { createStyles } from "@solid/lit-prism-patterns";
 
+const SEARCH_BOX_HEIGHT = 50;
+
 export default function styles(theme) {
   return createStyles(theme, ["icons", "table"], {
     searchBoxContainer: {
-      [theme.breakpoints.down("xs")]: {
-        display: "none",
-      },
-      display: "flex",
+      display: "none",
       margin: theme.spacing(0.7, 1.2),
       border: `1px solid ${theme.palette.grey.A100}`,
       borderRadius: "10px",
       height: "2.5rem",
+      [theme.breakpoints.down("xs")]: {
+        border: "none",
+        display: "flex",
+        "&.expanded": {
+          boxShadow: `0px 0px 0px 1px ${theme.palette.primary.main} inset`,
+          display: "flex",
+          height: SEARCH_BOX_HEIGHT,
+          borderRadius: "5px",
+          border: `1px solid ${theme.palette.grey.A100}`,
+          position: "absolute",
+          backgroundColor: theme.palette.background.paper,
+          right: theme.spacing(0.25),
+          left: theme.spacing(0.25),
+        },
+        "&.hidden": {
+          width: "min-content",
+        },
+      },
     },
     searchInput: {
+      [theme.breakpoints.down("xs")]: {
+        visibility: "hidden",
+        "&.expanded": {
+          visibility: "visible",
+        },
+      },
       fontSize: "0.8125rem",
       width: "100%",
       font: "inherit",
@@ -42,6 +65,18 @@ export default function styles(theme) {
     },
     iconSearch: {
       fontSize: theme.typography.body1.fontSize,
+    },
+    iconCloseExpanded: {
+      display: "none",
+      [theme.breakpoints.down("xs")]: {
+        display: "flex",
+        fontSize: theme.typography.body1.fontSize,
+        position: "relative",
+        paddingRight: "1rem",
+      },
+    },
+    iconCloseHidden: {
+      display: "none",
     },
   });
 }

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/styles.js
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/styles.js
@@ -25,38 +25,46 @@ const SEARCH_BOX_HEIGHT = 50;
 
 export default function styles(theme) {
   return createStyles(theme, ["icons", "table"], {
-    searchBoxContainer: {
-      display: "none",
-      margin: theme.spacing(0.7, 1.2),
-      border: `1px solid ${theme.palette.grey.A100}`,
-      borderRadius: "10px",
-      height: "2.5rem",
-      [theme.breakpoints.down("xs")]: {
-        border: "none",
-        display: "flex",
-        "&.expanded": {
-          boxShadow: `0px 0px 0px 1px ${theme.palette.primary.main} inset`,
-          display: "flex",
-          height: SEARCH_BOX_HEIGHT,
-          borderRadius: "5px",
-          border: `1px solid ${theme.palette.grey.A100}`,
-          position: "absolute",
-          backgroundColor: theme.palette.background.paper,
-          right: theme.spacing(0.25),
-          left: theme.spacing(0.25),
-        },
-        "&.hidden": {
-          width: "min-content",
-        },
+    [theme.breakpoints.up("sm")]: {
+      "searchBoxContainer--hidden": {
+        display: "none !important",
+      },
+      "searchBoxContainer--expanded": {
+        display: "none !important",
       },
     },
-    searchInput: {
-      [theme.breakpoints.down("xs")]: {
-        visibility: "hidden",
-        "&.expanded": {
-          visibility: "visible",
-        },
+    "searchBoxContainer--hidden": {
+      display: "flex",
+      border: "none",
+      margin: theme.spacing(0.7, 1.2),
+      width: "min-content",
+    },
+    "searchBoxContainer--expanded": {
+      margin: theme.spacing(0.7, 1.2),
+      boxShadow: `0px 0px 0px 1px ${theme.palette.primary.main} inset`,
+      display: "flex",
+      height: SEARCH_BOX_HEIGHT,
+      borderRadius: "5px",
+      position: "absolute",
+      backgroundColor: theme.palette.background.paper,
+      right: theme.spacing(0.25),
+      left: theme.spacing(0.25),
+      [theme.breakpoints.up("sm")]: {
+        border: `1px solid ${theme.palette.grey.A100}`,
+        borderRadius: "10px",
+        height: "2.5rem",
       },
+    },
+    "searchInput--hidden": {
+      visibility: "hidden",
+      fontSize: "0.8125rem",
+      width: "100%",
+      font: "inherit",
+      fontWeight: 500,
+      color: theme.palette.primary.text,
+    },
+    "searchInput--expanded": {
+      visibility: "visible",
       fontSize: "0.8125rem",
       width: "100%",
       font: "inherit",
@@ -67,12 +75,12 @@ export default function styles(theme) {
       fontSize: theme.typography.body1.fontSize,
     },
     iconCloseExpanded: {
-      display: "none",
-      [theme.breakpoints.down("xs")]: {
-        display: "flex",
-        fontSize: theme.typography.body1.fontSize,
-        position: "relative",
-        paddingRight: "1rem",
+      display: "flex",
+      fontSize: theme.typography.body1.fontSize,
+      position: "relative",
+      paddingRight: "1rem",
+      [theme.breakpoints.up("sm")]: {
+        display: "none",
       },
     },
     iconCloseHidden: {

--- a/components/resourceDetails/resourceSharing/sharingAccordion/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/sharingAccordion/__snapshots__/index.test.jsx.snap
@@ -34,7 +34,7 @@ exports[`SharingAccordion it renders three lists of empty permissions for editor
             <span
               class="PodBrowser-button__text"
             >
-              Add Editors
+              Edit Editors
             </span>
           </button>
         </div>
@@ -111,7 +111,7 @@ exports[`SharingAccordion it renders three lists of empty permissions for editor
             <span
               class="PodBrowser-button__text"
             >
-              Add Viewers
+              Edit Viewers
             </span>
           </button>
         </div>
@@ -192,7 +192,7 @@ exports[`SharingAccordion it renders three lists of empty permissions for editor
             <span
               class="PodBrowser-button__text"
             >
-              Block
+              Edit Blocked
             </span>
           </button>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1383,9 +1383,9 @@
       "dev": true
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.6.0.tgz",
-      "integrity": "sha512-DDQiCYvmubiMfIR84U3qsuNnfIO1xgxUtTHCFx+JL0KSC1aWA79LgdQre6fIGkFQKbHBwn5fRtRkOl0sgWb2Hw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.5.1.tgz",
+      "integrity": "sha512-2xKrUyZP3FtD1cGIhJWo4MisvIPUgYU/PK+jZ3/D4mCnA1yM+bIMdZtfn+Mm8iEqixNUAlkXEOca7Bc6gTYHOQ==",
       "requires": {
         "@types/form-urlencoded": "^2.0.1",
         "@types/jsonwebtoken": "^8.5.0",
@@ -1425,24 +1425,21 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.6.0.tgz",
-      "integrity": "sha512-GOW22/XuCqU3EHQQB2Z2zN3zn26X5bwdbZLrUYRjmgRi4xA8icRvqWPLc7k/1EIv31/xlqiExzGqY2XMCyNjAQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.5.1.tgz",
+      "integrity": "sha512-sZN9MnN7wA3XqRPGK3QD7bP0C20vwAeyVLX0RgyMlTl+58TDAYsPp5BrooqmDAkqsreUJqUPOt4mfkRax7vrnA==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.6.0",
-        "@inrupt/solid-client-authn-core": "^1.6.0",
+        "@inrupt/oidc-client-ext": "^1.5.1",
+        "@inrupt/solid-client-authn-core": "^1.5.1",
         "@types/form-urlencoded": "^2.0.1",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^14.14.14",
         "@types/uuid": "^8.3.0",
-        "assert": "^2.0.0",
-        "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
         "form-urlencoded": "^4.2.1",
         "jose": "^2.0.2",
         "lodash.clonedeep": "^4.5.0",
-        "os-browserify": "^0.3.0",
         "reflect-metadata": "^0.1.13",
         "stream-browserify": "^3.0.0",
         "tsyringe": "^4.4.0",
@@ -1451,20 +1448,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
-        },
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
+          "version": "14.14.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+          "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g=="
         },
         "buffer": {
           "version": "6.0.3",
@@ -1496,9 +1482,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.6.0.tgz",
-      "integrity": "sha512-eqFVAkqvYRXRKKOAYmv9VF5cCfrkxK+uhSCRaLj+iBoYuqB2Lk+3YBBtgvYSEzanRtXg3ZXhEHiGBYNxi8cXAw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.5.1.tgz",
+      "integrity": "sha512-w0iAW8kiVmmX0fNVlwjcE1lkkuai/biUA5SZrCiRC4SEA30IEvuDzui1p3Ck5PJifEIIplB5wQmXnZzhu0GprQ==",
       "requires": {
         "@inrupt/solid-common-vocab": "^0.5.3",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -3659,7 +3645,8 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -5867,11 +5854,6 @@
         "is-symbol": "^1.0.2"
       }
     },
-    "es6-object-assign": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
-      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
-    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -7795,15 +7777,6 @@
       "requires": {
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"
-      }
-    },
-    "is-nan": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3"
       }
     },
     "is-negative-zero": {
@@ -12118,15 +12091,6 @@
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -12198,9 +12162,9 @@
       }
     },
     "oidc-client": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
-      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.4.tgz",
+      "integrity": "sha512-71mEPaDr7g2Ji6t+e1fKLNKJL/XEuDXmXakDUJ9hVpmsLyQKY9kfbjeuDDAN6cP7Rhty3814he/aStqNLBREKA==",
       "requires": {
         "acorn": "^7.4.1",
         "base64-js": "^1.5.1",
@@ -12209,15 +12173,20 @@
         "serialize-javascript": "^4.0.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+        },
         "base64-js": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "core-js": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-          "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ=="
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1383,9 +1383,9 @@
       "dev": true
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.5.1.tgz",
-      "integrity": "sha512-2xKrUyZP3FtD1cGIhJWo4MisvIPUgYU/PK+jZ3/D4mCnA1yM+bIMdZtfn+Mm8iEqixNUAlkXEOca7Bc6gTYHOQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.6.0.tgz",
+      "integrity": "sha512-DDQiCYvmubiMfIR84U3qsuNnfIO1xgxUtTHCFx+JL0KSC1aWA79LgdQre6fIGkFQKbHBwn5fRtRkOl0sgWb2Hw==",
       "requires": {
         "@types/form-urlencoded": "^2.0.1",
         "@types/jsonwebtoken": "^8.5.0",
@@ -1425,21 +1425,24 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.5.1.tgz",
-      "integrity": "sha512-sZN9MnN7wA3XqRPGK3QD7bP0C20vwAeyVLX0RgyMlTl+58TDAYsPp5BrooqmDAkqsreUJqUPOt4mfkRax7vrnA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.6.0.tgz",
+      "integrity": "sha512-GOW22/XuCqU3EHQQB2Z2zN3zn26X5bwdbZLrUYRjmgRi4xA8icRvqWPLc7k/1EIv31/xlqiExzGqY2XMCyNjAQ==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.5.1",
-        "@inrupt/solid-client-authn-core": "^1.5.1",
+        "@inrupt/oidc-client-ext": "^1.6.0",
+        "@inrupt/solid-client-authn-core": "^1.6.0",
         "@types/form-urlencoded": "^2.0.1",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^14.14.14",
         "@types/uuid": "^8.3.0",
+        "assert": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
         "form-urlencoded": "^4.2.1",
         "jose": "^2.0.2",
         "lodash.clonedeep": "^4.5.0",
+        "os-browserify": "^0.3.0",
         "reflect-metadata": "^0.1.13",
         "stream-browserify": "^3.0.0",
         "tsyringe": "^4.4.0",
@@ -1448,9 +1451,20 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.28",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
-          "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g=="
+          "version": "14.14.31",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+        },
+        "assert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
         },
         "buffer": {
           "version": "6.0.3",
@@ -1482,9 +1496,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.5.1.tgz",
-      "integrity": "sha512-w0iAW8kiVmmX0fNVlwjcE1lkkuai/biUA5SZrCiRC4SEA30IEvuDzui1p3Ck5PJifEIIplB5wQmXnZzhu0GprQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.6.0.tgz",
+      "integrity": "sha512-eqFVAkqvYRXRKKOAYmv9VF5cCfrkxK+uhSCRaLj+iBoYuqB2Lk+3YBBtgvYSEzanRtXg3ZXhEHiGBYNxi8cXAw==",
       "requires": {
         "@inrupt/solid-common-vocab": "^0.5.3",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -3645,8 +3659,7 @@
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -5854,6 +5867,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -7777,6 +7795,15 @@
       "requires": {
         "global-dirs": "^2.0.1",
         "is-path-inside": "^3.0.1"
+      }
+    },
+    "is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "is-negative-zero": {
@@ -12091,6 +12118,15 @@
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -12162,9 +12198,9 @@
       }
     },
     "oidc-client": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.4.tgz",
-      "integrity": "sha512-71mEPaDr7g2Ji6t+e1fKLNKJL/XEuDXmXakDUJ9hVpmsLyQKY9kfbjeuDDAN6cP7Rhty3814he/aStqNLBREKA==",
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/oidc-client/-/oidc-client-1.11.5.tgz",
+      "integrity": "sha512-LcKrKC8Av0m/KD/4EFmo9Sg8fSQ+WFJWBrmtWd+tZkNn3WT/sQG3REmPANE9tzzhbjW6VkTNy4xhAXCfPApAOg==",
       "requires": {
         "acorn": "^7.4.1",
         "base64-js": "^1.5.1",
@@ -12173,20 +12209,15 @@
         "serialize-javascript": "^4.0.0"
       },
       "dependencies": {
-        "acorn": {
-          "version": "7.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
-        },
         "base64-js": {
           "version": "1.5.1",
           "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
           "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "core-js": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
+          "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ=="
         }
       }
     },

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -28,7 +28,6 @@ import {
   createThing,
   deleteFile,
   getSolidDataset,
-  getSourceIri,
   getSourceUrl,
   getStringNoLocale,
   getThing,

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -350,7 +350,6 @@ export function createContact(
   const emails = normalizedContact.emails.map(mapSchema("email"));
   const addresses = normalizedContact.addresses.map(mapSchema("address"));
   const telephones = normalizedContact.telephones.map(mapSchema("telephone"));
-
   const person = defineThing(
     { name: "this" },
     ...[(t) => addUrl(t, rdf.type, vcard.Individual), ...rootAttributeFns],
@@ -377,32 +376,6 @@ export function createContact(
     iri,
     dataset,
   };
-}
-
-// TODO: keeping this separate to maintain functionality but will likely adapt the old function to take a type if we need to reuse it for groups
-export async function findPersonContactInAddressBook(
-  addressBook,
-  webId,
-  fetch
-) {
-  const { dataset: addressBookDataset } = addressBook;
-  const { indexFilePredicate, contactTypeIri } = TYPE_MAP[foaf.Person];
-
-  const { response: indexFileDataset } = await getIndexDatasetFromAddressBook(
-    addressBookDataset,
-    indexFilePredicate,
-    fetch
-  );
-  const { response: people } = await getContacts(
-    indexFileDataset,
-    contactTypeIri,
-    fetch
-  );
-  const profiles = await getProfiles(people, fetch);
-  const existingContact = profiles.filter(
-    (profile) => asUrl(profile) === webId
-  );
-  return existingContact;
 }
 
 export async function findContactInAddressBook(people, webId, fetch) {

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -307,7 +307,7 @@ export async function getIndexDatasetFromAddressBook(
 ) {
   const { respond, error } = createResponder();
   try {
-    const addressBookIri = `${getSourceIri(addressBookDataset)}#this`; // TODO: Ugly hack, should remove
+    const addressBookIri = `${getSourceUrl(addressBookDataset)}#this`; // TODO: Ugly hack, should remove
     const addressBookThing = getThing(addressBookDataset, addressBookIri);
     const indexDatasetIri = getUrl(addressBookThing, indexFilePredicate);
     const indexFileDataset = await getSolidDataset(indexDatasetIri, { fetch });

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -450,7 +450,7 @@ export async function deleteContact(
   const addressBook = await getSolidDataset(addressBookIri, {
     fetch,
   });
-  const { indexFilePredicate } = TYPE_MAP[foaf.Person];
+  const { indexFilePredicate } = TYPE_MAP[type];
   const { response: indexFileDataset } = await getIndexDatasetFromAddressBook(
     addressBook,
     indexFilePredicate,

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -153,13 +153,10 @@ export async function getContacts(indexFileDataset, contactTypeIri, fetch) {
     return respond([]);
   }
   const contactsThings = getThingAll(indexFileDataset);
-
   const contactsIris = contactsThings.map((t) => asUrl(t));
-
   const contactsResponses = await Promise.all(
     contactsIris.map((iri) => getResource(iri, fetch))
   );
-
   const contacts = contactsResponses
     .filter(({ error: e }) => !e)
     .map(({ response }) => response)
@@ -389,7 +386,7 @@ export async function findPersonContactInAddressBook(
   fetch
 ) {
   const { dataset: addressBookDataset } = addressBook;
-  const { indexFilePredicate } = TYPE_MAP[foaf.Person];
+  const { indexFilePredicate, contactTypeIri } = TYPE_MAP[foaf.Person];
 
   const { response: indexFileDataset } = await getIndexDatasetFromAddressBook(
     addressBookDataset,
@@ -398,7 +395,7 @@ export async function findPersonContactInAddressBook(
   );
   const { response: people } = await getContacts(
     indexFileDataset,
-    foaf.Person,
+    contactTypeIri,
     fetch
   );
   const profiles = await getProfiles(people, fetch);

--- a/src/hooks/useContactProfile/index.js
+++ b/src/hooks/useContactProfile/index.js
@@ -22,9 +22,7 @@
 import { useSession } from "@inrupt/solid-ui-react";
 import useSWR from "swr";
 import { asUrl } from "@inrupt/solid-client";
-import { getResource } from "../../solidClientHelpers/resource";
-import { getWebIdUrl } from "../../addressBook";
-import { fetchProfile } from "../../solidClientHelpers/profile";
+import { getProfileForContact } from "../../models/profile";
 
 const getPersonThingUrl = (contact) => {
   let personThingUrl;
@@ -41,11 +39,7 @@ export default function useContactProfile(contact) {
   const personThingUrl = getPersonThingUrl(contact);
   return useSWR(["contact", personThingUrl], async () => {
     if (!personThingUrl) return null;
-    const {
-      response: { dataset, iri },
-    } = await getResource(personThingUrl, fetch);
-    const webId = getWebIdUrl(dataset, iri);
-    const fetchedProfile = await fetchProfile(webId, fetch);
-    return fetchedProfile;
+    const profile = await getProfileForContact(personThingUrl, fetch);
+    return profile;
   });
 }

--- a/src/hooks/useContactProfile/index.js
+++ b/src/hooks/useContactProfile/index.js
@@ -26,14 +26,19 @@ import { getResource } from "../../solidClientHelpers/resource";
 import { getWebIdUrl } from "../../addressBook";
 import { fetchProfile } from "../../solidClientHelpers/profile";
 
-export default function useContactProfile(contact) {
-  const { fetch } = useSession();
+const getPersonThingUrl = (contact) => {
   let personThingUrl;
   try {
     personThingUrl = asUrl(contact);
   } catch {
     personThingUrl = null;
   }
+  return personThingUrl;
+};
+
+export default function useContactProfile(contact) {
+  const { fetch } = useSession();
+  const personThingUrl = getPersonThingUrl(contact);
   return useSWR(["contact", personThingUrl], async () => {
     if (!personThingUrl) return null;
     const {

--- a/src/hooks/useContactProfile/index.test.js
+++ b/src/hooks/useContactProfile/index.test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { renderHook } from "@testing-library/react-hooks";
+import useSWR from "swr";
+import { useSession } from "@inrupt/solid-ui-react";
+import { createThing, mockThingFrom } from "@inrupt/solid-client";
+import useContactProfile from "./index";
+import * as profileFns from "../../solidClientHelpers/profile";
+import * as addressBookFns from "../../addressBook";
+import * as resourceFns from "../../solidClientHelpers/resource";
+
+jest.mock("@inrupt/solid-ui-react");
+jest.mock("swr");
+
+const mockedSwrHook = useSWR;
+
+describe("useContactProfile", () => {
+  const swrResponse = 42;
+
+  beforeEach(() => {
+    mockedSwrHook.mockReturnValue(swrResponse);
+  });
+
+  useSession.mockReturnValue({ fetch: jest.fn() });
+  it("exits if no person url", async () => {
+    const contactThing = createThing();
+    renderHook(() => useContactProfile(contactThing));
+    await expect(mockedSwrHook.mock.calls[0][1]()).resolves.toBeNull();
+  });
+
+  it("returns contact profile", async () => {
+    const contactThing = mockThingFrom(
+      "https://example.org/contacts/Person/1234"
+    );
+
+    const profile = {
+      name: "Example",
+      avatar: null,
+      webId: "https://example.org",
+    };
+
+    jest.spyOn(resourceFns, "getResource").mockResolvedValue({
+      response: {
+        dataset: contactThing,
+        iri: "https://example.org/contacts/Person/1234",
+      },
+    });
+
+    jest
+      .spyOn(addressBookFns, "getWebIdUrl")
+      .mockReturnValue("https://example.org");
+
+    jest.spyOn(profileFns, "fetchProfile").mockResolvedValue(profile);
+
+    renderHook(() => useContactProfile(contactThing));
+
+    await expect(mockedSwrHook.mock.calls[0][1]()).resolves.toEqual(profile);
+  });
+});

--- a/src/hooks/useContactProfile/index.test.js
+++ b/src/hooks/useContactProfile/index.test.js
@@ -24,7 +24,7 @@ import useSWR from "swr";
 import { useSession } from "@inrupt/solid-ui-react";
 import { createThing, mockThingFrom } from "@inrupt/solid-client";
 import useContactProfile from "./index";
-import * as profileFns from "../../solidClientHelpers/profile";
+import * as profileModel from "../../models/profile";
 import * as addressBookFns from "../../addressBook";
 import * as resourceFns from "../../solidClientHelpers/resource";
 
@@ -69,7 +69,7 @@ describe("useContactProfile", () => {
       .spyOn(addressBookFns, "getWebIdUrl")
       .mockReturnValue("https://example.org");
 
-    jest.spyOn(profileFns, "fetchProfile").mockResolvedValue(profile);
+    jest.spyOn(profileModel, "getProfileForContact").mockResolvedValue(profile);
 
     renderHook(() => useContactProfile(contactThing));
 

--- a/src/models/contact/group/index.js
+++ b/src/models/contact/group/index.js
@@ -55,6 +55,7 @@ export const GROUP_CONTACT = {
   indexFilePredicate: NAME_GROUP_INDEX_PREDICATE,
   contactTypeUrl: vcard.Group,
   isOfType: (contact) => getUrlAll(contact, rdf.type).includes(vcard.Group),
+  // TODO: need to add a createContact function here to create Group contact
 };
 
 /* Model internal functions */

--- a/src/models/contact/group/index.js
+++ b/src/models/contact/group/index.js
@@ -26,6 +26,7 @@ import {
   getSolidDataset,
   getSourceUrl,
   getThing,
+  getUrlAll,
   saveSolidDatasetAt,
   setStringNoLocale,
   setThing,
@@ -53,6 +54,7 @@ export const GROUP_CONTACT = {
   container: GROUP_CONTAINER,
   indexFilePredicate: NAME_GROUP_INDEX_PREDICATE,
   contactTypeUrl: vcard.Group,
+  isOfType: (contact) => getUrlAll(contact, rdf.type).includes(vcard.Group),
 };
 
 /* Model internal functions */

--- a/src/models/contact/group/index.js
+++ b/src/models/contact/group/index.js
@@ -55,7 +55,6 @@ export const GROUP_CONTACT = {
   indexFilePredicate: NAME_GROUP_INDEX_PREDICATE,
   contactTypeUrl: vcard.Group,
   isOfType: (contact) => getUrlAll(contact, rdf.type).includes(vcard.Group),
-  // TODO: need to add a createContact function here to create Group contact
 };
 
 /* Model internal functions */
@@ -95,7 +94,7 @@ export async function saveGroup(addressBook, name, fetch) {
   );
   // then link the group to the group index
   const {
-    updatedAddressBook,
+    addressBook: updatedAddressBook,
     indexUrl: groupIndexUrl,
   } = await addContactIndexToAddressBook(addressBook, GROUP_CONTACT, fetch);
 

--- a/src/models/contact/group/index.js
+++ b/src/models/contact/group/index.js
@@ -94,17 +94,11 @@ export async function saveGroup(addressBook, name, fetch) {
     { fetch }
   );
   // then link the group to the group index
-  let updatedAddressBook = addressBook;
-  let groupIndexUrl = getContactIndexUrl(addressBook, GROUP_CONTACT);
-  if (!groupIndexUrl) {
-    // add the index to the Address Book if it doesn't already exist
-    updatedAddressBook = await addContactIndexToAddressBook(
-      addressBook,
-      GROUP_CONTACT,
-      fetch
-    );
-    groupIndexUrl = getContactIndexUrl(updatedAddressBook, GROUP_CONTACT);
-  }
+  const {
+    updatedAddressBook,
+    indexUrl: groupIndexUrl,
+  } = await addContactIndexToAddressBook(addressBook, GROUP_CONTACT, fetch);
+
   const groupThing = createGroupThing(name, { url: groupThingUrl });
   const indexDataset = await updateOrCreateDataset(
     groupIndexUrl,

--- a/src/models/contact/group/index.test.js
+++ b/src/models/contact/group/index.test.js
@@ -84,6 +84,13 @@ beforeEach(() => {
     .mockImplementation((url) => mockSolidDatasetFrom(url));
 });
 
+describe("isOfType", () => {
+  it("returns true if contact is a group", () => {
+    const { thing: mockGroupThing } = mockGroup(group1Name, group1Url);
+    expect(GROUP_CONTACT.isOfType(mockGroupThing)).toBe(true);
+  });
+});
+
 describe("createGroupDatasetUrl", () => {
   it("creates a unique group URL", () => {
     mockedUuid.mockReturnValueOnce("1234").mockReturnValueOnce("5678");

--- a/src/models/contact/group/index.test.js
+++ b/src/models/contact/group/index.test.js
@@ -169,7 +169,7 @@ describe("saveGroup", () => {
   it("will create the corresponding index on the fly and link it to the addressBook", async () => {
     mockedSaveSolidDatasetAt
       .mockResolvedValueOnce(newGroup.dataset)
-      .mockResolvedValueOnce(addressBookWithGroupIndex)
+      .mockResolvedValueOnce(addressBookWithGroupIndex.dataset)
       .mockResolvedValueOnce(groupIndexWithGroup1Dataset);
 
     const { addressBook, group, groupIndex } = await saveGroup(

--- a/src/models/contact/group/index.test.js
+++ b/src/models/contact/group/index.test.js
@@ -169,7 +169,7 @@ describe("saveGroup", () => {
   it("will create the corresponding index on the fly and link it to the addressBook", async () => {
     mockedSaveSolidDatasetAt
       .mockResolvedValueOnce(newGroup.dataset)
-      .mockResolvedValueOnce(addressBookWithGroupIndex.dataset)
+      .mockResolvedValueOnce(addressBookWithGroupIndex)
       .mockResolvedValueOnce(groupIndexWithGroup1Dataset);
 
     const { addressBook, group, groupIndex } = await saveGroup(

--- a/src/models/contact/index.js
+++ b/src/models/contact/index.js
@@ -20,8 +20,11 @@
  */
 
 import {
+  addStringNoLocale,
+  addUrl,
   asUrl,
   createSolidDataset,
+  getSourceUrl,
   getThing,
   getThingAll,
   getUrl,
@@ -29,6 +32,10 @@ import {
   setThing,
   setUrl,
 } from "@inrupt/solid-client";
+import { vcard } from "rdf-namespaces";
+import { createResponder, defineThing } from "../../solidClientHelpers/utils";
+import { vcardExtras } from "../../addressBook";
+import { saveResource } from "../../solidClientHelpers/resource";
 import { joinPath } from "../../stringHelpers";
 import { getOrCreateDataset } from "../dataset";
 import { getAddressBookIndexUrl } from "../addressBook";
@@ -82,4 +89,45 @@ export async function addContactIndexToAddressBook(addressBook, type, fetch) {
     dataset,
     thing: getThing(dataset, asUrl(addressBook.thing, datasetUrl)),
   };
+}
+
+export async function saveContact(addressBook, contactSchema, type, fetch) {
+  const { respond, error } = createResponder();
+  const { containerUrl: addressBookContainerUrl } = addressBook;
+  const indexIri = getContactIndexUrl(addressBook, type);
+  const newContact = await type.createContact(
+    addressBookContainerUrl,
+    contactSchema
+  );
+  const { iri } = newContact;
+  const { response: contact, error: saveContactError } = await saveResource(
+    newContact,
+    fetch
+  );
+  if (saveContactError) return error(saveContactError);
+
+  const contactIndex = await getContactIndexDataset(addressBook, type, fetch);
+
+  const contactThing = defineThing(
+    {
+      url: `${getSourceUrl(contact)}#this`,
+    },
+    (t) =>
+      addStringNoLocale(t, vcard.fn, contactSchema.fn || contactSchema.name),
+    (t) => addUrl(t, vcardExtras("inAddressBook"), indexIri)
+  );
+
+  const contactIndexIri = getSourceUrl(contactIndex);
+  const contactResource = {
+    dataset: setThing(contactIndex, contactThing),
+    iri: contactIndexIri,
+  };
+
+  const { response: contacts, error: saveContactsError } = await saveResource(
+    contactResource,
+    fetch
+  );
+
+  if (saveContactsError) return error(saveContactsError);
+  return respond({ iri, contact, contacts });
 }

--- a/src/models/contact/index.js
+++ b/src/models/contact/index.js
@@ -85,7 +85,7 @@ export async function addContactIndexToAddressBook(addressBook, type, fetch) {
   }
 
   return {
-    updatedAddressBook,
+    addressBook: updatedAddressBook,
     indexUrl,
   };
 }

--- a/src/models/contact/index.js
+++ b/src/models/contact/index.js
@@ -25,12 +25,10 @@ import {
   getThing,
   getThingAll,
   getUrl,
-  getUrlAll,
   saveSolidDatasetAt,
   setThing,
   setUrl,
 } from "@inrupt/solid-client";
-import { rdf } from "rdf-namespaces";
 import { joinPath } from "../../stringHelpers";
 import { getOrCreateDataset } from "../dataset";
 import { getAddressBookIndexUrl } from "../addressBook";
@@ -58,9 +56,7 @@ export async function getContactAll(addressBook, types, fetch) {
     types.map(async (type) => {
       const dataset = await getContactIndexDataset(addressBook, type, fetch);
       return getThingAll(dataset)
-        .filter((contact) =>
-          getUrlAll(contact, rdf.type).includes(type.contactTypeUrl)
-        )
+        .filter((contact) => type.isOfType(contact))
         .map((thing) => ({
           thing,
           dataset,

--- a/src/models/contact/index.js
+++ b/src/models/contact/index.js
@@ -20,7 +20,9 @@
  */
 
 import {
+  asUrl,
   createSolidDataset,
+  getThing,
   getThingAll,
   getUrl,
   saveSolidDatasetAt,
@@ -73,7 +75,7 @@ export async function addContactIndexToAddressBook(addressBook, type, fetch) {
       type
     );
     const datasetUrl = getAddressBookIndexUrl(addressBook);
-    updatedAddressBook = await saveSolidDatasetAt(
+    const updatedAddressBookDataset = await saveSolidDatasetAt(
       datasetUrl,
       setThing(
         addressBook.dataset,
@@ -81,6 +83,11 @@ export async function addContactIndexToAddressBook(addressBook, type, fetch) {
       ),
       { fetch }
     );
+    updatedAddressBook = {
+      containerUrl: addressBook.containerUrl,
+      dataset: updatedAddressBookDataset,
+      thing: getThing(updatedAddressBookDataset, asUrl(addressBook.thing)),
+    };
     indexUrl = getContactIndexUrl(updatedAddressBook, type);
   }
 

--- a/src/models/contact/index.test.js
+++ b/src/models/contact/index.test.js
@@ -37,9 +37,7 @@ import {
   getContactIndexDataset,
   getContactIndexDefaultUrl,
   getContactIndexUrl,
-  saveContact,
 } from "./index";
-import * as resourceFns from "../../solidClientHelpers/resource";
 import { addGroupToMockedIndexDataset } from "../../../__testUtils/mockGroupContact";
 import { addPersonToMockedIndexDataset } from "../../../__testUtils/mockPersonContact";
 import { joinPath } from "../../stringHelpers";
@@ -237,13 +235,16 @@ describe("addContactIndexToAddressBook", () => {
   beforeEach(() => {
     mockedSaveSolidDatasetAt = jest
       .spyOn(solidClientFns, "saveSolidDatasetAt")
-      .mockResolvedValue(addressBookWithGroups.dataset);
+      .mockResolvedValue(addressBookWithGroups);
   });
 
   it("adds the contacts index to the address book", async () => {
     await expect(
       addContactIndexToAddressBook(addressBook, GROUP_CONTACT, fetch)
-    ).resolves.toEqual(addressBookWithGroups);
+    ).resolves.toEqual({
+      indexUrl: "https://example.pod.com/contacts/groups.ttl",
+      updatedAddressBook: addressBookWithGroups,
+    });
     expect(mockedSaveSolidDatasetAt).toHaveBeenCalledWith(
       getSourceUrl(addressBook.dataset),
       expect.any(Object),
@@ -260,112 +261,14 @@ describe("addContactIndexToAddressBook", () => {
     const newAddressBook = createAddressBook(containerUrl, webIdUrl);
     await expect(
       addContactIndexToAddressBook(newAddressBook, GROUP_CONTACT, fetch)
-    ).resolves.toEqual(addressBookWithGroups);
+    ).resolves.toEqual({
+      indexUrl: "https://example.pod.com/contacts/groups.ttl",
+      updatedAddressBook: addressBookWithGroups,
+    });
     expect(mockedSaveSolidDatasetAt).toHaveBeenCalledWith(
       getSourceUrl(addressBook.dataset),
       expect.any(Object),
       { fetch }
     );
-  });
-});
-// TODO: this currently only tests Person type until we have Groups
-describe("saveContact", () => {
-  const groupsUrl = "https://example.com/myGroups.ttl";
-  const peopleUrl = "https://example.com/myPeople.ttl";
-  const addressBook = chain(
-    mockAddressBook(),
-    (a) =>
-      addIndexToMockedAddressBook(a, PERSON_CONTACT, { indexUrl: peopleUrl }),
-    (a) =>
-      addIndexToMockedAddressBook(a, GROUP_CONTACT, { indexUrl: groupsUrl })
-  );
-  const addressBookDatasetIri = "https://user.example.com/contacts";
-  const webId = "https://user.example.com/card#me";
-  const contactDataset = solidClientFns.mockSolidDatasetFrom(webId);
-  const peopleIndexIri = `${addressBookDatasetIri}/people.ttl`;
-  const peopleIndexDataset = solidClientFns.mockSolidDatasetFrom(
-    peopleIndexIri
-  );
-
-  const schema = { webId, fn: "Test Person" };
-  const errorMessage = "boom";
-
-  beforeEach(() => {
-    jest
-      .spyOn(solidClientFns, "getSolidDataset")
-      .mockResolvedValue(peopleIndexDataset);
-  });
-
-  it("saves the contact and the people index", async () => {
-    jest
-      .spyOn(resourceFns, "saveResource")
-      .mockResolvedValueOnce({ response: contactDataset })
-      .mockResolvedValueOnce({ response: peopleIndexDataset });
-
-    jest.spyOn(resourceFns, "getResource").mockResolvedValueOnce({
-      response: {
-        iri: `${addressBookDatasetIri}/people.ttl`,
-        dataset: peopleIndexDataset,
-      },
-    });
-
-    const {
-      response: { contact, contacts },
-    } = await saveContact(addressBook, schema, PERSON_CONTACT, fetch);
-
-    expect(contact).toEqual(contactDataset);
-    expect(contacts).toEqual(peopleIndexDataset);
-  });
-
-  it("also handles schema.name", async () => {
-    jest
-      .spyOn(resourceFns, "saveResource")
-      .mockResolvedValueOnce({ response: contactDataset })
-      .mockResolvedValueOnce({ response: peopleIndexDataset });
-
-    jest.spyOn(resourceFns, "getResource").mockResolvedValueOnce({
-      response: {
-        iri: `${addressBookDatasetIri}/people.ttl`,
-        dataset: peopleIndexDataset,
-      },
-    });
-
-    const {
-      response: { contact, contacts },
-    } = await saveContact(addressBook, schema, PERSON_CONTACT, fetch);
-
-    expect(contact).toEqual(contactDataset);
-    expect(contacts).toEqual(peopleIndexDataset);
-  });
-
-  it("returns an error if it can't save the new contact", async () => {
-    jest.spyOn(resourceFns, "saveResource").mockResolvedValue({
-      error: errorMessage,
-    });
-
-    const { error } = await saveContact(
-      addressBook,
-      schema,
-      PERSON_CONTACT,
-      fetch
-    );
-
-    expect(error).toEqual(errorMessage);
-  });
-
-  it("returns an error if it can't save the new contact to the index", async () => {
-    jest
-      .spyOn(resourceFns, "saveResource")
-      .mockResolvedValueOnce({ response: contactDataset })
-      .mockResolvedValueOnce({ error: errorMessage });
-
-    const { error } = await saveContact(
-      addressBook,
-      schema,
-      PERSON_CONTACT,
-      fetch
-    );
-
-    expect(error).toEqual(errorMessage);
   });
 });

--- a/src/models/contact/index.test.js
+++ b/src/models/contact/index.test.js
@@ -30,7 +30,9 @@ import {
   mockSolidDatasetFrom,
 } from "@inrupt/solid-client";
 import { vcard } from "rdf-namespaces";
-import mockAddressBook from "../../../__testUtils/mockAddressBook";
+import mockAddressBook, {
+  mockEmptyAddressBook,
+} from "../../../__testUtils/mockAddressBook";
 import {
   addContactIndexToAddressBook,
   getContactAll,
@@ -235,7 +237,7 @@ describe("addContactIndexToAddressBook", () => {
   beforeEach(() => {
     mockedSaveSolidDatasetAt = jest
       .spyOn(solidClientFns, "saveSolidDatasetAt")
-      .mockResolvedValue(addressBookWithGroups);
+      .mockResolvedValue(addressBookWithGroups.dataset);
   });
 
   it("adds the contacts index to the address book", async () => {
@@ -258,7 +260,7 @@ describe("addContactIndexToAddressBook", () => {
   });
 
   it("also handles newly created address books (without any saved datasets)", async () => {
-    const newAddressBook = createAddressBook(containerUrl, webIdUrl);
+    const newAddressBook = mockEmptyAddressBook(containerUrl, webIdUrl);
     await expect(
       addContactIndexToAddressBook(newAddressBook, GROUP_CONTACT, fetch)
     ).resolves.toEqual({

--- a/src/models/contact/index.test.js
+++ b/src/models/contact/index.test.js
@@ -243,7 +243,7 @@ describe("addContactIndexToAddressBook", () => {
       addContactIndexToAddressBook(addressBook, GROUP_CONTACT, fetch)
     ).resolves.toEqual({
       indexUrl: "https://example.pod.com/contacts/groups.ttl",
-      updatedAddressBook: addressBookWithGroups,
+      addressBook: addressBookWithGroups,
     });
     expect(mockedSaveSolidDatasetAt).toHaveBeenCalledWith(
       getSourceUrl(addressBook.dataset),
@@ -263,7 +263,7 @@ describe("addContactIndexToAddressBook", () => {
       addContactIndexToAddressBook(newAddressBook, GROUP_CONTACT, fetch)
     ).resolves.toEqual({
       indexUrl: "https://example.pod.com/contacts/groups.ttl",
-      updatedAddressBook: addressBookWithGroups,
+      addressBook: addressBookWithGroups,
     });
     expect(mockedSaveSolidDatasetAt).toHaveBeenCalledWith(
       getSourceUrl(addressBook.dataset),

--- a/src/models/contact/person/index.js
+++ b/src/models/contact/person/index.js
@@ -61,8 +61,6 @@ export const PERSON_CONTACT = {
   indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
   contactTypeUrl: vcard.Individual,
   isOfType: (contact) => !!getUrl(contact, vcardExtras("inAddressBook")),
-  // eslint-disable-next-line no-use-before-define
-  createContact: createPersonContact,
 };
 
 /* Model functions */
@@ -94,7 +92,7 @@ export function createWebIdNode(webId, iri) {
   return { webIdNode, webIdNodeUrl };
 }
 
-export function createPersonContact(addressBook, contact) {
+function createPersonContact(addressBook, contact) {
   const { containerUrl: addressBookContainerUrl } = addressBook;
 
   const normalizedContact = {
@@ -145,9 +143,9 @@ export function createPersonContact(addressBook, contact) {
   };
 }
 
-export async function savePerson(addressBook, contactSchema, type, fetch) {
+export async function savePerson(addressBook, contactSchema, fetch) {
   const indexIri = asUrl(addressBook.thing);
-  const newContact = type.createContact(addressBook, contactSchema);
+  const newContact = createPersonContact(addressBook, contactSchema);
   const { iri, dataset } = newContact;
   const personDataset = await saveSolidDatasetAt(iri, dataset, { fetch });
   const personThing = defineThing(
@@ -160,7 +158,7 @@ export async function savePerson(addressBook, contactSchema, type, fetch) {
   );
 
   const {
-    updatedAddressBook,
+    addressBook: updatedAddressBook,
     indexUrl: personIndexUrl,
   } = await addContactIndexToAddressBook(addressBook, PERSON_CONTACT, fetch);
 
@@ -185,8 +183,6 @@ export async function findPersonContactInAddressBook(
 ) {
   const people = await getPersonAll(addressBook, fetch);
   const profiles = await getProfilesForPersonContacts(people, fetch);
-  const existingContact = profiles.filter(
-    (profile) => asUrl(profile) === webId
-  );
+  const existingContact = profiles.filter((profile) => profile.webId === webId);
   return existingContact;
 }

--- a/src/models/contact/person/index.js
+++ b/src/models/contact/person/index.js
@@ -21,6 +21,7 @@
 
 import { v4 as uuid } from "uuid";
 import { vcard } from "rdf-namespaces";
+import { getUrl } from "@inrupt/solid-client";
 import { vcardExtras } from "../../../addressBook";
 import { joinPath } from "../../../stringHelpers";
 import { getContactAll } from "../index";
@@ -40,6 +41,7 @@ export const PERSON_CONTACT = {
   indexFile: PEOPLE_INDEX_FILE,
   indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
   contactTypeUrl: vcard.Individual,
+  isOfType: (contact) => !!getUrl(contact, vcardExtras("inAddressBook")),
 };
 
 /* Model functions */

--- a/src/models/contact/person/index.js
+++ b/src/models/contact/person/index.js
@@ -20,11 +20,26 @@
  */
 
 import { v4 as uuid } from "uuid";
-import { vcard } from "rdf-namespaces";
-import { getUrl } from "@inrupt/solid-client";
-import { vcardExtras } from "../../../addressBook";
+import { vcard, foaf, rdf } from "rdf-namespaces";
+import {
+  addUrl,
+  asUrl,
+  createSolidDataset,
+  createThing,
+  getThing,
+  getUrl,
+  setThing,
+} from "@inrupt/solid-client";
+import {
+  getSchemaOperations,
+  mapSchema,
+  vcardExtras,
+} from "../../../addressBook";
 import { joinPath } from "../../../stringHelpers";
 import { getContactAll } from "../index";
+// eslint-disable-next-line import/no-cycle
+import { getProfilesForPersonContacts } from "../../profile";
+import { chain, defineThing } from "../../../solidClientHelpers/utils";
 
 /**
  * Person contacts represent the agents of type vcard:Individual, foaf:Person, schema:Person
@@ -42,6 +57,8 @@ export const PERSON_CONTACT = {
   indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
   contactTypeUrl: vcard.Individual,
   isOfType: (contact) => !!getUrl(contact, vcardExtras("inAddressBook")),
+  // eslint-disable-next-line no-use-before-define
+  createContact: createPersonContact,
 };
 
 /* Model functions */
@@ -51,4 +68,86 @@ export function createPersonDatasetUrl(addressBook, id = uuid()) {
 
 export async function getPersonAll(addressBook, fetch) {
   return getContactAll(addressBook, [PERSON_CONTACT], fetch);
+}
+
+export function getWebIdUrl(dataset, iri) {
+  const thing = getThing(dataset, iri);
+  const webIdNodeUrl = getUrl(thing, vcard.url);
+  if (webIdNodeUrl) {
+    const webIdNode = getThing(dataset, webIdNodeUrl);
+    return webIdNode && getUrl(webIdNode, vcard.value);
+  }
+  return getUrl(thing, foaf.openid);
+}
+
+export function createWebIdNode(webId, iri) {
+  const webIdNode = chain(
+    createThing(),
+    (t) => addUrl(t, rdf.type, vcardExtras("WebId")),
+    (t) => addUrl(t, vcard.value, webId)
+  );
+  const webIdNodeUrl = asUrl(webIdNode, iri);
+  return { webIdNode, webIdNodeUrl };
+}
+
+export async function createPersonContact(addressBookContainerUrl, contact) {
+  const normalizedContact = {
+    emails: [],
+    addresses: [],
+    telephones: [],
+    ...contact,
+  };
+
+  const id = uuid();
+  const iri = joinPath(
+    addressBookContainerUrl,
+    PERSON_CONTAINER,
+    id,
+    INDEX_FILE
+  );
+  const { webIdNode, webIdNodeUrl } = createWebIdNode(contact.webId, iri);
+  const rootAttributeFns = getSchemaOperations(contact, webIdNodeUrl);
+  const emails = normalizedContact.emails.map(mapSchema("email"));
+  const addresses = normalizedContact.addresses.map(mapSchema("address"));
+  const telephones = normalizedContact.telephones.map(mapSchema("telephone"));
+
+  const person = defineThing(
+    { name: "this" },
+    ...[(t) => addUrl(t, rdf.type, vcard.Individual), ...rootAttributeFns],
+    ...emails.map(({ name }) => {
+      return (t) => addUrl(t, vcard.hasEmail, [iri, name].join("#"));
+    }),
+    ...addresses.map(({ name }) => {
+      return (t) => addUrl(t, vcard.hasAddress, [iri, name].join("#"));
+    }),
+    ...telephones.map(({ name }) => {
+      return (t) => addUrl(t, vcard.hasTelephone, [iri, name].join("#"));
+    })
+  );
+  const dataset = chain(
+    createSolidDataset(),
+    (d) => setThing(d, person),
+    (d) => setThing(d, webIdNode),
+    ...emails
+      .concat(addresses)
+      .concat(telephones)
+      .map(({ thing }) => (d) => setThing(d, thing))
+  );
+  return {
+    iri,
+    dataset,
+  };
+}
+
+export async function findPersonContactInAddressBook(
+  addressBook,
+  webId,
+  fetch
+) {
+  const people = await getPersonAll(addressBook, fetch);
+  const profiles = await getProfilesForPersonContacts(people, fetch);
+  const existingContact = profiles.filter(
+    (profile) => asUrl(profile) === webId
+  );
+  return existingContact;
 }

--- a/src/models/contact/person/index.test.js
+++ b/src/models/contact/person/index.test.js
@@ -77,6 +77,12 @@ const addressBookWithPeopleIndex = addIndexToMockedAddressBook(
 );
 const person1 = mockPersonContact(emptyAddressBook, person1Url, person1Name);
 
+describe("isOfType", () => {
+  it("returns true if contact is a group", () => {
+    expect(PERSON_CONTACT.isOfType(person1.thing)).toBe(true);
+  });
+});
+
 describe("createPersonDatasetUrl", () => {
   it("creates a unique person URL", () => {
     mockedUuid.mockReturnValueOnce("1234").mockReturnValueOnce("5678");

--- a/src/models/contact/person/index.test.js
+++ b/src/models/contact/person/index.test.js
@@ -22,7 +22,27 @@
 import { v4 as uuid } from "uuid";
 import * as solidClientFns from "@inrupt/solid-client";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
-import { createPersonDatasetUrl, getPersonAll, PERSON_CONTACT } from "./index";
+import { vcard } from "rdf-namespaces";
+import { vcardExtras } from "../../../addressBook";
+import {
+  aliceAlternativeWebIdUrl,
+  aliceWebIdUrl,
+  bobWebIdUrl,
+  mockPersonDatasetAlice,
+  mockPersonDatasetBob,
+  mockWebIdNode,
+} from "../../../../__testUtils/mockPersonResource";
+import {
+  PERSON_CONTACT,
+  createPersonContact,
+  createPersonDatasetUrl,
+  findPersonContactInAddressBook,
+  getWebIdUrl,
+  getPersonAll,
+} from "./index";
+import * as contactModel from "..";
+import * as profileModel from "../../profile";
+
 import mockAddressBook from "../../../../__testUtils/mockAddressBook";
 import { chain } from "../../../solidClientHelpers/utils";
 import { addIndexToMockedAddressBook } from "../../../../__testUtils/mockContact";
@@ -43,6 +63,7 @@ const person1Url = `${person1DatasetUrl}#this`;
 const person1Name = "Person 1";
 
 const person2DatasetUrl = "https://example.com/contacts/Person/5678/index.ttl";
+const person2Url = `${person2DatasetUrl}#this`;
 
 const personIndexWithPerson1Dataset = chain(
   mockSolidDatasetFrom(peopleIndexDatasetUrl),
@@ -90,6 +111,155 @@ describe("getPersonAll", () => {
       .mockResolvedValue(mockSolidDatasetFrom(peopleIndexDatasetUrl));
     await expect(
       getPersonAll(addressBookWithPeopleIndex, fetch)
+    ).resolves.toEqual([]);
+  });
+});
+
+describe("getWebIdUrl", () => {
+  it("returns the webId for a given person dataset", () => {
+    const webIdUrl = "http://example.com/alice#me";
+    const { webIdNode } = mockWebIdNode(webIdUrl, aliceAlternativeWebIdUrl);
+    const personDataset = chain(
+      mockSolidDatasetFrom("http://example.com/alice"),
+      (d) => solidClientFns.setThing(d, mockPersonDatasetAlice()),
+      (d) => solidClientFns.setThing(d, webIdNode)
+    );
+
+    expect(getWebIdUrl(personDataset, aliceWebIdUrl)).toEqual(webIdUrl);
+  });
+});
+
+describe("createPersonContact", () => {
+  const addressBookIri = "https://user.example.com/contacts";
+  const webIdUrl = "https://user.example.com/card";
+
+  beforeEach(() => {
+    mockedUuid
+      .mockReturnValue("1234")
+      .mockReturnValueOnce("5678")
+      .mockReturnValueOnce("9012");
+  });
+
+  test("it creates a new contact with a given schema object", async () => {
+    const schema = {
+      webId: webIdUrl,
+      addresses: [
+        {
+          countryName: "Fake Country",
+          locality: "Fake Town",
+          postalCode: "55555",
+          region: "Fake State",
+          streetAddress: "123 Fake St.",
+        },
+      ],
+      fn: "Test Person",
+      emails: [
+        {
+          type: "Home",
+          value: "test@example.com",
+        },
+        {
+          type: "Work",
+          value: "test.person@example.com",
+        },
+      ],
+      telephones: [
+        {
+          type: "Home",
+          value: "555-555-5555",
+        },
+      ],
+      organizationName: "Test Company",
+      role: "Developer",
+    };
+
+    const { dataset } = await createPersonContact(addressBookIri, schema);
+
+    const things = solidClientFns.getThingAll(dataset);
+    const webId = things[0]; // always the first thing in this dataset
+    const addressesThing = things[4];
+    const emailsAndPhones = things.reduce(
+      (memo, t) =>
+        memo.concat(solidClientFns.getStringNoLocaleAll(t, vcard.value)),
+      []
+    );
+    const webIdThing = things[1];
+    expect(solidClientFns.getUrl(webIdThing, vcard.value)).toEqual(webIdUrl);
+    expect(solidClientFns.getStringNoLocale(webId, vcard.fn)).toEqual(
+      "Test Person"
+    );
+    expect(
+      solidClientFns.getStringNoLocale(webId, vcardExtras("organization-name"))
+    ).toEqual("Test Company");
+    expect(solidClientFns.getStringNoLocale(webId, vcard.role)).toEqual(
+      "Developer"
+    );
+    expect(emailsAndPhones).toContain("test@example.com");
+    expect(emailsAndPhones).toContain("test.person@example.com");
+    expect(emailsAndPhones).toContain("555-555-5555");
+    expect(
+      solidClientFns.getStringNoLocale(
+        addressesThing,
+        vcardExtras("country-name")
+      )
+    ).toEqual("Fake Country");
+    expect(
+      solidClientFns.getStringNoLocale(addressesThing, vcard.locality)
+    ).toEqual("Fake Town");
+    expect(
+      solidClientFns.getStringNoLocale(
+        addressesThing,
+        vcardExtras("postal-code")
+      )
+    ).toEqual("55555");
+    expect(
+      solidClientFns.getStringNoLocale(addressesThing, vcard.region)
+    ).toEqual("Fake State");
+    expect(
+      solidClientFns.getStringNoLocale(
+        addressesThing,
+        vcardExtras("street-address")
+      )
+    ).toEqual("123 Fake St.");
+  });
+});
+
+describe("findPersonContactInAddressBook", () => {
+  const addressBook = mockAddressBook();
+  const webId1Url = aliceWebIdUrl;
+  const webId2Url = bobWebIdUrl;
+  const webId1 = mockPersonDatasetAlice();
+  const person1Thing = mockPersonContact(addressBook, person1Url);
+  const webId2 = mockPersonDatasetBob();
+  const person2Thing = mockPersonContact(addressBook, person2Url);
+  const people = [
+    { dataset: webId1, thing: person1Thing },
+    { dataset: webId2, thing: person2Thing },
+  ];
+  const profiles = [
+    solidClientFns.mockThingFrom(webId1Url),
+    solidClientFns.mockThingFrom(webId2Url),
+  ];
+
+  beforeEach(() => {
+    jest.spyOn(contactModel, "getContactAll").mockResolvedValue(people);
+    jest
+      .spyOn(profileModel, "getProfilesForPersonContacts")
+      .mockResolvedValue(profiles);
+  });
+
+  it("finds a given WebId from a list of profiles fetched from a list of datasets about people", async () => {
+    const [profile1] = await findPersonContactInAddressBook(
+      addressBook,
+      webId1Url,
+      fetch
+    );
+    expect(solidClientFns.asUrl(profile1)).toEqual(webId1Url);
+  });
+
+  it("returns an empty list if no profile is found", async () => {
+    await expect(
+      findPersonContactInAddressBook(addressBook, webId2, fetch)
     ).resolves.toEqual([]);
   });
 });

--- a/src/models/profile/index.js
+++ b/src/models/profile/index.js
@@ -26,7 +26,7 @@ import {
   getThing,
   getUrl,
 } from "@inrupt/solid-client";
-
+import { fetchProfile } from "../../solidClientHelpers/profile";
 import { getResource } from "../../solidClientHelpers/resource";
 // eslint-disable-next-line import/no-cycle
 import { getWebIdUrl } from "../contact/person";
@@ -35,7 +35,14 @@ import { getWebIdUrl } from "../contact/person";
 
 /* Model functions */
 
-// eslint-disable-next-line import/prefer-default-export
+export async function getProfileForContact(personContactUrl, fetch) {
+  const {
+    response: { dataset, iri },
+  } = await getResource(personContactUrl, fetch);
+  const webId = getWebIdUrl(dataset, iri);
+  const fetchedProfile = await fetchProfile(webId, fetch);
+  return fetchedProfile;
+}
 export async function getProfilesForPersonContacts(people, fetch) {
   const peopleThings = await Promise.all(
     people.map(({ thing }) => getResource(asUrl(thing), fetch))

--- a/src/models/profile/index.js
+++ b/src/models/profile/index.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { vcard } from "rdf-namespaces";
+import {
+  addStringNoLocale,
+  asUrl,
+  getThing,
+  getUrl,
+} from "@inrupt/solid-client";
+
+import { getResource } from "../../solidClientHelpers/resource";
+// eslint-disable-next-line import/no-cycle
+import { getWebIdUrl } from "../contact/person";
+
+/* Model constants */
+
+/* Model functions */
+
+// eslint-disable-next-line import/prefer-default-export
+export async function getProfilesForPersonContacts(people, fetch) {
+  const peopleThings = await Promise.all(
+    people.map(({ thing }) => getResource(asUrl(thing), fetch))
+  );
+  const profileResponses = await Promise.all(
+    peopleThings.map(async ({ response: { dataset, iri } }) => {
+      const url = getWebIdUrl(dataset, iri);
+      return getResource(url, fetch);
+    })
+  );
+  return profileResponses
+    .filter(({ error }) => !error)
+    .map(({ response }) => response)
+    .map(({ dataset, iri }) => {
+      const thing = getThing(dataset, iri);
+      const avatar = getUrl(thing, vcard.hasPhoto);
+      return addStringNoLocale(getThing(thing, iri), vcard.hasPhoto, avatar);
+    });
+}

--- a/src/models/profile/index.js
+++ b/src/models/profile/index.js
@@ -19,13 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { vcard } from "rdf-namespaces";
-import {
-  addStringNoLocale,
-  asUrl,
-  getThing,
-  getUrl,
-} from "@inrupt/solid-client";
+import { asUrl, getThing } from "@inrupt/solid-client";
 import { fetchProfile } from "../../solidClientHelpers/profile";
 import { getResource } from "../../solidClientHelpers/resource";
 // eslint-disable-next-line import/no-cycle
@@ -58,7 +52,6 @@ export async function getProfilesForPersonContacts(people, fetch) {
     .map(({ response }) => response)
     .map(({ dataset, iri }) => {
       const thing = getThing(dataset, iri);
-      const avatar = getUrl(thing, vcard.hasPhoto);
-      return addStringNoLocale(getThing(thing, iri), vcard.hasPhoto, avatar);
+      return thing;
     });
 }

--- a/src/models/profile/index.js
+++ b/src/models/profile/index.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { asUrl, getThing } from "@inrupt/solid-client";
+import { asUrl } from "@inrupt/solid-client";
 import { fetchProfile } from "../../solidClientHelpers/profile";
 import { getResource } from "../../solidClientHelpers/resource";
 // eslint-disable-next-line import/no-cycle
@@ -38,20 +38,8 @@ export async function getProfileForContact(personContactUrl, fetch) {
   return fetchedProfile;
 }
 export async function getProfilesForPersonContacts(people, fetch) {
-  const peopleThings = await Promise.all(
-    people.map(({ thing }) => getResource(asUrl(thing), fetch))
+  const responses = await Promise.all(
+    people.map(({ thing }) => getProfileForContact(asUrl(thing), fetch))
   );
-  const profileResponses = await Promise.all(
-    peopleThings.map(async ({ response: { dataset, iri } }) => {
-      const url = getWebIdUrl(dataset, iri);
-      return getResource(url, fetch);
-    })
-  );
-  return profileResponses
-    .filter(({ error }) => !error)
-    .map(({ response }) => response)
-    .map(({ dataset, iri }) => {
-      const thing = getThing(dataset, iri);
-      return thing;
-    });
+  return responses.filter((profile) => profile);
 }

--- a/src/models/profile/index.test.js
+++ b/src/models/profile/index.test.js
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable camelcase */
+import { foaf, rdf } from "rdf-namespaces";
+import * as solidClientFns from "@inrupt/solid-client";
+import {
+  asUrl,
+  mockSolidDatasetFrom,
+  mockThingFrom,
+  setThing,
+  setUrl,
+} from "@inrupt/solid-client";
+import * as resourceFns from "../../solidClientHelpers/resource";
+import {
+  aliceAlternativeWebIdUrl,
+  aliceProfileUrl,
+  aliceWebIdUrl,
+  bobAlternateWebIdUrl,
+  bobProfileUrl,
+  bobWebIdUrl,
+  mockPersonDatasetAlice,
+  mockPersonDatasetBob,
+} from "../../../__testUtils/mockPersonResource";
+import mockPersonContactThing from "../../../__testUtils/mockPersonContactThing";
+import { chain } from "../../solidClientHelpers/utils";
+import { getProfilesForPersonContacts } from "./index";
+
+describe("getProfilesForPersonContacts", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("it fetches the profiles of the given people contacts", async () => {
+    const fetch = jest.fn();
+    const person1Iri =
+      "https://user.example.com/contacts/Person/1234/index.ttl";
+    const person2Iri =
+      "https://user.example.com/contacts/Person/1234/index.ttl";
+    const person1 = {
+      dataset: chain(mockSolidDatasetFrom(person1Iri), (d) =>
+        setThing(
+          d,
+          chain(mockThingFrom(person1Iri), (t) =>
+            setUrl(t, rdf.type, foaf.Person)
+          )
+        )
+      ),
+      thing: mockThingFrom(person1Iri),
+    };
+    const person2 = {
+      dataset: chain(mockSolidDatasetFrom(person2Iri), (d) =>
+        setThing(
+          d,
+          chain(mockThingFrom(person2Iri), (t) =>
+            setUrl(t, rdf.type, foaf.Person)
+          )
+        )
+      ),
+      thing: mockThingFrom(person2Iri),
+    };
+
+    jest
+      .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({
+        response: {
+          dataset: mockPersonContactThing(aliceAlternativeWebIdUrl),
+          iri: aliceAlternativeWebIdUrl,
+        },
+      })
+      .mockResolvedValueOnce({
+        response: {
+          dataset: mockPersonContactThing(bobAlternateWebIdUrl),
+          iri: bobAlternateWebIdUrl,
+        },
+      });
+
+    jest
+      .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({
+        response: {
+          dataset: setThing(
+            solidClientFns.mockSolidDatasetFrom(aliceProfileUrl),
+            mockPersonDatasetAlice()
+          ),
+          iri: aliceWebIdUrl,
+        },
+      })
+      .mockResolvedValueOnce({
+        response: {
+          dataset: setThing(
+            solidClientFns.mockSolidDatasetFrom(bobProfileUrl),
+            mockPersonDatasetBob()
+          ),
+          iri: bobWebIdUrl,
+        },
+      });
+
+    const [profile1, profile2] = await getProfilesForPersonContacts(
+      [person1, person2],
+      fetch
+    );
+
+    expect(asUrl(profile1)).toEqual(aliceWebIdUrl);
+    expect(asUrl(profile2)).toEqual(bobWebIdUrl);
+  });
+
+  test("it filters out people for which the resource couldn't be fetched", async () => {
+    const fetch = jest.fn();
+    const person1Iri =
+      "https://user.example.com/contacts/Person/1234/index.ttl";
+    const person2Iri =
+      "https://user.example.com/contacts/Person/1234/index.ttl";
+    const person1 = {
+      dataset: chain(mockSolidDatasetFrom(person1Iri), (d) =>
+        setThing(
+          d,
+          chain(mockThingFrom(person1Iri), (t) =>
+            setUrl(t, rdf.type, foaf.Person)
+          )
+        )
+      ),
+      thing: mockThingFrom(person1Iri),
+    };
+    const person2 = {
+      dataset: chain(mockSolidDatasetFrom(person2Iri), (d) =>
+        setThing(
+          d,
+          chain(mockThingFrom(person2Iri), (t) =>
+            setUrl(t, rdf.type, foaf.Person)
+          )
+        )
+      ),
+      thing: mockThingFrom(person2Iri),
+    };
+
+    jest
+      .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({
+        response: {
+          dataset: mockPersonContactThing(aliceAlternativeWebIdUrl),
+          iri: aliceAlternativeWebIdUrl,
+        },
+      })
+      .mockResolvedValueOnce({
+        response: {
+          dataset: mockPersonContactThing(bobAlternateWebIdUrl),
+          iri: bobAlternateWebIdUrl,
+        },
+      });
+
+    jest
+      .spyOn(resourceFns, "getResource")
+      .mockResolvedValueOnce({
+        response: {
+          dataset: setThing(
+            solidClientFns.mockSolidDatasetFrom(aliceProfileUrl),
+            mockPersonDatasetAlice()
+          ),
+          iri: aliceWebIdUrl,
+        },
+      })
+      .mockResolvedValueOnce({
+        error: "There was an error",
+      });
+
+    const profiles = await getProfilesForPersonContacts(
+      [person1, person2],
+      fetch
+    );
+
+    expect(profiles).toHaveLength(1);
+  });
+});

--- a/src/models/profile/index.test.js
+++ b/src/models/profile/index.test.js
@@ -23,7 +23,6 @@
 import { foaf, rdf } from "rdf-namespaces";
 import * as solidClientFns from "@inrupt/solid-client";
 import {
-  asUrl,
   mockSolidDatasetFrom,
   mockThingFrom,
   setThing,
@@ -45,6 +44,10 @@ import {
 import mockPersonContactThing from "../../../__testUtils/mockPersonContactThing";
 import { chain } from "../../solidClientHelpers/utils";
 import { getProfileForContact, getProfilesForPersonContacts } from "./index";
+import { fetchProfile } from "../../solidClientHelpers/profile";
+
+jest.mock("../../solidClientHelpers/profile");
+const mockedFetchProfile = fetchProfile;
 
 describe("getProfilesForPersonContacts", () => {
   afterEach(() => {
@@ -116,12 +119,11 @@ describe("getProfilesForPersonContacts", () => {
         },
       });
 
-    jest
-      .spyOn(profileFns, "fetchProfile")
+    mockedFetchProfile
       .mockResolvedValueOnce({
         webId: aliceWebIdUrl,
         avatar: null,
-        name: "Alice",
+        name: "Moo",
       })
       .mockResolvedValueOnce({
         webId: bobWebIdUrl,
@@ -134,8 +136,8 @@ describe("getProfilesForPersonContacts", () => {
       fetch
     );
 
-    expect(asUrl(profile1)).toEqual(aliceWebIdUrl);
-    expect(asUrl(profile2)).toEqual(bobWebIdUrl);
+    expect(profile1.webId).toEqual(aliceWebIdUrl);
+    expect(profile2.webId).toEqual(bobWebIdUrl);
   });
 
   test("it filters out people for which the resource couldn't be fetched", async () => {
@@ -197,7 +199,7 @@ describe("getProfilesForPersonContacts", () => {
         error: "There was an error",
       });
 
-    jest.spyOn(profileFns, "fetchProfile").mockResolvedValueOnce({
+    mockedFetchProfile.mockResolvedValueOnce({
       webId: aliceWebIdUrl,
       avatar: null,
       name: "Alice",

--- a/src/solidClientHelpers/utils.js
+++ b/src/solidClientHelpers/utils.js
@@ -156,3 +156,11 @@ export function sharedStart(...strings) {
   while (i < L && a1.charAt(i) === a2.charAt(i)) i++;
   return a1.substring(0, i);
 }
+
+export async function serializePromises(promiseFactories) {
+  return promiseFactories.reduce((promise, func) => {
+    return promise.then((result) =>
+      func()?.then(Array.prototype.concat.bind(result))
+    );
+  }, Promise.resolve([]));
+}

--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -40,6 +40,7 @@ import {
   getTypes,
   isContainerIri,
   namespace,
+  serializePromises,
   sharedStart,
 } from "./utils";
 
@@ -252,5 +253,19 @@ describe("sharedStart", () => {
     expect(sharedStart("foo", "bar")).toEqual("");
     expect(sharedStart("bar", "baz", "bam")).toEqual("ba");
     expect(sharedStart(undefined, "baz")).toEqual("");
+  });
+});
+
+describe("serializePromises", () => {
+  const asyncFn = async (str) => {
+    return new Promise((resolve) => resolve(str));
+  };
+  it("takes an array of promise factories and resolves them sequentially", async () => {
+    const strings = ["example1", "example2", "example3"];
+    const promiseFactories = strings.map((str) => () => asyncFn(str));
+    serializePromises(promiseFactories);
+    await expect(promiseFactories[0]()).resolves.toBe("example1");
+    await expect(promiseFactories[1]()).resolves.toBe("example2");
+    await expect(promiseFactories[2]()).resolves.toBe("example3");
   });
 });


### PR DESCRIPTION
# Multiselect agent picker

In this PR:

- adding contacts to agent picker modal table
- changing functionality to allow removing existing agents from a policy (they appeared as checked in the table when they already belong to a policy)
- adding tests
- Agent Picker Modal's filters (search bar and tabs) are functional now

Not in this PR:
- Sharing accordion permissions table tabs are still filtering by "profile.types", since I still do not know what permissions for groups will look like so it will have to be updated once groups permissions are available

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
