### PR TITLE
Fix: hide action button for inherited access

### DIFF
--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/index.jsx
@@ -34,7 +34,7 @@ import { makeStyles } from "@material-ui/styles";
 import RemoveButton from "./removeButton";
 import styles from "./styles";
 
-const TESTCAFE_ID_MENU_BUTTON = "menu-button";
+export const TESTCAFE_ID_MENU_BUTTON = "menu-button";
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 export default function AgentAccessOptionsMenu({

--- a/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AgentProfileDetails does not render action button for inherited permissions 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-nameAndAvatarContainer"
+  >
+    <div
+      class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+    >
+      <span
+        class="PodBrowser-icon-user PodBrowser-avatar__icon"
+      />
+    </div>
+    <p
+      class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
+      data-testid="agent-web-id"
+    >
+      Example Agent
+    </p>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`AgentProfileDetails renders action button for non-inherited permissions 1`] = `
+<DocumentFragment>
+  <div
+    class="PodBrowser-nameAndAvatarContainer"
+  >
+    <div
+      class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+    >
+      <span
+        class="PodBrowser-icon-user PodBrowser-avatar__icon"
+      />
+    </div>
+    <p
+      class="PodBrowser-root PodBrowser-detailText PodBrowser-body1 PodBrowser-detailText"
+      data-testid="agent-web-id"
+    >
+      Example Agent
+    </p>
+    <button
+      class="PodBrowser-button"
+      data-testid="menu-button"
+      type="button"
+    >
+      <i
+        class="PodBrowser-icon-more"
+      />
+    </button>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`AgentProfileDetails renders correctly for authenticated agent 1`] = `
 <DocumentFragment>
   <div

--- a/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/index.jsx
@@ -97,13 +97,15 @@ export default function AgentProfileDetails({
       >
         {localProfile ? displayProfileName(localProfile) : webId}
       </Typography>
-      <AgentAccessOptionsMenu
-        resourceIri={resourceIri}
-        permission={permission}
-        setLoading={setLoading}
-        setLocalAccess={setLocalAccess}
-        mutatePermissions={mutatePermissions}
-      />
+      {!permission.inherited ? (
+        <AgentAccessOptionsMenu
+          resourceIri={resourceIri}
+          permission={permission}
+          setLoading={setLoading}
+          setLocalAccess={setLocalAccess}
+          mutatePermissions={mutatePermissions}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/index.test.jsx
@@ -25,6 +25,7 @@ import AgentProfileDetails from "./index";
 import { renderWithTheme } from "../../../../../__testUtils/withTheme";
 import { PUBLIC_AGENT_PREDICATE } from "../../../../../src/models/contact/public";
 import { AUTHENTICATED_AGENT_PREDICATE } from "../../../../../src/models/contact/authenticated";
+import { TESTCAFE_ID_MENU_BUTTON } from "../agentAccessOptionsMenu";
 
 const webId = "https://example.com/profile/card#me";
 
@@ -67,6 +68,40 @@ describe("AgentProfileDetails", () => {
       />
     );
     expect(asFragment()).toMatchSnapshot();
+  });
+  it("renders action button for non-inherited permissions", () => {
+    const { asFragment, getByTestId } = renderWithTheme(
+      <AgentProfileDetails
+        resourceIri={resourceIri}
+        permission={permission}
+        profile={profile}
+        setLoading={jest.fn()}
+        setLocalAccess={jest.fn()}
+        mutatePermissions={jest.fn()}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(getByTestId(TESTCAFE_ID_MENU_BUTTON)).not.toBeNull();
+  });
+  it("does not render action button for inherited permissions", () => {
+    const inheritedPermission = {
+      webId,
+      alias: "editors",
+      type: "agent",
+      inherited: true,
+    };
+    const { asFragment, queryByTestId } = renderWithTheme(
+      <AgentProfileDetails
+        resourceIri={resourceIri}
+        permission={inheritedPermission}
+        profile={profile}
+        setLoading={jest.fn()}
+        setLocalAccess={jest.fn()}
+        mutatePermissions={jest.fn()}
+      />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    expect(queryByTestId(TESTCAFE_ID_MENU_BUTTON)).toBeNull();
   });
 
   it("renders correctly for public agent", () => {


### PR DESCRIPTION
This PR hides the action button for agents who have inherited access, since we are not yet handling the removal of inherited access.

To test this, be are aware of the bug in inheritance which makes inherited access for the second policy added only accessible through a private browser window. 

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
