### PR TITLE
Disabling checkboxes for permissions from inherited policies

### DIFF
--- a/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
@@ -68,6 +68,7 @@ import {
   AUTHENTICATED_AGENT_PREDICATE,
 } from "../../../../src/models/contact/authenticated";
 import ResourceInfoContext from "../../../../src/contexts/resourceInfoContext";
+import { getWebIdsFromPermissions } from "../../../../src/accessControl/acp";
 
 export const handleSubmit = ({
   newAgentsWebIds,
@@ -221,7 +222,7 @@ function AgentPickerModal(
     PERSON_CONTACT,
   ]);
 
-  const webIdsInPermissions = permissions?.map((p) => p.webId);
+  const webIdsInPermissions = getWebIdsFromPermissions(permissions);
 
   const bem = useBem(useStyles());
 
@@ -447,9 +448,9 @@ function AgentPickerModal(
                   value={value}
                   index={index}
                   addingWebId={addingWebId}
+                  permissions={permissions}
                   toggleCheckbox={toggleCheckbox}
                   newAgentsWebIds={newAgentsWebIds}
-                  webIdsInPermissions={webIdsInPermissions}
                   webIdsToDelete={webIdsToDelete}
                 />
               )}

--- a/components/resourceDetails/resourceSharing/agentPickerModal/webIdCheckbox/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/webIdCheckbox/index.test.jsx
@@ -36,8 +36,15 @@ describe("WebIdCheckbox", () => {
   const addingWebId = false;
   const toggleCheckbox = jest.fn();
   const newAgentsWebIds = [];
-  const webIdsInPermissions = [];
+  const permissions = [];
   const webIdsToDelete = [];
+
+  beforeEach(() => {
+    mockedUseContactProfile.mockReturnValue({
+      data: { webId },
+    });
+  });
+
   test("renders a checkbox with the correct value", () => {
     mockedUseContactProfile.mockReturnValue({
       data: { webId: "https://somewebid.com" },
@@ -50,7 +57,7 @@ describe("WebIdCheckbox", () => {
         addingWebId={addingWebId}
         toggleCheckbox={toggleCheckbox}
         newAgentsWebIds={newAgentsWebIds}
-        webIdsInPermissions={webIdsInPermissions}
+        permissions={permissions}
         webIdsToDelete={webIdsToDelete}
       />
     );
@@ -70,7 +77,7 @@ describe("WebIdCheckbox", () => {
         addingWebId={addingWebId}
         toggleCheckbox={toggleCheckbox}
         newAgentsWebIds={newAgentsWebIds}
-        webIdsInPermissions={webIdsInPermissions}
+        permissions={permissions}
         webIdsToDelete={webIdsToDelete}
       />
     );
@@ -89,7 +96,7 @@ describe("WebIdCheckbox", () => {
         addingWebId={addingWebId}
         toggleCheckbox={toggleCheckbox}
         newAgentsWebIds={newAgentsWebIds}
-        webIdsInPermissions={webIdsInPermissions}
+        permissions={permissions}
         webIdsToDelete={webIdsToDelete}
       />
     );
@@ -98,9 +105,6 @@ describe("WebIdCheckbox", () => {
     expect(checkbox).toHaveAttribute("value", "");
   });
   test("checkbox is checked if agent is already in permissions", () => {
-    mockedUseContactProfile.mockReturnValue({
-      data: { webId },
-    });
     const { getByTestId } = renderWithTheme(
       <WebIdCheckbox
         value={null}
@@ -108,7 +112,7 @@ describe("WebIdCheckbox", () => {
         addingWebId={addingWebId}
         toggleCheckbox={toggleCheckbox}
         newAgentsWebIds={newAgentsWebIds}
-        webIdsInPermissions={[webId]}
+        permissions={[{ webId }]}
         webIdsToDelete={webIdsToDelete}
       />
     );
@@ -117,9 +121,6 @@ describe("WebIdCheckbox", () => {
     expect(checkbox).toBeChecked();
   });
   test("calls toggleCheckbox on click with the correct values", () => {
-    mockedUseContactProfile.mockReturnValue({
-      data: { webId },
-    });
     const { getByTestId } = renderWithTheme(
       <WebIdCheckbox
         value={null}
@@ -127,7 +128,7 @@ describe("WebIdCheckbox", () => {
         addingWebId={addingWebId}
         toggleCheckbox={toggleCheckbox}
         newAgentsWebIds={newAgentsWebIds}
-        webIdsInPermissions={[webId]}
+        permissions={[{ webId }]}
         webIdsToDelete={webIdsToDelete}
       />
     );
@@ -138,5 +139,21 @@ describe("WebIdCheckbox", () => {
       index,
       webId
     );
+  });
+  it("disables checkbox if permission came from inherited policy", () => {
+    const { getByTestId } = renderWithTheme(
+      <WebIdCheckbox
+        value={null}
+        index={index}
+        addingWebId={addingWebId}
+        toggleCheckbox={toggleCheckbox}
+        newAgentsWebIds={newAgentsWebIds}
+        permissions={[{ webId, inherited: true }]}
+        webIdsToDelete={webIdsToDelete}
+      />
+    );
+    const checkbox = getByTestId(TESTCAFE_ID_WEBID_CHECKBOX);
+    userEvent.click(checkbox);
+    expect(toggleCheckbox).not.toHaveBeenCalled();
   });
 });

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -462,6 +462,16 @@ export async function getPodBrowserPermissions(
   }
 }
 
+export function getWebIdsFromPermissions(permissions) {
+  return (permissions || []).map(({ webId }) => webId);
+}
+
+export function getWebIdsFromInheritedPermissions(permissions) {
+  return getWebIdsFromPermissions(
+    (permissions || []).filter(({ inherited }) => inherited)
+  );
+}
+
 export default class AcpAccessControlStrategy {
   #originalWithAcr;
 

--- a/src/accessControl/acp/index.test.js
+++ b/src/accessControl/acp/index.test.js
@@ -36,6 +36,8 @@ import AcpAccessControlStrategy, {
   removePermissionsForAgent,
   setAgents,
   getNamedPolicyModesAndAgents,
+  getWebIdsFromPermissions,
+  getWebIdsFromInheritedPermissions,
 } from "./index";
 import {
   getPolicyUrl,
@@ -1279,5 +1281,29 @@ describe("removePermissionsForAgent", () => {
         .getRuleAll(updatedDataset)
         .reduce((memo, rule) => memo.concat(acpFns.getAgentAll(rule)), [])
     ).toEqual([agent2]);
+  });
+});
+
+describe("getWebIdsFromPermissions", () => {
+  it("returns WebID from list of permissions", () => {
+    const webId = "http://example.com/card#me";
+    expect(getWebIdsFromPermissions([])).toEqual([]);
+    expect(getWebIdsFromPermissions([{ webId }])).toEqual([webId]);
+    expect(getWebIdsFromPermissions(null)).toEqual([]);
+  });
+});
+
+describe("getWebIdsFromInheritedPermissions", () => {
+  it("returns WebID from list of inherited permissions", () => {
+    const webId1 = "http://example.com/card1#me";
+    const webId2 = "http://example.com/card2#me";
+    expect(getWebIdsFromInheritedPermissions([])).toEqual([]);
+    expect(
+      getWebIdsFromInheritedPermissions([
+        { webId: webId1, inherited: true },
+        { webId: webId2 },
+      ])
+    ).toEqual([webId1]);
+    expect(getWebIdsFromInheritedPermissions(null)).toEqual([]);
   });
 });


### PR DESCRIPTION
# New feature description

This will disable checkboxes in the Sharing accordion (shown for servers that supports ACP) when the agent shown has gotten the permission through inherited policies (aka cascaded policies).

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
