### PR TITLE
Fix: adding check for confirmation dialog

### DIFF
--- a/components/resourceDetails/resourceSharing/agentAccessOld/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccessOld/index.jsx
@@ -125,7 +125,7 @@ export default function AgentAccess({ onLoading, permission: { acl, webId } }) {
   const { accessControl } = useContext(AccessControlContext);
   const [isLoading, setIsLoading] = useState(false);
 
-  const { confirmed, setContent, setOpen } = useContext(
+  const { open, confirmed, setContent, setOpen } = useContext(
     ConfirmationDialogContext
   );
 
@@ -144,10 +144,18 @@ export default function AgentAccess({ onLoading, permission: { acl, webId } }) {
   );
 
   useEffect(() => {
-    if (!confirmed || authenticatedWebId !== webId) return;
+    if (open !== dialogId || !confirmed || authenticatedWebId !== webId) return;
     // this triggers when a visitor changes their own permissions
     savePermissions(tempAccess);
-  }, [authenticatedWebId, confirmed, savePermissions, tempAccess, webId]);
+  }, [
+    authenticatedWebId,
+    confirmed,
+    savePermissions,
+    tempAccess,
+    webId,
+    dialogId,
+    open,
+  ]);
 
   const onSubmit = submitHandler(
     authenticatedWebId,


### PR DESCRIPTION
In this PR:

- checking for confirmation dialog id before calling savePermissions for user changing their own permissions

We weren't checking if the confirmation dialog being confirmed was the permissions change dialog, so we were calling `savePermissions` every time any dialog was confirmed, which was causing a change in permissions before the folder was deleted. 

The confirmation dialog is particularly hard to test which is why we didn't catch this before, and we have a ticket to refactor it (using a simple dialog component instead of context wherever we need it). 

This PR fixes bug #SDK-2085.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
