### PR TITLE
upgrade solid-client-authn-browser to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1383,20 +1383,27 @@
       "dev": true
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.6.0.tgz",
-      "integrity": "sha512-DDQiCYvmubiMfIR84U3qsuNnfIO1xgxUtTHCFx+JL0KSC1aWA79LgdQre6fIGkFQKbHBwn5fRtRkOl0sgWb2Hw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.8.0.tgz",
+      "integrity": "sha512-Rj4hyqdsCA7+ovRGKLxT11CK9ouSCOx4IbhXTmkgTMlVLYfMNIU1SiA/2K4KBTJDzsWlFGimnprlDgZivs3W3A==",
       "requires": {
         "@types/form-urlencoded": "^2.0.1",
         "@types/jsonwebtoken": "^8.5.0",
         "@types/node-jose": "^1.1.5",
         "@types/uuid": "^8.3.0",
-        "form-urlencoded": "^4.2.1",
+        "form-urlencoded": "~4.4.2",
         "jose": "^2.0.4",
         "jsonwebtoken": "^8.5.1",
         "node-jose": "^2.0.0",
         "oidc-client": "^1.11.3",
         "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "form-urlencoded": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.4.2.tgz",
+          "integrity": "sha512-6sZj0HI9tCcGuzC9W/nkHvNLAjOo1G/jjnNluChOGMwn75Po6g5nGYASxQUJeSQHLng1SpovGjQr1f4xz1PqQw=="
+        }
       }
     },
     "@inrupt/prism-react-components": {
@@ -1425,12 +1432,12 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.6.0.tgz",
-      "integrity": "sha512-GOW22/XuCqU3EHQQB2Z2zN3zn26X5bwdbZLrUYRjmgRi4xA8icRvqWPLc7k/1EIv31/xlqiExzGqY2XMCyNjAQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.8.0.tgz",
+      "integrity": "sha512-1zYE5mYzmgsZi9AOVmMAkCEXFXBOwGlOOG0p3vV4h2YnDC7YsP7cszQ3jfxwm4nnIEK+h9g3UjWKHevAKWAkzQ==",
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.6.0",
-        "@inrupt/solid-client-authn-core": "^1.6.0",
+        "@inrupt/oidc-client-ext": "^1.8.0",
+        "@inrupt/solid-client-authn-core": "^1.8.0",
         "@types/form-urlencoded": "^2.0.1",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/node": "^14.14.14",
@@ -1451,9 +1458,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.31",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
-          "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+          "version": "14.14.41",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+          "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g=="
         },
         "assert": {
           "version": "2.0.0",
@@ -1496,9 +1503,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.6.0.tgz",
-      "integrity": "sha512-eqFVAkqvYRXRKKOAYmv9VF5cCfrkxK+uhSCRaLj+iBoYuqB2Lk+3YBBtgvYSEzanRtXg3ZXhEHiGBYNxi8cXAw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.8.0.tgz",
+      "integrity": "sha512-U8APJNfLwR/cPwg6CbT6RP5O5SI70jyqCv+6GY9DcyGE612aSLHWquo0oKpCi0p+ruHKBOV/dzuzKZBEAuS5rA==",
       "requires": {
         "@inrupt/solid-common-vocab": "^0.5.3",
         "@types/lodash.clonedeep": "^4.5.6",
@@ -3320,9 +3327,9 @@
       "dev": true
     },
     "@types/jsonwebtoken": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
-      "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-rNAPdomlIUX0i0cg2+I+Q1wOUr531zHBQ+cV/28PJ39bSPKjahatZZ2LMuhiguETkCgLVzfruw/ZvNMNkKoSzw==",
       "requires": {
         "@types/node": "*"
       }
@@ -6984,9 +6991,9 @@
       }
     },
     "form-urlencoded": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.2.1.tgz",
-      "integrity": "sha512-0eFJroOH2qaqc/630d4YZpmsyKmh6sfq/1z3YMXvFab0O6teGnf8640C7gufikwbQJFaC6nPlG4d/GiYVN+Dcw=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.5.1.tgz",
+      "integrity": "sha512-Rkd/RdMaprsMJEGzEbxolwacp78WupH7u369KEyIY3pEZ1fhL6HtyQ1FX+4HSfA1VVhET18UwCUcr5DVaDIaqg=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -7237,6 +7244,11 @@
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -7655,12 +7667,25 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.1.tgz",
+      "integrity": "sha512-J0ELF4yHFxHy0cmSxZuheDOz2luOdVvqjwmEcj8H/L1JHeuEDSDbeRP+Dk9kFVk5RTFzbucJ2Kb9F7ixY2QaCg=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -7838,6 +7863,11 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -7883,8 +7913,7 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -7907,24 +7936,33 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2",
+            "get-intrinsic": "^1.1.1",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
             "object-inspect": "^1.9.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.3",
-            "string.prototype.trimstart": "^1.0.3"
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
           }
         },
         "is-callable": {
@@ -7947,9 +7985,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
         },
         "object.assign": {
           "version": "4.1.2",
@@ -10817,9 +10855,9 @@
       }
     },
     "jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }
@@ -12215,9 +12253,9 @@
           "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "core-js": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-          "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ=="
+          "version": "3.11.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
+          "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw=="
         }
       }
     },
@@ -14744,9 +14782,9 @@
       }
     },
     "tsyringe": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.4.0.tgz",
-      "integrity": "sha512-SlMApe1lhIq546CDp7bF+IdF4RB6d+9C5T7B0AS0P/Bm+Qpizj/gEmZzvw9J/KlXPEt4qHTbi1TRvX3rCPSdTg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.5.0.tgz",
+      "integrity": "sha512-XvYgdUxkmGQfpCkKyr/ybJx71OLSnNec1SO0xdohMjaS2UOEyKi76YfKx92XUXgc1TocypHENg6y4wCyYyMKag==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -14805,6 +14843,24 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
       "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        }
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -15154,6 +15210,18 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -15180,24 +15248,33 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.2",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
-          "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
-            "get-intrinsic": "^1.0.2",
+            "get-intrinsic": "^1.1.1",
             "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
+            "has-symbols": "^1.0.2",
+            "is-callable": "^1.2.3",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.1",
+            "is-regex": "^1.1.2",
+            "is-string": "^1.0.5",
             "object-inspect": "^1.9.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
-            "string.prototype.trimend": "^1.0.3",
-            "string.prototype.trimstart": "^1.0.3"
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.0"
+          },
+          "dependencies": {
+            "has-symbols": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+            }
           }
         },
         "is-callable": {
@@ -15220,9 +15297,9 @@
           }
         },
         "object-inspect": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
         },
         "object.assign": {
           "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@datapunt/matomo-tracker-react": "^0.3.1",
     "@inrupt/prism-react-components": "^0.13.3",
     "@inrupt/solid-client": "^1.3.0",
-    "@inrupt/solid-client-authn-browser": "^1.6.0",
+    "@inrupt/solid-client-authn-browser": "^1.8.0",
     "@inrupt/solid-ui-react": "^1.7.0",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",


### PR DESCRIPTION
This PR upgrades `solid-client-authn-browser` to the latest version (1.8.0)
