### PR TITLE
Fix: remove unnecessary dependency in hook causing rerenders

### DIFF
--- a/src/hooks/useAccessControl/index.jsx
+++ b/src/hooks/useAccessControl/index.jsx
@@ -24,11 +24,9 @@ import { useSession } from "@inrupt/solid-ui-react";
 import { getSourceUrl } from "@inrupt/solid-client";
 import { getAccessControl, isAcp } from "../../accessControl";
 import usePoliciesContainerUrl from "../usePoliciesContainerUrl";
-import useAuthenticatedProfile from "../useAuthenticatedProfile";
 
 export default function useAccessControl(resourceInfo) {
   const { fetch } = useSession();
-  const { data: authenticatedProfile } = useAuthenticatedProfile();
   const [accessControl, setAccessControl] = useState(null);
   const policiesContainerUrl = usePoliciesContainerUrl(
     resourceInfo && getSourceUrl(resourceInfo)
@@ -52,7 +50,7 @@ export default function useAccessControl(resourceInfo) {
         setAccessControl(null);
         setError(accessControlError);
       });
-  }, [authenticatedProfile, fetch, policiesContainerUrl, resourceInfo]);
+  }, [fetch, policiesContainerUrl, resourceInfo]);
 
   return { accessControl, error };
 }

--- a/src/hooks/useAccessControl/index.test.jsx
+++ b/src/hooks/useAccessControl/index.test.jsx
@@ -27,15 +27,11 @@ import * as accessControlFns from "../../accessControl";
 import usePoliciesContainerUrl from "../usePoliciesContainerUrl";
 import mockSessionContextProvider from "../../../__testUtils/mockSessionContextProvider";
 import mockSession from "../../../__testUtils/mockSession";
-import useAuthenticatedProfile from "../useAuthenticatedProfile";
 import { mockProfileAlice } from "../../../__testUtils/mockPersonResource";
 import { joinPath } from "../../stringHelpers";
 
 jest.mock("../usePoliciesContainerUrl");
 const mockedPoliciesContainerUrlHook = usePoliciesContainerUrl;
-
-jest.mock("../useAuthenticatedProfile");
-const mockedAuthenticatedProfileHook = useAuthenticatedProfile;
 
 jest.mock("@inrupt/solid-ui-react");
 const mockedUseSession = useSession;
@@ -60,9 +56,6 @@ describe("useAccessControl", () => {
     wrapper = mockSessionContextProvider(session);
     mockedUseSession.mockReturnValue(session);
     jest.spyOn(accessControlFns, "isAcp").mockReturnValue(false);
-    mockedAuthenticatedProfileHook.mockReturnValue({
-      data: authenticatedProfile,
-    });
   });
 
   it("returns null if given no resourceUri", () => {


### PR DESCRIPTION
This PR removes the dependency on `authenticatedProfile` in the `useAccessControl` hook, since it was not used and it was causing the details drawer to rerender (causing the blinking effect described in the issue).

It is unclear to me why this was added to the `useEffect`  dependencies, but it did not seem to cause any issues to remove it. 

This PR fixes bug #SDK-2050 and fixes #294.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
