### PR TITLE
fix: anchor transform permission Add popover to the bottom

### DIFF
--- a/components/addPermissionUsingWebIdButton/index.jsx
+++ b/components/addPermissionUsingWebIdButton/index.jsx
@@ -161,7 +161,7 @@ export default function AddPermissionUsingWebIdButton({
           horizontal: "center",
         }}
         transformOrigin={{
-          vertical: "top",
+          vertical: "bottom",
           horizontal: "center",
         }}
       >

--- a/components/addPermissionUsingWebIdButton/index.jsx
+++ b/components/addPermissionUsingWebIdButton/index.jsx
@@ -155,9 +155,10 @@ export default function AddPermissionUsingWebIdButton({
         classes={classes}
         open={open}
         anchorEl={anchorEl}
+        getContentAnchorEl={null}
         onClose={handleClose}
         anchorOrigin={{
-          vertical: "bottom",
+          vertical: "top",
           horizontal: "center",
         }}
         transformOrigin={{
@@ -176,6 +177,7 @@ export default function AddPermissionUsingWebIdButton({
           <InputGroup>
             <Label>Assign permissions</Label>
             <PermissionsForm
+              isMenu
               acl={access}
               onChange={setAccess}
               disabled={disabled}

--- a/components/permissionsForm/index.jsx
+++ b/components/permissionsForm/index.jsx
@@ -66,6 +66,7 @@ export default function PermissionsForm({
   disabled: propsDisabled,
   onChange,
   webId,
+  isMenu,
 }) {
   const classes = useStyles();
   const { session } = useSession();
@@ -86,16 +87,20 @@ export default function PermissionsForm({
 
   return (
     <div className={classes.container}>
-      <Button
-        data-testid={TESTCAFE_ID_PERMISSIONS_DROPDOWN_BUTTON}
-        className={classes.summary}
-        onClick={toggleOpen(formOpen, setFormOpen)}
-        endIcon={arrowIcon(formOpen)}
-      >
-        <span>{displayPermissions(access)}</span>
-      </Button>
+      {!isMenu ? (
+        <Button
+          data-testid={TESTCAFE_ID_PERMISSIONS_DROPDOWN_BUTTON}
+          className={classes.summary}
+          onClick={toggleOpen(formOpen, setFormOpen)}
+          endIcon={arrowIcon(formOpen)}
+        >
+          <span>{displayPermissions(access)}</span>
+        </Button>
+      ) : null}
       <section
-        className={formOpen ? classes.selectionOpen : classes.selectionClosed}
+        className={
+          formOpen || isMenu ? classes.selectionOpen : classes.selectionClosed
+        }
       >
         <List>
           <PermissionCheckbox
@@ -140,6 +145,7 @@ PermissionsForm.propTypes = {
     append: T.bool.isRequired,
     control: T.bool.isRequired,
   }),
+  isMenu: T.bool,
   webId: T.string,
   children: T.node,
   disabled: T.bool,
@@ -153,6 +159,7 @@ PermissionsForm.defaultProps = {
     append: false,
     control: false,
   },
+  isMenu: false,
   children: null,
   disabled: null,
   webId: null,


### PR DESCRIPTION
This PR fixes bug where the permissions "Add WebId" button would go off the screen when the content of the popover grows. The solution in this PR is to have the vertical growth start from the bottom of the popover, so it grows upwards vertically and it doesn't go off the screen.

Update: after discussion with @KyraAssaad we decided to always display the options for a new WebId to prevent the popover from repositioning when state changes. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
