### PR TITLE
Chore: remove unnecessary font style sheet link

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -32,10 +32,6 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
           <meta name="theme-color" content={theme.palette.primary.main} />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Raleway:400,700|Roboto:300,400,700&display=swap"
-          />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
This PR removes an unnecessary style sheet link for a font.