### PR TITLE
fix: validate WebId when adding it to permissions

### DIFF
--- a/components/addContact/__snapshots__/index.test.jsx.snap
+++ b/components/addContact/__snapshots__/index.test.jsx.snap
@@ -54,8 +54,8 @@ exports[`AddContact it renders the Add Contact form 1`] = `
       <input
         class="PodBrowser-input"
         id="id1"
-        pattern="https://.+"
-        title="Must start with https://"
+        pattern="https:\\\\/\\\\/\\\\S+"
+        title="Must be a valid URL that starts with https:// and does not contain spaces"
         type="url"
         value=""
       />

--- a/components/agentSearchForm/__snapshots__/index.test.jsx.snap
+++ b/components/agentSearchForm/__snapshots__/index.test.jsx.snap
@@ -13,8 +13,8 @@ exports[`AgentSearchForm it has a default heading 1`] = `
     <input
       class="PodBrowser-input"
       id="id2"
-      pattern="https://.+"
-      title="Must start with https://"
+      pattern="https:\\\\/\\\\/\\\\S+"
+      title="Must be a valid URL that starts with https:// and does not contain spaces"
       type="url"
       value=""
     />
@@ -46,8 +46,8 @@ exports[`AgentSearchForm it renders an AgentSearchForm 1`] = `
     <input
       class="PodBrowser-input"
       id="id1"
-      pattern="https://.+"
-      title="Must start with https://"
+      pattern="https:\\\\/\\\\/\\\\S+"
+      title="Must be a valid URL that starts with https:// and does not contain spaces"
       type="url"
       value=""
     />

--- a/components/agentSearchForm/index.jsx
+++ b/components/agentSearchForm/index.jsx
@@ -138,8 +138,8 @@ export default function AgentSearchForm({
         onChange={handleChange}
         value={value}
         type="url"
-        pattern="https://.+"
-        title="Must start with https://"
+        pattern="https:\/\/\S+"
+        title="Must be a valid URL that starts with https:// and does not contain spaces"
         onBlur={onBlur}
         required={invalidWebIdField}
         variant={existingWebId || isPodOwner ? "invalid" : null}

--- a/components/pages/contacts/add/__snapshots__/index.test.jsx.snap
+++ b/components/pages/contacts/add/__snapshots__/index.test.jsx.snap
@@ -32,8 +32,8 @@ exports[`AddContactPage renders 1`] = `
       <input
         class="PodBrowser-input"
         id="id1"
-        pattern="https://.+"
-        title="Must start with https://"
+        pattern="https:\\\\/\\\\/\\\\S+"
+        title="Must be a valid URL that starts with https:// and does not contain spaces"
         type="url"
         value=""
       />


### PR DESCRIPTION
This PR changes the pattern used for validation so that it checks not only that the WebId begins with `https://` but also that it does not contain spaces.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
