### PR TITLE
Fix: disallow adding own WebID to permissions

### DIFF
--- a/components/resourceDetails/resourceSharing/addAgentRow/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/addAgentRow/__snapshots__/index.test.jsx.snap
@@ -21,7 +21,6 @@ exports[`AddAgentRow when adding a new webId renders a row with an input for the
             title="Must start with https://"
           >
             <input
-              aria-invalid="false"
               class="PodBrowser-input PodBrowser-input"
               data-testid="webid-input"
               placeholder="Enter WebID"

--- a/components/resourceDetails/resourceSharing/addAgentRow/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentRow/index.test.jsx
@@ -24,6 +24,8 @@ import userEvent from "@testing-library/user-event";
 import { useSession, useThing } from "@inrupt/solid-ui-react";
 import { addUrl, createThing } from "@inrupt/solid-client";
 import AddAgentRow, {
+  EXISTING_WEBID_ERROR_MESSAGE,
+  OWN_WEBID_ERROR_MESSAGE,
   TESTCAFE_ID_ADD_WEBID_BUTTON,
   TESTCAFE_ID_WEBID_INPUT,
 } from "./index";
@@ -42,7 +44,10 @@ describe("AddAgentRow", () => {
     const mockThing = createThing();
     beforeEach(() => {
       mockedThingHook.mockReturnValue({ thing: mockThing });
-      useSession.mockReturnValue({ fetch: jest.fn() });
+      useSession.mockReturnValue({
+        fetch: jest.fn(),
+        session: { info: { webId: "https://podownerwebid.com/" } },
+      });
       mockedUseContactProfile.mockReturnValue({ data: null });
     });
     const index = 0;
@@ -86,7 +91,27 @@ describe("AddAgentRow", () => {
       const addButton = getByTestId(TESTCAFE_ID_ADD_WEBID_BUTTON);
       userEvent.type(input, "https://example.org/profile/card#me");
       userEvent.click(addButton);
-      const errorText = getByText("That WebID has already been added");
+      const errorText = getByText(EXISTING_WEBID_ERROR_MESSAGE);
+      expect(errorText).not.toBeNull();
+    });
+    it("renders a validation error if added webId is own webId", () => {
+      const { getByTestId, getByText } = renderWithTheme(
+        <AddAgentRow
+          index={index}
+          setNewAgentsWebIds={setNewAgentsWebIds}
+          newAgentsWebIds={newAgentsWebIds}
+          setAddingWebId={setAddingWebId}
+          setNoAgentsAlert={setNoAgentsAlert}
+          addingWebId={addingWebId}
+          updateTemporaryRowThing={updateTemporaryRowThing}
+          permissions={permissions}
+        />
+      );
+      const input = getByTestId(TESTCAFE_ID_WEBID_INPUT);
+      const addButton = getByTestId(TESTCAFE_ID_ADD_WEBID_BUTTON);
+      userEvent.type(input, "https://podownerwebid.com/");
+      userEvent.click(addButton);
+      const errorText = getByText(OWN_WEBID_ERROR_MESSAGE);
       expect(errorText).not.toBeNull();
     });
     it("clears error when changing input again", () => {


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-899.

- Added a check to display a validation error when the user tries to add themselves as an agent to a policy.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
