### PR TITLE
Fix: address book iri

### DIFF
--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -413,7 +413,7 @@ export async function saveContact(
   );
   const { iri } = newContact;
 
-  const indexIri = joinPath(addressBookContainerUrl, INDEX_FILE);
+  const indexIri = joinPath(addressBookContainerUrl, INDEX_FILE, "#this"); // FIXME: hack, should use the new address book model and get the url from there
   const { indexFilePredicate } = TYPE_MAP[foaf.Person];
 
   const { response: contact, error: saveContactError } = await saveResource(


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-906.

This PR fixes the issue of contacts adding the wrong iri for the address book. The fix is a temporary hack, the proper way of handling it is using the new address book model and getting the iri from there, which involves a refactor that turned out to be bigger than I expected so I will make a separate PR for that, since we're removing Contacts soon, and it's not a priority. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
