### PR TITLE
Use native Next.js source map functionality

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const withSourceMaps = require("@zeit/next-source-maps")();
 const SentryWebpackPlugin = require("@sentry/webpack-plugin");
 
 const {
@@ -34,7 +33,8 @@ const {
 process.env.SENTRY_DSN = SENTRY_DSN;
 
 /* eslint no-param-reassign: 0 */
-module.exports = withSourceMaps({
+module.exports = {
+  productionBrowserSourceMaps: true,
   webpack(config, options) {
     // If the environment is the browser, we should load sentry/react instead of
     // sentry/node.
@@ -62,4 +62,4 @@ module.exports = withSourceMaps({
 
     return config;
   },
-});
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3704,11 +3704,6 @@
       "integrity": "sha512-m9mIcnOrx/mdMUUr7Ns6/Atv82qgNhlhGLKsZOM/AsifqJqsFZB3/5K8MTEkYN36Bf5pjxh3rIWg9KveKuZUSQ==",
       "dev": true
     },
-    "@zeit/next-source-maps": {
-      "version": "0.0.4-canary.1",
-      "resolved": "https://registry.npmjs.org/@zeit/next-source-maps/-/next-source-maps-0.0.4-canary.1.tgz",
-      "integrity": "sha512-SPQCLs7ToaqzQnqXqGSCoL7KTlnOAao+1F5hy7Hkuq85TjHsUC3eeLsmVrBIraIhXG/ARHmZ0JHOesPDtBfpzw=="
-    },
     "abab": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@sentry/react": "^6.1.0",
     "@solid/lit-prism-patterns": "^0.13.5",
     "@solid/lit-prism-theme-sdk-default": "^0.13.5",
-    "@zeit/next-source-maps": "0.0.4-canary.1",
     "encoding": "^0.1.13",
     "jss": "^10.5.1",
     "jss-preset-default": "^10.5.1",


### PR DESCRIPTION
I was initially planning on just enabling source maps if `process.env.VERCEL_ENV !== "production"`, but then I saw that source maps were already supposed to be enabled always (using a package [that's now deprecated](https://www.npmjs.com/package/@zeit/next-source-maps)), so I just did so too.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

(Yes, this is because my computer crawls to a halt when I try to run PodBrowser locally :P Unfortunately, it seems that this is not enough to have the React DevTools show me the full component names, but it still seems like a sensible change.)