### PR TITLE
Refactor: confirmation dialog

### DIFF
--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -140,10 +140,10 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   const {
     confirmed,
     open,
-    setConfirmed,
     setContent,
     setOpen,
     setTitle,
+    closeDialog,
   } = useContext(ConfirmationDialogContext);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
   const [file, setFile] = useState(null);
@@ -190,19 +190,10 @@ export default function AddFileButton({ className, onSave, resourceList }) {
     }
 
     if (confirmed !== null) {
-      setOpen(null);
-      setConfirmed(null);
+      closeDialog();
       setConfirmationSetup(false);
     }
-  }, [
-    confirmationSetup,
-    confirmed,
-    saveResource,
-    setConfirmed,
-    setOpen,
-    file,
-    open,
-  ]);
+  }, [confirmationSetup, confirmed, saveResource, closeDialog, file, open]);
 
   return (
     <>

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -19,6 +19,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+
 import React, { useContext, useEffect, useRef, useState } from "react";
 import T from "prop-types";
 import { overwriteFile } from "@inrupt/solid-client";
@@ -27,11 +29,14 @@ import PodLocationContext from "../../src/contexts/podLocationContext";
 import AlertContext from "../../src/contexts/alertContext";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
 import { joinPath } from "../../src/stringHelpers";
+import ConfirmationDialog from "../confirmationDialog";
 
 export const TESTCAFE_ID_UPLOAD_BUTTON = "upload-file-button";
 export const TESTCAFE_ID_UPLOAD_INPUT = "upload-file-input";
 
 export const DUPLICATE_DIALOG_ID = "upload-duplicate-file";
+
+export const CONFIRMATION_MESSAGE = "Do you want to replace it?";
 
 function normalizeSafeFileName(fileName) {
   return fileName.replace(/^-/, "");
@@ -87,7 +92,7 @@ export function handleUploadedFile({
       setTitle(
         `File ${normalizeSafeFileName(uploadedFile.name)} already exists`
       );
-      setContent(<p>Do you want to replace it?</p>);
+      setContent(CONFIRMATION_MESSAGE);
       setConfirmationSetup(true);
       setIsUploading(false);
     } else {
@@ -122,28 +127,6 @@ export function handleFileSelect({
       setAlertOpen(true);
     } finally {
       setIsUploading(false);
-    }
-  };
-}
-
-export function handleConfirmation({
-  setOpen,
-  setConfirmed,
-  saveResource,
-  setConfirmationSetup,
-}) {
-  return (confirmationSetup, confirmed, file, open) => {
-    if (confirmationSetup && confirmed === null && open === DUPLICATE_DIALOG_ID)
-      return;
-
-    if (confirmationSetup && confirmed && open === DUPLICATE_DIALOG_ID) {
-      saveResource(file);
-    }
-
-    if (confirmed !== null) {
-      setOpen(null);
-      setConfirmed(null);
-      setConfirmationSetup(false);
     }
   };
 }
@@ -198,49 +181,62 @@ export default function AddFileButton({ className, onSave, resourceList }) {
     resourceList,
   });
 
-  const onConfirmation = handleConfirmation({
-    setOpen,
-    setConfirmed,
-    saveResource,
-    setConfirmationSetup,
-    open,
-  });
-
   useEffect(() => {
-    onConfirmation(confirmationSetup, confirmed, file, open);
-  }, [confirmationSetup, confirmed, onConfirmation, file, open]);
+    if (confirmationSetup && confirmed === null && open === DUPLICATE_DIALOG_ID)
+      return;
+
+    if (confirmationSetup && confirmed && open === DUPLICATE_DIALOG_ID) {
+      saveResource(file);
+    }
+
+    if (confirmed !== null) {
+      setOpen(null);
+      setConfirmed(null);
+      setConfirmationSetup(false);
+    }
+  }, [
+    confirmationSetup,
+    confirmed,
+    saveResource,
+    setConfirmed,
+    setOpen,
+    file,
+    open,
+  ]);
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-    <label
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex="0"
-      htmlFor="upload-file-input"
-      className={className}
-      data-testid={TESTCAFE_ID_UPLOAD_BUTTON}
-      disabled={isUploading}
-      onClick={(e) => {
-        e.target.value = null;
-      }}
-      onKeyUp={(e) => {
-        if (e.key === "Enter") {
-          if (ref.current) {
-            ref.current.click();
-          }
+    <>
+      <label
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex="0"
+        htmlFor="upload-file-input"
+        className={className}
+        data-testid={TESTCAFE_ID_UPLOAD_BUTTON}
+        disabled={isUploading}
+        onClick={(e) => {
           e.target.value = null;
-        }
-      }}
-    >
-      {isUploading ? "Uploading..." : "Upload File"}
-      <input
-        ref={ref}
-        id="upload-file-input"
-        data-testid={TESTCAFE_ID_UPLOAD_INPUT}
-        type="file"
-        style={{ display: "none" }}
-        onChange={onFileSelect}
-      />
-    </label>
+        }}
+        onKeyUp={(e) => {
+          if (e.key === "Enter") {
+            if (ref.current) {
+              ref.current.click();
+            }
+            e.target.value = null;
+          }
+        }}
+      >
+        {isUploading ? "Uploading..." : "Upload File"}
+        <input
+          ref={ref}
+          id="upload-file-input"
+          data-testid={TESTCAFE_ID_UPLOAD_INPUT}
+          type="file"
+          style={{ display: "none" }}
+          onChange={onFileSelect}
+        />
+      </label>
+      <ConfirmationDialog />
+    </>
   );
 }
 

--- a/components/confirmationDialog/index.jsx
+++ b/components/confirmationDialog/index.jsx
@@ -39,6 +39,10 @@ export const TESTCAFE_ID_CONFIRM_BUTTON = "confirm-button";
 export const TESTCAFE_ID_CONFIRMATION_CANCEL_BUTTON =
   "confirmation-cancel-button";
 export const TESTCAFE_ID_CONFIRMATION_DIALOG = "confirmation-dialog";
+export const TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE =
+  "confirmation-dialog-title";
+export const TESTCAFE_ID_CONFIRMATION_DIALOG_CONTENT =
+  "confirmation-dialog-content";
 
 export default function ConfirmationDialog() {
   const classes = useStyles();
@@ -60,11 +64,16 @@ export default function ConfirmationDialog() {
       aria-labelledby="confirmation-dialog"
       open={!!open}
     >
-      <DialogTitle disableTypography classes={{ root: classes.dialogTitle }}>
+      <DialogTitle
+        data-testid={TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE}
+        disableTypography
+        classes={{ root: classes.dialogTitle }}
+      >
         {title}
       </DialogTitle>
       <DialogContent>
         <DialogContentText
+          data-testid={TESTCAFE_ID_CONFIRMATION_DIALOG_CONTENT}
           classes={{ root: classes.dialogText }}
           id="alert-confirmation-dialog"
         >

--- a/components/confirmationDialog/index.test.jsx
+++ b/components/confirmationDialog/index.test.jsx
@@ -19,6 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import mockConfirmationDialogContextProvider from "../../__testUtils/mockConfirmationDialogContextProvider";
@@ -45,7 +46,7 @@ describe("ConfirmationDialog", () => {
       </ConfirmationDialogProvider>
     );
     const button = getByTestId(TESTCAFE_ID_CONFIRM_BUTTON);
-    userEvent.click(button);
+    act(() => userEvent.click(button));
     expect(setConfirmed).toHaveBeenCalledWith(true);
   });
   test("when cancelText and confirmText are null, it displays default values", () => {
@@ -66,7 +67,7 @@ describe("ConfirmationDialog", () => {
     const cancelButton = getByText("Cancel");
     expect(cancelButton).not.toBeNull();
   });
-  test("clicking on cancel button calls setConfirmed with true", () => {
+  test("clicking on cancel button calls setConfirmed with false", () => {
     const setConfirmed = jest.fn();
     const ConfirmationDialogProvider = mockConfirmationDialogContextProvider({
       open: "confirmation-dialog",
@@ -78,7 +79,7 @@ describe("ConfirmationDialog", () => {
       </ConfirmationDialogProvider>
     );
     const button = getByTestId(TESTCAFE_ID_CONFIRMATION_CANCEL_BUTTON);
-    userEvent.click(button);
+    act(() => userEvent.click(button));
     expect(setConfirmed).toHaveBeenCalledWith(false);
   });
 });

--- a/components/deleteButton/index.jsx
+++ b/components/deleteButton/index.jsx
@@ -26,41 +26,13 @@ import { useBem } from "@solid/lit-prism-patterns";
 import T from "prop-types";
 import AlertContext from "../../src/contexts/alertContext";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
+import ConfirmationDialog from "../confirmationDialog";
 import styles from "./styles";
 import { isHTTPError } from "../../src/error";
 
-const TESTCAFE_ID_DELETE_BUTTON = "delete-button";
+export const TESTCAFE_ID_DELETE_BUTTON = "delete-button";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
-
-export function handleConfirmation({
-  dialogId,
-  open,
-  setOpen,
-  setConfirmed,
-  deleteResource,
-  setTitle,
-  setContent,
-  setConfirmationSetup,
-}) {
-  return (confirmationSetup, confirmed, title, content) => {
-    if (open !== dialogId) return;
-    if (confirmationSetup && confirmed === null) return;
-    setTitle(title);
-    setContent(<p>{content}</p>);
-    setConfirmationSetup(true);
-
-    if (confirmationSetup && confirmed) {
-      deleteResource();
-    }
-
-    if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
-      setConfirmationSetup(false);
-    }
-  };
-}
 
 export function handleDeleteResource({
   onDelete,
@@ -122,40 +94,48 @@ export default function DeleteButton({
     successMessage,
   });
 
-  const onConfirmation = handleConfirmation({
-    dialogId,
-    open,
-    setOpen,
-    setConfirmed,
-    deleteResource,
-    setTitle,
-    setContent,
-    setConfirmationSetup,
-  });
-
   useEffect(() => {
-    onConfirmation(
-      confirmationSetup,
-      confirmed,
-      confirmationTitle,
-      confirmationContent
-    );
+    if (open !== dialogId) return;
+    if (confirmationSetup && confirmed === null) return;
+    setTitle(confirmationTitle);
+    setContent(<p>{confirmationContent}</p>);
+    setConfirmationSetup(true);
+
+    if (confirmationSetup && confirmed) {
+      deleteResource();
+    }
+
+    if (confirmationSetup && confirmed !== null) {
+      setConfirmed(null);
+      setOpen(null);
+      setConfirmationSetup(false);
+    }
   }, [
-    confirmationSetup,
-    confirmed,
-    onConfirmation,
+    deleteResource,
+    open,
+    dialogId,
     confirmationTitle,
     confirmationContent,
+    setConfirmationSetup,
+    confirmed,
+    confirmationSetup,
+    setContent,
+    setConfirmed,
+    setOpen,
+    setTitle,
   ]);
 
   return (
-    <button
-      type="button"
-      className={clsx(bem("button"))}
-      data-testid={TESTCAFE_ID_DELETE_BUTTON}
-      {...buttonProps}
-      onClick={() => setOpen(dialogId)}
-    />
+    <>
+      <button
+        type="button"
+        className={clsx(bem("button"))}
+        data-testid={TESTCAFE_ID_DELETE_BUTTON}
+        {...buttonProps}
+        onClick={() => setOpen(dialogId)}
+      />
+      <ConfirmationDialog />
+    </>
   );
 }
 

--- a/components/deleteButton/index.jsx
+++ b/components/deleteButton/index.jsx
@@ -69,10 +69,10 @@ export default function DeleteButton({
   const {
     confirmed,
     open,
-    setConfirmed,
     setContent,
     setOpen,
     setTitle,
+    closeDialog,
   } = useContext(ConfirmationDialogContext);
 
   function onDeleteError(e) {
@@ -106,8 +106,7 @@ export default function DeleteButton({
     }
 
     if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
+      closeDialog();
       setConfirmationSetup(false);
     }
   }, [
@@ -120,9 +119,8 @@ export default function DeleteButton({
     confirmed,
     confirmationSetup,
     setContent,
-    setConfirmed,
-    setOpen,
     setTitle,
+    closeDialog,
   ]);
 
   return (

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/removeButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/removeButton/index.jsx
@@ -34,38 +34,7 @@ import {
   profile as profilePropType,
 } from "../../../../../../constants/propTypes";
 import ResourceInfoContext from "../../../../../../src/contexts/resourceInfoContext";
-
-export const handleConfirmation = ({
-  open,
-  dialogId,
-  bypassDialog,
-  setConfirmationSetup,
-  setOpen,
-  setConfirmed,
-  handleRemoveAgent,
-  setConfirmText,
-}) => {
-  return (webId, alias, confirmationSetup, confirmed) => {
-    setConfirmationSetup(true);
-    if (bypassDialog) {
-      setConfirmed(true);
-      handleRemoveAgent(webId, alias);
-    }
-    if (open !== dialogId) return;
-    if (confirmationSetup && confirmed === null) return;
-
-    if (confirmationSetup && confirmed) {
-      handleRemoveAgent(webId, alias);
-    }
-
-    if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
-      setConfirmationSetup(false);
-    }
-    setConfirmText(null);
-  };
-};
+import ConfirmationDialog from "../../../../../confirmationDialog";
 
 export const handleRemovePermissions = ({
   setLoading,
@@ -94,6 +63,8 @@ export const handleRemovePermissions = ({
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 export const TESTCAFE_ID_REMOVE_BUTTON = "remove-button";
+export const DIALOG_ID = "remove-agent";
+export const CONFIRMATION_TEXT = "Remove";
 
 export default function RemoveButton({
   resourceIri,
@@ -106,7 +77,6 @@ export default function RemoveButton({
   const { mutate: mutateResourceInfo } = useContext(ResourceInfoContext);
   const resourceName = getResourceName(resourceIri);
   const classes = useStyles();
-  const dialogId = "remove-agent";
   const [bypassDialog, setBypassDialog] = useState(false);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
   const handleRemoveAgent = handleRemovePermissions({
@@ -127,7 +97,7 @@ export default function RemoveButton({
   } = useContext(ConfirmationDialogContext);
 
   const handleOpenDialog = () => {
-    setConfirmText("Remove");
+    setConfirmText(CONFIRMATION_TEXT);
     // eslint-disable-next-line prettier/prettier
     if (
       PUBLIC_AGENT_PREDICATE === webId ||
@@ -139,25 +109,42 @@ export default function RemoveButton({
       profile?.name || webId
     }'s access from ${resourceName}`;
     setTitle(text);
-    setOpen(dialogId);
+    setOpen(DIALOG_ID);
   };
 
-  const onConfirmation = handleConfirmation({
-    open,
-    dialogId,
-    bypassDialog,
+  useEffect(() => {
+    setConfirmationSetup(true);
+    if (bypassDialog) {
+      setConfirmed(true);
+      handleRemoveAgent(webId, alias);
+    }
+    if (open !== DIALOG_ID) return;
+    if (confirmationSetup && confirmed === null) return;
+
+    if (confirmationSetup && confirmed) {
+      handleRemoveAgent(webId, alias);
+    }
+
+    if (confirmationSetup && confirmed !== null) {
+      setConfirmed(null);
+      setOpen(null);
+      setConfirmationSetup(false);
+    }
+    setConfirmText(null);
+  }, [
     confirmationSetup,
     confirmed,
-    setConfirmationSetup,
-    setOpen,
+    title,
+    webId,
+    alias,
+    bypassDialog,
     setConfirmed,
-    handleRemoveAgent,
+    setConfirmationSetup,
     setConfirmText,
-  });
-
-  useEffect(() => {
-    onConfirmation(webId, alias, confirmationSetup, confirmed);
-  }, [confirmationSetup, confirmed, onConfirmation, title, webId, alias]);
+    handleRemoveAgent,
+    setOpen,
+    open,
+  ]);
 
   return (
     <ListItem
@@ -171,6 +158,7 @@ export default function RemoveButton({
       >
         Remove
       </ListItemText>
+      <ConfirmationDialog />
     </ListItem>
   );
 }

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/removeButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/removeButton/index.jsx
@@ -94,6 +94,7 @@ export default function RemoveButton({
     title,
     setTitle,
     setConfirmText,
+    closeDialog,
   } = useContext(ConfirmationDialogContext);
 
   const handleOpenDialog = () => {
@@ -126,8 +127,7 @@ export default function RemoveButton({
     }
 
     if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
+      closeDialog();
       setConfirmationSetup(false);
     }
     setConfirmText(null);
@@ -142,8 +142,8 @@ export default function RemoveButton({
     setConfirmationSetup,
     setConfirmText,
     handleRemoveAgent,
-    setOpen,
     open,
+    closeDialog,
   ]);
 
   return (

--- a/components/resourceDetails/resourceSharing/agentAccess/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/index.jsx
@@ -47,7 +47,7 @@ export default function AgentAccess({ permission }) {
   } = useSession();
   const bem = useBem(useStyles());
   const { webId, acl } = permission;
-  const { dataset } = useContext(DatasetContext);
+  const { solidDataset: dataset } = useContext(DatasetContext);
   const [isLoadingProfile, setIsLoadingProfile] = useState(false);
   const [loading, setLoading] = useState(false);
   const resourceIri = getSourceUrl(dataset);

--- a/components/resourceDetails/resourceSharing/agentAccessOld/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccessOld/__snapshots__/index.test.jsx.snap
@@ -237,6 +237,7 @@ exports[`AgentAccess renders 1`] = `
         </ul>
         <button
           class="PodBrowser-button PodBrowser-button--secondary"
+          data-testid="permissions-form-submit-button"
           type="submit"
         >
           <span
@@ -545,6 +546,7 @@ exports[`AgentAccess renders an error message with a 'try again' button if it's 
             </ul>
             <button
               class="PodBrowser-button PodBrowser-button--secondary"
+              data-testid="permissions-form-submit-button"
               type="submit"
             >
               <span
@@ -811,6 +813,7 @@ exports[`AgentAccess user tries to change access for themselves checkboxes are d
         </ul>
         <button
           class="PodBrowser-button PodBrowser-button--secondary"
+          data-testid="permissions-form-submit-button"
           type="submit"
         >
           <span
@@ -1062,6 +1065,7 @@ exports[`AgentAccess user tries to change access for themselves checkboxes are o
         </ul>
         <button
           class="PodBrowser-button PodBrowser-button--secondary"
+          data-testid="permissions-form-submit-button"
           type="submit"
         >
           <span

--- a/components/resourceDetails/resourceSharing/agentAccessOld/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccessOld/index.jsx
@@ -42,6 +42,7 @@ import { Alert, Skeleton } from "@material-ui/lab";
 import PermissionsForm from "../../../permissionsForm";
 import styles from "./styles";
 import ConfirmationDialogContext from "../../../../src/contexts/confirmationDialogContext";
+import ConfirmationDialog from "../../../confirmationDialog";
 import {
   displayProfileName,
   fetchProfile,
@@ -55,6 +56,10 @@ const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 const TESTCAFE_ID_AGENT_WEB_ID = "agent-web-id";
 const TESTCAFE_ID_TRY_AGAIN_BUTTON = "try-again-button";
 const TESTCAFE_ID_TRY_AGAIN_SPINNER = "try-again-spinner";
+export const TESTCAFE_ID_PERMISSIONS_FORM_SUBMIT_BUTTON =
+  "permissions-form-submit-button";
+export const OWN_PERMISSIONS_WARNING_PERMISSION =
+  "You are about to change your own permissions. Are you sure?";
 
 export function submitHandler(
   authenticatedWebId,
@@ -68,7 +73,7 @@ export function submitHandler(
   return async (event) => {
     event.preventDefault();
     if (authenticatedWebId === webId) {
-      setContent("You are about to change your own permissions. Are you sure?");
+      setContent(OWN_PERMISSIONS_WARNING_PERMISSION);
       setOpen(dialogId);
     } else {
       await savePermissions(tempAccess);
@@ -121,7 +126,7 @@ export default function AgentAccess({ onLoading, permission: { acl, webId } }) {
   const bem = useBem(useStyles());
   const [access, setAccess] = useState(acl);
   const [tempAccess, setTempAccess] = useState(acl);
-  const { dataset } = useContext(DatasetContext);
+  const { solidDataset: dataset } = useContext(DatasetContext);
   const { accessControl } = useContext(AccessControlContext);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -231,12 +236,18 @@ export default function AgentAccess({ onLoading, permission: { acl, webId } }) {
               acl={access}
               onChange={setTempAccess}
             >
-              <PrismButton onClick={onSubmit} type="submit" variant="secondary">
+              <PrismButton
+                onClick={onSubmit}
+                type="submit"
+                variant="secondary"
+                data-testid={TESTCAFE_ID_PERMISSIONS_FORM_SUBMIT_BUTTON}
+              >
                 Save
               </PrismButton>
             </PermissionsForm>
           </Form>
         </div>
+        <ConfirmationDialog />
       </div>
     );
   }
@@ -276,11 +287,17 @@ export default function AgentAccess({ onLoading, permission: { acl, webId } }) {
           acl={access}
           onChange={setTempAccess}
         >
-          <PrismButton onClick={onSubmit} type="submit" variant="secondary">
+          <PrismButton
+            onClick={onSubmit}
+            type="submit"
+            variant="secondary"
+            data-testid={TESTCAFE_ID_PERMISSIONS_FORM_SUBMIT_BUTTON}
+          >
             Save
           </PrismButton>
         </PermissionsForm>
       </Form>
+      <ConfirmationDialog />
     </>
   );
 }

--- a/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
@@ -49,6 +49,7 @@ import styles from "./styles";
 import AddWebIdButton from "./addWebIdButton";
 import WebIdCheckbox from "./webIdCheckbox";
 import ConfirmationDialogContext from "../../../../src/contexts/confirmationDialogContext";
+import ConfirmationDialog from "../../../confirmationDialog";
 import usePolicyPermissions from "../../../../src/hooks/usePolicyPermissions";
 import useContacts from "../../../../src/hooks/useContacts";
 import { GROUP_CONTACT } from "../../../../src/models/contact/group";
@@ -69,6 +70,12 @@ import {
 } from "../../../../src/models/contact/authenticated";
 import ResourceInfoContext from "../../../../src/contexts/resourceInfoContext";
 import { getWebIdsFromPermissions } from "../../../../src/accessControl/acp";
+
+const AGENT_PREDICATE = "http://www.w3.org/ns/solid/acp#agent";
+const TESTCAFE_ID_ADD_AGENT_PICKER_MODAL = "agent-picker-modal";
+export const TESTCAFE_SUBMIT_WEBIDS_BUTTON = "submit-webids-button";
+const TESTCAFE_CANCEL_WEBIDS_BUTTON = "cancel-webids-button";
+export const DIALOG_ID = "add-new-permissions";
 
 export const handleSubmit = ({
   newAgentsWebIds,
@@ -133,39 +140,6 @@ export const handleSubmit = ({
   };
 };
 
-export const handleConfirmation = ({
-  open,
-  dialogId,
-  bypassDialog,
-  setConfirmationSetup,
-  setOpen,
-  setConfirmed,
-  setContent,
-  setTitle,
-  handleSubmitNewWebIds,
-}) => {
-  return (confirmationSetup, confirmed) => {
-    setConfirmationSetup(true);
-    if (bypassDialog) {
-      setConfirmed(true);
-      handleSubmitNewWebIds();
-    }
-    if (open !== dialogId) return;
-    if (confirmationSetup && confirmed === null) return;
-    if (confirmationSetup && confirmed) {
-      handleSubmitNewWebIds();
-    }
-
-    if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
-      setConfirmationSetup(false);
-      setContent(null);
-      setTitle(null);
-    }
-  };
-};
-
 export const handleSaveContact = async (iri, addressBook, fetch) => {
   let error;
   if (!iri) {
@@ -196,11 +170,6 @@ export const handleSaveContact = async (iri, addressBook, fetch) => {
 };
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
-const AGENT_PREDICATE = "http://www.w3.org/ns/solid/acp#agent";
-
-const TESTCAFE_ID_ADD_AGENT_PICKER_MODAL = "agent-picker-modal";
-export const TESTCAFE_SUBMIT_WEBIDS_BUTTON = "submit-webids-button";
-const TESTCAFE_CANCEL_WEBIDS_BUTTON = "cancel-webids-button";
 
 function AgentPickerModal(
   { type, onClose, setLoading, advancedSharing, editing },
@@ -230,7 +199,7 @@ function AgentPickerModal(
 
   const { session } = useSession();
   const { fetch } = session;
-  const { dataset } = useContext(DatasetContext);
+  const { solidDataset: dataset } = useContext(DatasetContext);
   const resourceIri = getSourceUrl(dataset);
   const resourceName = getResourceName(resourceIri);
   // TODO: Uncomment to reintroduce tabs
@@ -244,7 +213,6 @@ function AgentPickerModal(
   // const [filteredContacts, setFilteredContacts] = useState([]);
   const [addingWebId, setAddingWebId] = useState(false);
   const [globalFilter, setGlobalFilter] = useState("");
-  const dialogId = "add-new-permissions";
   const [confirmationSetup, setConfirmationSetup] = useState(false);
   const {
     open,
@@ -313,20 +281,8 @@ function AgentPickerModal(
     } permissions to ${header}`;
     setTitle(confirmationTitle);
     setContent(confirmationContent);
-    setOpen(dialogId);
+    setOpen(DIALOG_ID);
   };
-
-  const onConfirmation = handleConfirmation({
-    open,
-    dialogId,
-    bypassDialog,
-    setConfirmationSetup,
-    setOpen,
-    setConfirmed,
-    setContent,
-    setTitle,
-    handleSubmitNewWebIds,
-  });
 
   const updateTemporaryRowThing = (newThing) => {
     const { dataset: addressBookDataset } = addressBook;
@@ -366,8 +322,36 @@ function AgentPickerModal(
   // }, [contactsArray, selectedTabValue, globalFilter]);
 
   useEffect(() => {
-    onConfirmation(confirmationSetup, confirmed);
-  }, [confirmationSetup, confirmed, onConfirmation]);
+    setConfirmationSetup(true);
+    if (bypassDialog) {
+      setConfirmed(true);
+      handleSubmitNewWebIds();
+    }
+    if (open !== DIALOG_ID) return;
+    if (confirmationSetup && confirmed === null) return;
+    if (confirmationSetup && confirmed) {
+      handleSubmitNewWebIds();
+    }
+
+    if (confirmationSetup && confirmed !== null) {
+      setConfirmed(null);
+      setOpen(null);
+      setConfirmationSetup(false);
+      setContent(null);
+      setTitle(null);
+    }
+  }, [
+    open,
+    bypassDialog,
+    setConfirmationSetup,
+    confirmationSetup,
+    setOpen,
+    setConfirmed,
+    confirmed,
+    setContent,
+    setTitle,
+    handleSubmitNewWebIds,
+  ]);
 
   const handleAddRow = () => {
     setAddingWebId(true);
@@ -506,6 +490,7 @@ function AgentPickerModal(
         >
           {saveText}
         </Button>
+        <ConfirmationDialog />
       </div>
     </div>
   );

--- a/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
@@ -221,6 +221,7 @@ function AgentPickerModal(
     setContent,
     setOpen,
     setTitle,
+    closeDialog,
   } = useContext(ConfirmationDialogContext);
 
   // TODO: Uncomment to reintroduce tabs
@@ -334,23 +335,18 @@ function AgentPickerModal(
     }
 
     if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
+      closeDialog();
       setConfirmationSetup(false);
-      setContent(null);
-      setTitle(null);
     }
   }, [
     open,
     bypassDialog,
     setConfirmationSetup,
     confirmationSetup,
-    setOpen,
     setConfirmed,
     confirmed,
-    setContent,
-    setTitle,
     handleSubmitNewWebIds,
+    closeDialog,
   ]);
 
   const handleAddRow = () => {

--- a/components/resourceDetails/resourceSharing/policyActionButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/policyActionButton/index.jsx
@@ -33,38 +33,10 @@ import { AUTHENTICATED_AGENT_PREDICATE } from "../../../../src/models/contact/au
 import { PUBLIC_AGENT_PREDICATE } from "../../../../src/models/contact/public";
 import { serializePromises } from "../../../../src/solidClientHelpers/utils";
 import ConfirmationDialogContext from "../../../../src/contexts/confirmationDialogContext";
+import ConfirmationDialog from "../../../confirmationDialog";
 import { getResourceName } from "../../../../src/solidClientHelpers/resource";
 import { POLICIES_TYPE_MAP } from "../../../../constants/policies";
 import ResourceInfoContext from "../../../../src/contexts/resourceInfoContext";
-
-export const handleConfirmation = ({
-  open,
-  dialogId,
-  setConfirmationSetup,
-  setOpen,
-  setConfirmed,
-  setContent,
-  setTitle,
-  removeAllAgents,
-  webIds,
-}) => {
-  return (confirmationSetup, confirmed) => {
-    setConfirmationSetup(true);
-    if (open !== dialogId) return;
-    if (confirmationSetup && confirmed === null) return;
-    if (confirmationSetup && confirmed) {
-      removeAllAgents(webIds);
-    }
-
-    if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
-      setConfirmationSetup(false);
-      setContent(null);
-      setTitle(null);
-    }
-  };
-};
 
 export const TEXT_POLICY_ACTION_BUTTON_DISABLED_REMOVE_BUTTON =
   "There's no one to remove";
@@ -106,7 +78,7 @@ export default function PolicyActionButton({ permissions, setLoading, type }) {
   const policyType = getPolicyType(type);
   const dialogId = "remove-policy";
   const [policyToDelete, setPolicyToDelete] = useState();
-  const { dataset } = useContext(DatasetContext);
+  const { solidDataset: dataset } = useContext(DatasetContext);
   const resourceIri = getSourceUrl(dataset);
   const resourceName = resourceIri
     ? getResourceName(resourceIri)
@@ -145,21 +117,34 @@ export default function PolicyActionButton({ permissions, setLoading, type }) {
     mutateResourceInfo,
   });
 
-  const onConfirmation = handleConfirmation({
+  useEffect(() => {
+    setConfirmationSetup(true);
+    if (open !== dialogId) return;
+    if (confirmationSetup && confirmed === null) return;
+    if (confirmationSetup && confirmed) {
+      removeAllAgents(webIds);
+    }
+
+    if (confirmationSetup && confirmed !== null) {
+      setConfirmed(null);
+      setOpen(null);
+      setConfirmationSetup(false);
+      setContent(null);
+      setTitle(null);
+    }
+  }, [
     open,
     dialogId,
     setConfirmationSetup,
+    confirmationSetup,
     setOpen,
     setConfirmed,
+    confirmed,
     setContent,
     setTitle,
     removeAllAgents,
     webIds,
-  });
-
-  useEffect(() => {
-    onConfirmation(confirmationSetup, confirmed);
-  }, [confirmationSetup, confirmed, onConfirmation]);
+  ]);
 
   if (!policyType)
     return <ErrorMessage error={new Error("Type of policy not recognized")} />;
@@ -179,6 +164,7 @@ export default function PolicyActionButton({ permissions, setLoading, type }) {
       >
         {policyType.removeButtonLabel}
       </Button>
+      <ConfirmationDialog />
     </ActionButton>
   );
 }

--- a/components/resourceDetails/resourceSharing/policyActionButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/policyActionButton/index.jsx
@@ -88,10 +88,10 @@ export default function PolicyActionButton({ permissions, setLoading, type }) {
   const {
     open,
     confirmed,
-    setConfirmed,
     setContent,
     setOpen,
     setTitle,
+    closeDialog,
   } = useContext(ConfirmationDialogContext);
   const { mutate: mutateResourceInfo } = useContext(ResourceInfoContext);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
@@ -126,24 +126,18 @@ export default function PolicyActionButton({ permissions, setLoading, type }) {
     }
 
     if (confirmationSetup && confirmed !== null) {
-      setConfirmed(null);
-      setOpen(null);
+      closeDialog();
       setConfirmationSetup(false);
-      setContent(null);
-      setTitle(null);
     }
   }, [
     open,
     dialogId,
     setConfirmationSetup,
     confirmationSetup,
-    setOpen,
-    setConfirmed,
     confirmed,
-    setContent,
-    setTitle,
     removeAllAgents,
     webIds,
+    closeDialog,
   ]);
 
   if (!policyType)

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -47,7 +47,6 @@ import { AlertProvider } from "../src/contexts/alertContext";
 import { ConfirmationDialogProvider } from "../src/contexts/confirmationDialogContext";
 import { FeatureProvider } from "../src/contexts/featureFlagsContext";
 import Notification from "../components/notification";
-import ConfirmationDialog from "../components/confirmationDialog";
 import PodBrowserHeader from "../components/header";
 
 import "./styles.css";
@@ -154,7 +153,6 @@ export default function App(props) {
                       </main>
                     </div>
                     <Notification />
-                    <ConfirmationDialog />
                   </ConfirmationDialogProvider>
                 </AlertProvider>
               </FeatureProvider>

--- a/src/contexts/confirmationDialogContext/index.jsx
+++ b/src/contexts/confirmationDialogContext/index.jsx
@@ -35,6 +35,7 @@ export const defaultConfirmationDialogContext = {
   confirmText: "Confirm",
   setCancelText: () => {},
   setConfirmText: () => {},
+  closeDialog: () => {},
 };
 const ConfirmationDialogContext = createContext(
   defaultConfirmationDialogContext
@@ -49,6 +50,13 @@ function ConfirmationDialogProvider({ children }) {
   const [cancelText, setCancelText] = useState("Cancel");
   const [confirmText, setConfirmText] = useState("Confirm");
   const [confirmed, setConfirmed] = useState(null);
+
+  const closeDialog = () => {
+    setConfirmed(null);
+    setOpen(null);
+    setContent(null);
+    setTitle(null);
+  };
 
   return (
     <ConfirmationDialogContext.Provider
@@ -65,6 +73,7 @@ function ConfirmationDialogProvider({ children }) {
         setCancelText,
         confirmText,
         setConfirmText,
+        closeDialog,
       }}
     >
       {children}


### PR DESCRIPTION
In this PR:

- use confirmation dialog in the components where it's needed, so that it is appended in a way that can be tested

- write tests for interactions with the confirmation dialog

# To test: 

- Verify that the confirmation dialog works as intended in all the places where it's used:
