### PR TITLE
Feat: adjust footer copyright year to 2021

### DIFF
--- a/components/footer/index.jsx
+++ b/components/footer/index.jsx
@@ -37,7 +37,7 @@ export default function Footer({ atlassianFeedbackWidth }) {
       "data-testid": TESTCAFE_ID_TOS_LINK,
     },
   ];
-  const texts = [{ text: "Copyright 2020 Inrupt, inc." }];
+  const texts = [{ text: "Copyright 2021 Inrupt, inc." }];
   const style = atlassianFeedbackWidth
     ? {
         paddingRight: atlassianFeedbackWidth + theme.spacing(1),


### PR DESCRIPTION
The footer currently displays "Copyright 2020 Inrupt Inc.". This change updates that year to 2021.

- [ na ] I've added a unit test to test for potential regressions of this bug.
- [ na ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

