### PR TITLE
Fix: deleting containers with encoded names

### DIFF
--- a/components/containerDetails/index.jsx
+++ b/components/containerDetails/index.jsx
@@ -40,7 +40,8 @@ export default function ContainerDetails({ children, update }) {
         handleCloseDrawer({ setMenuOpen, router })();
       }}
       onDeleteCurrentContainer={(iri) => {
-        update();
+        const deletingCurrentContainer = true;
+        update(deletingCurrentContainer);
         handleRedirectToParentContainer({ setMenuOpen, iri, router })();
       }}
     />

--- a/src/hooks/useContainer/index.js
+++ b/src/hooks/useContainer/index.js
@@ -49,9 +49,22 @@ export default function useContainer(iri) {
     fetchContainer();
   }, [url, fetch]);
 
-  async function update() {
-    const updatedContainer = await getContainer(url, { fetch });
-    setContainer(updatedContainer);
+  async function update(deletingCurrentContainer = false) {
+    setIsFetching(true);
+    try {
+      const updatedContainer = await getContainer(url, { fetch });
+      setContainer(updatedContainer);
+      setContainerError(null);
+      setIsFetching(false);
+    } catch (e) {
+      if (!deletingCurrentContainer) {
+        setContainerError(e);
+      } else {
+        setContainerError(null);
+      }
+      setContainer(null);
+      setIsFetching(false);
+    }
   }
 
   return {


### PR DESCRIPTION
- handle error when re-fetching container in update function returned from useContainer hook
- allow an optional deletingCurrentContainer prop to the update function so that error is still set correctly when updating for other reasons
- add tests

<!-- When fixing a bug: -->

This PR fixes bug #.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
