### PR TITLE
Fix/remove blocked policy box

### DIFF
--- a/components/resourceDetails/resourceSharing/sharingAccordion/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/sharingAccordion/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SharingAccordion renders three lists of named policies for editors, viewers and blocked and an Advanced Sharing button 1`] = `
+exports[`SharingAccordion renders two lists of named policies for editors and viewers and an Advanced Sharing button 1`] = `
 <DocumentFragment>
   <div
     class="PodBrowser-root PodBrowser-root PodBrowser-accordion PodBrowser-expanded PodBrowser-rounded PodBrowser-rounded PodBrowser-elevation1 PodBrowser-rounded"
@@ -174,94 +174,6 @@ exports[`SharingAccordion renders three lists of named policies for editors, vie
               >
                 <p>
                   No viewers
-                </p>
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="PodBrowser-root PodBrowser-root PodBrowser-accordion PodBrowser-expanded PodBrowser-rounded PodBrowser-rounded PodBrowser-elevation1 PodBrowser-rounded"
-    data-testid="agent-access-table"
-  >
-    <div
-      class="PodBrowser-headerContainer"
-    >
-      <i
-        class="PodBrowser-icon-block PodBrowser-icon PodBrowser-iconBlocked"
-      />
-      <div
-        class="PodBrowser-textContainer"
-      >
-        <div
-          class="PodBrowser-titleAndButtonContainer"
-        >
-          <p
-            class="PodBrowser-title"
-          >
-            Blocked
-          </p>
-          <button
-            class="PodBrowser-button PodBrowser-button--text"
-            data-testid="add-agent-button"
-          >
-            <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
-            />
-            <span
-              class="PodBrowser-button__text"
-            >
-              Edit Blocked
-            </span>
-          </button>
-          <button
-            class="PodBrowser-button PodBrowser-button--icon-only PodBrowser-action-button"
-          >
-            <span
-              class="PodBrowser-button__text"
-            >
-              <span
-                aria-label="Show menu for policy"
-                class="PodBrowser-icon-more"
-              />
-            </span>
-          </button>
-        </div>
-        <span
-          class="PodBrowser-description"
-        >
-          <p>
-            <b>
-              Cannot 
-            </b>
-            view this resource
-          </p>
-        </span>
-      </div>
-    </div>
-    <div
-      class="PodBrowser-container PodBrowser-entered"
-      style="min-height: 0px;"
-    >
-      <div
-        class="PodBrowser-wrapper"
-      >
-        <div
-          class="PodBrowser-wrapperInner"
-        >
-          <div
-            role="region"
-          >
-            <div
-              class="PodBrowser-permissionsContainer"
-            >
-              <span
-                class="PodBrowser-emptyStateTextContainer"
-              >
-                <p>
-                  No one is blocked
                 </p>
               </span>
             </div>
@@ -464,94 +376,6 @@ exports[`SharingAccordion when resource is a container renders an info box which
               >
                 <p>
                   No viewers
-                </p>
-              </span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="PodBrowser-root PodBrowser-root PodBrowser-accordion PodBrowser-expanded PodBrowser-rounded PodBrowser-rounded PodBrowser-elevation1 PodBrowser-rounded"
-    data-testid="agent-access-table"
-  >
-    <div
-      class="PodBrowser-headerContainer"
-    >
-      <i
-        class="PodBrowser-icon-block PodBrowser-icon PodBrowser-iconBlocked"
-      />
-      <div
-        class="PodBrowser-textContainer"
-      >
-        <div
-          class="PodBrowser-titleAndButtonContainer"
-        >
-          <p
-            class="PodBrowser-title"
-          >
-            Blocked
-          </p>
-          <button
-            class="PodBrowser-button PodBrowser-button--text"
-            data-testid="add-agent-button"
-          >
-            <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
-            />
-            <span
-              class="PodBrowser-button__text"
-            >
-              Edit Blocked
-            </span>
-          </button>
-          <button
-            class="PodBrowser-button PodBrowser-button--icon-only PodBrowser-action-button"
-          >
-            <span
-              class="PodBrowser-button__text"
-            >
-              <span
-                aria-label="Show menu for policy"
-                class="PodBrowser-icon-more"
-              />
-            </span>
-          </button>
-        </div>
-        <span
-          class="PodBrowser-description"
-        >
-          <p>
-            <b>
-              Cannot 
-            </b>
-            view this resource
-          </p>
-        </span>
-      </div>
-    </div>
-    <div
-      class="PodBrowser-container PodBrowser-entered"
-      style="min-height: 0px;"
-    >
-      <div
-        class="PodBrowser-wrapper"
-      >
-        <div
-          class="PodBrowser-wrapperInner"
-        >
-          <div
-            role="region"
-          >
-            <div
-              class="PodBrowser-permissionsContainer"
-            >
-              <span
-                class="PodBrowser-emptyStateTextContainer"
-              >
-                <p>
-                  No one is blocked
                 </p>
               </span>
             </div>

--- a/components/resourceDetails/resourceSharing/sharingAccordion/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/sharingAccordion/index.test.jsx
@@ -61,11 +61,11 @@ describe("SharingAccordion", () => {
     });
   });
   // Note: since the permissions cannot be mocked reliably for the custom policies, those are tested separately in the table component
-  it("renders three lists of named policies for editors, viewers and blocked and an Advanced Sharing button", () => {
+  it("renders two lists of named policies for editors and viewers and an Advanced Sharing button", () => {
     const { asFragment, queryAllByTestId, queryByTestId } = renderWithTheme(
       <SharingAccordion />
     );
-    expect(queryAllByTestId(TESTCAFE_ID_AGENT_ACCESS_TABLE)).toHaveLength(3);
+    expect(queryAllByTestId(TESTCAFE_ID_AGENT_ACCESS_TABLE)).toHaveLength(2);
     expect(queryByTestId(TESTCAFE_ID_ADVANCED_SHARING_BUTTON)).not.toBeNull();
     expect(asFragment()).toMatchSnapshot();
   });

--- a/constants/policies.js
+++ b/constants/policies.js
@@ -148,4 +148,5 @@ const {
 
 export const customPolicies = [viewAndAdd, editOnly, addOnly];
 
-export const namedPolicies = [editors, viewers, blocked];
+// TODO: add blocked to this list once we have deny policies
+export const namedPolicies = [editors, viewers];

--- a/constants/policies.js
+++ b/constants/policies.js
@@ -140,6 +140,7 @@ export const POLICIES_TYPE_MAP = {
 const {
   editors,
   viewers,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   blocked,
   viewAndAdd,
   editOnly,

--- a/src/models/policy/index.test.js
+++ b/src/models/policy/index.test.js
@@ -107,11 +107,12 @@ describe("getPolicyResourceUrl", () => {
   });
 });
 
+// TODO: add blocked to named policies list once we have deny policies
+
 describe("getPolicyType", () => {
   it("returns something for known policy types", () => {
     expect(getPolicyType("editors")).toBeDefined();
     expect(getPolicyType("viewers")).toBeDefined();
-    expect(getPolicyType("blocked")).toBeDefined();
     expect(getPolicyType("viewAndAdd")).toBeDefined();
     expect(getPolicyType("editOnly")).toBeDefined();
     expect(getPolicyType("addOnly")).toBeDefined();
@@ -123,7 +124,6 @@ describe("isCustomPolicy", () => {
   it("returns true for custom policies", () => {
     expect(isCustomPolicy("editors")).toBe(false);
     expect(isCustomPolicy("viewers")).toBe(false);
-    expect(isCustomPolicy("blocked")).toBe(false);
     expect(isCustomPolicy("viewAndAdd")).toBe(true);
     expect(isCustomPolicy("editOnly")).toBe(true);
     expect(isCustomPolicy("addOnly")).toBe(true);
@@ -134,7 +134,6 @@ describe("isNamedPolicy", () => {
   it("returns true for named policies", () => {
     expect(isNamedPolicy("editors")).toBe(true);
     expect(isNamedPolicy("viewers")).toBe(true);
-    expect(isNamedPolicy("blocked")).toBe(true);
     expect(isNamedPolicy("viewAndAdd")).toBe(false);
     expect(isNamedPolicy("editOnly")).toBe(false);
     expect(isNamedPolicy("addOnly")).toBe(false);


### PR DESCRIPTION
This PR fixes: remove blocked policy box 

Since we still don't have the functionality to deny access, we are temporarily removing this policy box from the sharing accordion.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
