### PR TITLE
fix: change error message when deleting a non-empty container

### DIFF
--- a/components/deleteButton/index.jsx
+++ b/components/deleteButton/index.jsx
@@ -88,7 +88,7 @@ export default function DeleteButton({
   dialogId,
   onDelete,
   successMessage,
-  resourceIri,
+  resourceName,
   ...buttonProps
 }) {
   const bem = useBem(useStyles());
@@ -106,7 +106,7 @@ export default function DeleteButton({
   function onDeleteError(e) {
     setSeverity("error");
     if (isHTTPError(e, 409)) {
-      setMessage(`Cannot delete ${resourceIri} as it still contains files.`);
+      setMessage(`${resourceName} has files in it and cannot be deleted.`);
     } else {
       setMessage(e.toString());
     }
@@ -165,5 +165,5 @@ DeleteButton.propTypes = {
   dialogId: T.string.isRequired,
   onDelete: T.func.isRequired,
   successMessage: T.string.isRequired,
-  resourceIri: T.string.isRequired,
+  resourceName: T.string.isRequired,
 };

--- a/components/deleteButton/index.jsx
+++ b/components/deleteButton/index.jsx
@@ -27,6 +27,7 @@ import T from "prop-types";
 import AlertContext from "../../src/contexts/alertContext";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
 import styles from "./styles";
+import { isHTTPError } from "../../src/error";
 
 const TESTCAFE_ID_DELETE_BUTTON = "delete-button";
 
@@ -87,6 +88,7 @@ export default function DeleteButton({
   dialogId,
   onDelete,
   successMessage,
+  resourceIri,
   ...buttonProps
 }) {
   const bem = useBem(useStyles());
@@ -103,7 +105,11 @@ export default function DeleteButton({
 
   function onDeleteError(e) {
     setSeverity("error");
-    setMessage(e.toString());
+    if (isHTTPError(e, 409)) {
+      setMessage(`Cannot delete ${resourceIri} as it still contains files`);
+    } else {
+      setMessage(e.toString());
+    }
     setAlertOpen(true);
   }
 
@@ -159,4 +165,5 @@ DeleteButton.propTypes = {
   dialogId: T.string.isRequired,
   onDelete: T.func.isRequired,
   successMessage: T.string.isRequired,
+  resourceIri: T.string.isRequired,
 };

--- a/components/deleteButton/index.jsx
+++ b/components/deleteButton/index.jsx
@@ -106,7 +106,7 @@ export default function DeleteButton({
   function onDeleteError(e) {
     setSeverity("error");
     if (isHTTPError(e, 409)) {
-      setMessage(`Cannot delete ${resourceIri} as it still contains files`);
+      setMessage(`Cannot delete ${resourceIri} as it still contains files.`);
     } else {
       setMessage(e.toString());
     }

--- a/components/deleteResourceButton/index.jsx
+++ b/components/deleteResourceButton/index.jsx
@@ -60,7 +60,6 @@ export default function DeleteResourceButton({
 }) {
   const { fetch } = useSession();
   const router = useRouter();
-
   const { alertError } = useContext(AlertContext);
   const policiesContainerUrl = usePoliciesContainerUrl(resourceIri);
   const { data: resourceInfo, error: resourceError } = useResourceInfo(
@@ -86,7 +85,7 @@ export default function DeleteResourceButton({
       confirmationContent={`Are you sure you wish to delete ${name}?`}
       dialogId={`delete-resource-${resourceIri}`}
       onDelete={handleDelete}
-      resourceIri={resourceIri}
+      resourceName={name}
       successMessage={`${name} was successfully deleted.`}
       {...buttonProps}
     >

--- a/components/deleteResourceButton/index.jsx
+++ b/components/deleteResourceButton/index.jsx
@@ -86,6 +86,7 @@ export default function DeleteResourceButton({
       confirmationContent={`Are you sure you wish to delete ${name}?`}
       dialogId={`delete-resource-${resourceIri}`}
       onDelete={handleDelete}
+      resourceIri={resourceIri}
       successMessage={`${name} was successfully deleted.`}
       {...buttonProps}
     >


### PR DESCRIPTION
This PR fixes our error message when deleting a non-empty container to make it more understandable for users. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
