### PR TITLE
Fix/broken image request

### DIFF
--- a/components/agentList/index.jsx
+++ b/components/agentList/index.jsx
@@ -67,6 +67,10 @@ export function handleClose(setSelectedContactIndex) {
   return () => setSelectedContactIndex(null);
 }
 
+const RowAvatar = ({ value, row }) => (
+  <AgentAvatar altText={row.values.col1} imageUrl={value} />
+);
+
 export function handleDeleteContact({
   addressBook,
   closeDrawer,
@@ -212,9 +216,7 @@ function AgentList({ contactType, setSearchValues }) {
           property={hasPhotoPredicate}
           header=""
           dataType="url"
-          body={({ value, row }) => (
-            <AgentAvatar imageUrl={value} altText={row.values.col1} />
-          )}
+          body={RowAvatar}
         />
         <TableColumn
           property={formattedNamePredicate}
@@ -242,6 +244,20 @@ AgentList.propTypes = {
 
 AgentList.defaultProps = {
   contactType: "",
+};
+
+RowAvatar.propTypes = {
+  value: PropTypes.string,
+  row: PropTypes.shape({
+    values: PropTypes.shape({
+      col1: PropTypes.string,
+    }),
+  }),
+};
+
+RowAvatar.defaultProps = {
+  value: null,
+  row: null,
 };
 
 export default AgentList;

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -22,7 +22,8 @@
 import React, { useEffect, useState } from "react";
 import clsx from "clsx";
 import Link from "next/link";
-import { Avatar, createStyles } from "@material-ui/core";
+import T from "prop-types";
+import { createStyles } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
 import {
@@ -47,6 +48,7 @@ import useContactsOld from "../../src/hooks/useContactsOld";
 import useProfiles from "../../src/hooks/useProfiles";
 import ContactsListSearch from "./contactsListSearch";
 import ProfileLink from "../profileLink";
+import AgentAvatar from "../agentAvatar";
 import { SearchProvider } from "../../src/contexts/searchContext";
 import { deleteContact, getWebIdUrl } from "../../src/addressBook";
 import ContactsDrawer from "./contactsDrawer";
@@ -57,6 +59,10 @@ const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 export function handleClose(setSelectedContactIndex) {
   return () => setSelectedContactIndex(null);
 }
+
+const RowAvatar = ({ value, row }) => (
+  <AgentAvatar altText={row.values.col1} imageUrl={value} />
+);
 
 export function handleDeleteContact({
   addressBook,
@@ -198,15 +204,7 @@ function ContactsList() {
               property={hasPhotoPredicate}
               header=""
               dataType="url"
-              body={({ value, row }) => {
-                return (
-                  <Avatar
-                    className={bem("avatar")}
-                    alt={row.values.col1 || "Contact avatar"}
-                    src={value}
-                  />
-                );
-              }}
+              body={RowAvatar}
             />
             <TableColumn
               property={formattedNamePredicate}
@@ -222,8 +220,18 @@ function ContactsList() {
   );
 }
 
-ContactsList.propTypes = {};
+RowAvatar.propTypes = {
+  value: T.string,
+  row: T.shape({
+    values: T.shape({
+      col1: T.string,
+    }),
+  }),
+};
 
-ContactsList.defaultProps = {};
+RowAvatar.defaultProps = {
+  value: null,
+  row: null,
+};
 
 export default ContactsList;

--- a/components/deleteButton/index.jsx
+++ b/components/deleteButton/index.jsx
@@ -143,5 +143,9 @@ DeleteButton.propTypes = {
   dialogId: T.string.isRequired,
   onDelete: T.func.isRequired,
   successMessage: T.string.isRequired,
-  resourceName: T.string.isRequired,
+  resourceName: T.string,
+};
+
+DeleteButton.defaultProps = {
+  resourceName: "this resource",
 };


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-523.

In this PR:
 - Extracted the custom body for the image to prevent re-renders, both in the Contacts and Privacy pages (some duplicate code but we're removing Contacts soon)
 - Fixed a prop type warning by making a prop optional in the Delete Button

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

