### PR TITLE
Fix: pass restorePreviousSession to SessionProvider 

### DIFF
--- a/components/container/index.test.jsx
+++ b/components/container/index.test.jsx
@@ -23,7 +23,10 @@ import React from "react";
 import * as RouterFns from "next/router";
 import { addUrl } from "@inrupt/solid-client";
 import { space } from "rdf-namespaces";
+import * as solidUiReactFns from "@inrupt/solid-ui-react";
 import { renderWithTheme } from "../../__testUtils/withTheme";
+import mockSession from "../../__testUtils/mockSession";
+import mockSessionContextProvider from "../../__testUtils/mockSessionContextProvider";
 import Container from "./index";
 import useContainer from "../../src/hooks/useContainer";
 import useAuthenticatedProfile from "../../src/hooks/useAuthenticatedProfile";
@@ -66,7 +69,11 @@ describe("Container view", () => {
   const { dataset } = container;
 
   beforeEach(() => {
-    mockedContainerHook.mockReturnValue({ data: container, mutate: jest.fn() });
+    mockedContainerHook.mockReturnValue({
+      data: container,
+      mutate: jest.fn(),
+      update: jest.fn(),
+    });
     mockedAuthenticatedProfileHook.mockReturnValue({
       data: mockProfileAlice((t) =>
         addUrl(t, space.storage, "https://example.com/")
@@ -87,7 +94,7 @@ describe("Container view", () => {
     ]);
   });
 
-  it("renders a table", () => {
+  test("renders a table", () => {
     const { asFragment } = renderWithTheme(<Container iri={iri} />);
     expect(asFragment()).toMatchSnapshot();
   });
@@ -141,12 +148,17 @@ describe("Container view", () => {
   });
 
   it("renders Not supported if the fetch for container returns 500", () => {
+    const session = mockSession();
+    const SessionProvider = mockSessionContextProvider(session);
     mockedContainerHook.mockReturnValue({
       error: new Error("500"),
     });
     const { asFragment, getByTestId } = renderWithTheme(
-      <Container iri={iri} />
+      <SessionProvider>
+        <Container iri={iri} />
+      </SessionProvider>
     );
+
     expect(asFragment()).toMatchSnapshot();
     expect(getByTestId(TESTCAFE_ID_NOT_SUPPORTED)).toBeDefined();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1538,33 +1538,147 @@
       }
     },
     "@inrupt/solid-ui-react": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-ui-react/-/solid-ui-react-2.1.1.tgz",
-      "integrity": "sha512-XNfOvRcoH5obC1ueneBkfMa3HsCOjTjvZElNP7K9B4Qj/AAi40NS1KOfERoc1kGXqL+Ylt+yQsqE75r8jvNfNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-ui-react/-/solid-ui-react-2.3.0.tgz",
+      "integrity": "sha512-AJ7fkxxeVGxFnoEWuCdcgji0ebBDoV0peunYE1eRmkryBQ4bvZcVQw8cYEp9VHFuR/nJE0rQMKTsBBvj/2RGBw==",
       "requires": {
-        "@inrupt/solid-client": "^1.3.0",
-        "@inrupt/solid-client-authn-browser": "^1.5.1",
-        "ajv": "^7.0.3",
-        "core-js": "^3.8.3",
+        "@inrupt/solid-client": "^1.6.1",
+        "@inrupt/solid-client-authn-browser": "^1.8.1",
+        "core-js": "^3.11.0",
         "react-table": "^7.6.3",
-        "swr": "^0.4.1"
+        "swr": "^0.5.6"
       },
       "dependencies": {
+        "@inrupt/oidc-client-ext": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.8.1.tgz",
+          "integrity": "sha512-aXgwtB5i8kzeGHlULUzwuI56RKFN5WVRpxpx1PywSsLuH94wCl5r+HRjXtIenWvYoYEgpmFxtzrflo5HI9lswA==",
+          "requires": {
+            "@types/form-urlencoded": "^2.0.1",
+            "@types/jsonwebtoken": "^8.5.0",
+            "@types/node-jose": "^1.1.5",
+            "@types/uuid": "^8.3.0",
+            "form-urlencoded": "~4.4.2",
+            "jose": "^2.0.4",
+            "jsonwebtoken": "^8.5.1",
+            "node-jose": "^2.0.0",
+            "oidc-client": "^1.11.3",
+            "uuid": "^8.3.1"
+          },
+          "dependencies": {
+            "form-urlencoded": {
+              "version": "4.4.2",
+              "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.4.2.tgz",
+              "integrity": "sha512-6sZj0HI9tCcGuzC9W/nkHvNLAjOo1G/jjnNluChOGMwn75Po6g5nGYASxQUJeSQHLng1SpovGjQr1f4xz1PqQw=="
+            }
+          }
+        },
+        "@inrupt/solid-client-authn-browser": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.8.1.tgz",
+          "integrity": "sha512-9Dj3xSCgckEVMDophmXUyA7pAJdh2U8hleNyj7inVPFABkWwr91rNARYcp1oFYgwzmdRfyf9zaKVd5aI2b18xQ==",
+          "requires": {
+            "@inrupt/oidc-client-ext": "^1.8.1",
+            "@inrupt/solid-client-authn-core": "^1.8.1",
+            "@types/form-urlencoded": "^2.0.1",
+            "@types/lodash.clonedeep": "^4.5.6",
+            "@types/node": "^14.14.14",
+            "@types/uuid": "^8.3.0",
+            "assert": "^2.0.0",
+            "browserify-zlib": "^0.2.0",
+            "buffer": "^6.0.3",
+            "crypto-browserify": "^3.12.0",
+            "form-urlencoded": "^6.0.3",
+            "jose": "^2.0.5",
+            "lodash.clonedeep": "^4.5.0",
+            "os-browserify": "^0.3.0",
+            "reflect-metadata": "^0.1.13",
+            "stream-browserify": "^3.0.0",
+            "tsyringe": "^4.4.0",
+            "util": "^0.12.3",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@inrupt/solid-client-authn-core": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.8.1.tgz",
+          "integrity": "sha512-S2tClHwqZXmEEN+A9rSYX8ThDmICCG7sdYobUuFpmFonHbeutdVATekIUizC6XdH4Ry+S51PAOTsDyY2ytxqtA==",
+          "requires": {
+            "@inrupt/solid-common-vocab": "^0.5.3",
+            "@types/lodash.clonedeep": "^4.5.6",
+            "@types/uuid": "^8.3.0",
+            "ajv": "^6.12.6",
+            "cross-fetch": "^3.0.6",
+            "lodash.clonedeep": "^4.5.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@types/node": {
+          "version": "14.17.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.1.tgz",
+          "integrity": "sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw=="
+        },
         "ajv": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
-          "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
           }
         },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        "assert": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
+          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+          "requires": {
+            "es6-object-assign": "^1.1.0",
+            "is-nan": "^1.2.1",
+            "object-is": "^1.0.1",
+            "util": "^0.12.0"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "form-urlencoded": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.4.tgz",
+          "integrity": "sha512-39GnqmnZkThJBXiKhBCrBGPKiwFHDgi3lcGO3SfURjXoz9x8quxNRTiIWViYN+QzQXxxl/uyKm+i+0PCj7Aqbw=="
+        },
+        "ieee754": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+          "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "swr": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/swr/-/swr-0.5.6.tgz",
+          "integrity": "sha512-Bmx3L4geMZjYT5S2Z6EE6/5Cx6v1Ka0LhqZKq8d6WL2eu9y6gHWz3dUzfIK/ymZVHVfwT/EweFXiYGgfifei3w==",
+          "requires": {
+            "dequal": "2.0.2"
+          }
+        },
+        "util": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "safe-buffer": "^5.1.2",
+            "which-typed-array": "^1.1.2"
+          }
         }
       }
     },
@@ -5064,9 +5178,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
-      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw=="
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
+      "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ=="
     },
     "core-js-pure": {
       "version": "3.6.5",
@@ -13490,7 +13604,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@inrupt/prism-react-components": "^0.13.3",
     "@inrupt/solid-client": "^1.7.0",
     "@inrupt/solid-client-authn-browser": "^1.8.0",
-    "@inrupt/solid-ui-react": "^2.1.1",
+    "@inrupt/solid-ui-react": "^2.3.0",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -27,14 +27,14 @@ import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 
 import PropTypes from "prop-types";
 import Head from "next/head";
-import { useRouter } from "next/router";
+import router, { useRouter } from "next/router";
 import CssBaseline from "@material-ui/core/CssBaseline";
 
 import { create } from "jss";
 import preset from "jss-preset-default";
 
 import { appLayout, useBem } from "@solid/lit-prism-patterns";
-import { SessionProvider } from "@inrupt/solid-ui-react";
+import { SessionProvider, useSession } from "@inrupt/solid-ui-react";
 import {
   createStyles,
   makeStyles,
@@ -136,7 +136,11 @@ export default function App(props) {
       <MatomoProvider value={matomoInstance}>
         <StylesProvider jss={jss}>
           <ThemeProvider theme={theme}>
-            <SessionProvider sessionId="pod-browser" restorePreviousSession>
+            <SessionProvider
+              sessionId="pod-browser"
+              restorePreviousSession
+              onSessionRestore={(url) => router.push(url)}
+            >
               <FeatureProvider>
                 <AlertProvider>
                   <ConfirmationDialogProvider>

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -27,14 +27,14 @@ import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 
 import PropTypes from "prop-types";
 import Head from "next/head";
-import router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import CssBaseline from "@material-ui/core/CssBaseline";
 
 import { create } from "jss";
 import preset from "jss-preset-default";
 
 import { appLayout, useBem } from "@solid/lit-prism-patterns";
-import { SessionProvider, useSession } from "@inrupt/solid-ui-react";
+import { SessionProvider } from "@inrupt/solid-ui-react";
 import {
   createStyles,
   makeStyles,
@@ -96,7 +96,8 @@ export function hasSolidAuthClientHash() {
 export default function App(props) {
   const { Component, pageProps } = props;
   const bem = useBem(useStyles());
-  const { pathname, asPath } = useRouter();
+  const router = useRouter();
+  const { pathname, asPath } = router;
 
   useEffect(() => {
     // Remove injected serverside JSS

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -136,7 +136,7 @@ export default function App(props) {
       <MatomoProvider value={matomoInstance}>
         <StylesProvider jss={jss}>
           <ThemeProvider theme={theme}>
-            <SessionProvider sessionId="pod-browser">
+            <SessionProvider sessionId="pod-browser" restorePreviousSession>
               <FeatureProvider>
                 <AlertProvider>
                   <ConfirmationDialogProvider>


### PR DESCRIPTION
In this PR:

- upgrade to latest version of `solid-ui-react`
- pass `restorePreviousSession` to `SessionProvider` to restore session on browser refresh
- use `onSessionRestore` to redirect to navigated page

<!-- When fixing a bug: -->

This PR fixes bug #SDK-2048.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
