### PR TITLE
Changed icon from + to pencil in "Edit [policy]"

### DIFF
--- a/components/resourceDetails/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.jsx.snap
@@ -771,7 +771,7 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                         data-testid="add-agent-button"
                       >
                         <span
-                          class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+                          class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
                         />
                         <span
                           class="PodBrowser-button__text"
@@ -859,7 +859,7 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                         data-testid="add-agent-button"
                       >
                         <span
-                          class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+                          class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
                         />
                         <span
                           class="PodBrowser-button__text"

--- a/components/resourceDetails/resourceSharing/addAgentButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentButton/__snapshots__/index.test.jsx.snap
@@ -7,7 +7,7 @@ exports[`AddAgentButton renders a button with the correct text 1`] = `
     data-testid="add-agent-button"
   >
     <span
-      class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+      class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
     />
     <span
       class="PodBrowser-button__text"

--- a/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
@@ -61,7 +61,7 @@ export default function AddAgentButton({ type, setLoading }) {
         data-testid={TESTCAFE_ID_ADD_AGENT_BUTTON}
         variant="text"
         onClick={handleOpen}
-        iconBefore="add"
+        iconBefore="edit"
       >
         {editText}
       </Button>

--- a/components/resourceDetails/resourceSharing/agentAccessTable/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccessTable/__snapshots__/index.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`AgentAccessTable renders a list of permissions 1`] = `
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"
@@ -182,7 +182,7 @@ exports[`AgentAccessTable renders an empty list of permissions if permissions ar
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"
@@ -275,7 +275,7 @@ exports[`AgentAccessTable renders an empty list of permissions if there are no p
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"

--- a/components/resourceDetails/resourceSharing/sharingAccordion/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/sharingAccordion/__snapshots__/index.test.jsx.snap
@@ -28,7 +28,7 @@ exports[`SharingAccordion renders two lists of named policies for editors and vi
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"
@@ -116,7 +116,7 @@ exports[`SharingAccordion renders two lists of named policies for editors and vi
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"
@@ -230,7 +230,7 @@ exports[`SharingAccordion when resource is a container renders an info box which
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"
@@ -318,7 +318,7 @@ exports[`SharingAccordion when resource is a container renders an info box which
             data-testid="add-agent-button"
           >
             <span
-              class="PodBrowser-icon-add PodBrowser-button__icon PodBrowser-button__icon--before"
+              class="PodBrowser-icon-edit PodBrowser-button__icon PodBrowser-button__icon--before"
             />
             <span
               class="PodBrowser-button__text"


### PR DESCRIPTION
This PR fixes bug #.

Changing the icon add (+) to edit (a pencil) for "Edit [name of policy members]".

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).