### PR TITLE
Switch vcard.fn to foaf.name

### DIFF
--- a/__testUtils/mockApp.js
+++ b/__testUtils/mockApp.js
@@ -24,11 +24,9 @@ import {
   addUrl,
   createSolidDataset,
   createThing,
-  setStringNoLocale,
   setThing,
-  setUrl,
 } from "@inrupt/solid-client";
-import { vcard, rdf, schema } from "rdf-namespaces";
+import { vcard, rdf, schema, foaf } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { vcardExtras } from "../src/addressBook";
 
@@ -44,7 +42,7 @@ export const APP_TOS_URL = "https://mockappurl.com/terms-of-service";
 
 const contactThing = chain(
   createThing({ url: "https://mockappurl.com#contacts" }),
-  (t) => addStringNoLocale(t, vcard.fn, "Example Contact"),
+  (t) => addStringNoLocale(t, foaf.name, "Example Contact"),
   (t) => addStringNoLocale(t, vcard.hasTelephone, "555-5555"),
   (t) => addStringNoLocale(t, vcard.hasEmail, "example@email.com"),
   (t) => addUrl(t, vcard.url, "https://examplewebsite.com")
@@ -55,7 +53,7 @@ const dataset = setThing(createSolidDataset(), contactThing);
 export function mockApp() {
   return chain(
     createThing({ url: APP_WEBID }),
-    (t) => addStringNoLocale(t, vcard.fn, "Mock App"),
+    (t) => addStringNoLocale(t, foaf.name, "Mock App"),
     (t) => addUrl(t, vcardExtras("WebId"), APP_WEBID),
     (t) => addUrl(t, rdf.type, schema.SoftwareApplication), // just guessing what the type might be for apps
     (t) => addUrl(t, TOS_PREDICATE, APP_TOS_URL),

--- a/__testUtils/mockGroup.js
+++ b/__testUtils/mockGroup.js
@@ -30,7 +30,7 @@ import {
   setThing,
   setUrl,
 } from "@inrupt/solid-client";
-import { rdf, vcard } from "rdf-namespaces";
+import { foaf, rdf, vcard } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { getBaseUrl } from "../src/solidClientHelpers/resource";
 
@@ -66,7 +66,7 @@ export function mockGroupThing(name, url, { description, members } = {}) {
   return chain(
     mockThingFrom(url),
     (t) => setUrl(t, rdf.type, vcard.Group),
-    (t) => setStringNoLocale(t, vcard.fn, name),
+    (t) => setStringNoLocale(t, foaf.name, name),
     ...(members || []).map((agentUrl) => (t) =>
       addUrl(t, vcard.hasMember, agentUrl)
     ),

--- a/__testUtils/mockPersonContact.js
+++ b/__testUtils/mockPersonContact.js
@@ -27,7 +27,7 @@ import {
   setThing,
   setUrl,
 } from "@inrupt/solid-client";
-import { vcard } from "rdf-namespaces";
+import { foaf } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { vcardExtras } from "../src/addressBook";
 import { getBaseUrl } from "../src/solidClientHelpers/resource";
@@ -35,7 +35,7 @@ import { getBaseUrl } from "../src/solidClientHelpers/resource";
 function mockContactPersonThing(addressBook, personThingUrl, name) {
   return chain(
     mockThingFrom(personThingUrl),
-    (t) => setStringNoLocale(t, vcard.fn, name),
+    (t) => setStringNoLocale(t, foaf.name, name),
     (t) => setUrl(t, vcardExtras("inAddressBook"), asUrl(addressBook.thing))
   );
 }

--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -57,7 +57,7 @@ export const aliceAlternativeWebIdUrl = "https://alice2.example.org/card#me";
 export function mockPersonDatasetAlice(...operations) {
   return chain(
     mockThingFrom(aliceWebIdUrl),
-    (t) => addStringNoLocale(t, vcard.fn, aliceName),
+    (t) => addStringNoLocale(t, foaf.name, aliceName),
     (t) => addStringNoLocale(t, vcard.nickname, aliceNick),
     (t) => addUrl(t, vcard.hasPhoto, alicePhoto),
     (t) => addUrl(t, rdf.type, foaf.Person),

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { vcard } from "rdf-namespaces";
+import { foaf } from "rdf-namespaces";
 import {
   addStringNoLocale,
   mockSolidDatasetFrom,
@@ -172,7 +172,7 @@ describe("handleSubmit", () => {
     const personUri = "http://example.com/alice#me";
     const personDataset = addStringNoLocale(
       mockThingFrom(personUri),
-      vcard.fn,
+      foaf.name,
       "Alice"
     );
     const contactsIri = contactsContainerIri("http://www.example.com/");

--- a/components/agentList/index.jsx
+++ b/components/agentList/index.jsx
@@ -114,7 +114,7 @@ function AgentList({ contactType, setSearchValues }) {
     }
   }, [profiles, contactType]);
 
-  const formattedNamePredicate = vcard.fn;
+  const namePredicate = foaf.name;
   const hasPhotoPredicate = vcard.hasPhoto;
 
   const {
@@ -133,13 +133,13 @@ function AgentList({ contactType, setSearchValues }) {
   useEffect(() => {
     if (selectedContactIndex === null) return;
     const contactThing = profilesForTable[selectedContactIndex];
-    const name = getStringNoLocale(contactThing, formattedNamePredicate);
+    const name = getStringNoLocale(contactThing, namePredicate);
     const type = getUrl(contactThing, rdf.type);
     setAgentType(type);
     setSelectedContactName(name);
     const webId = getUrl(contactThing, vcardExtras("WebId"));
     setSelectedContactWebId(webId);
-  }, [selectedContactIndex, formattedNamePredicate, profilesForTable, fetch]);
+  }, [selectedContactIndex, namePredicate, profilesForTable, fetch]);
 
   if (addressBookError) return addressBookError;
   if (contactsError) return contactsError;
@@ -216,7 +216,7 @@ function AgentList({ contactType, setSearchValues }) {
           body={RowAvatar}
         />
         <TableColumn
-          property={formattedNamePredicate}
+          property={namePredicate}
           header="Name"
           filterable
           sortable

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -102,7 +102,7 @@ function ContactsList() {
     mutate: peopleMutate,
   } = useContactsOld(addressBook, foaf.Person);
   const profiles = useProfiles(people);
-  const formattedNamePredicate = vcard.fn;
+  const formattedNamePredicate = foaf.name;
   const hasPhotoPredicate = vcard.hasPhoto;
 
   const {

--- a/components/profile/appProfile/index.jsx
+++ b/components/profile/appProfile/index.jsx
@@ -20,7 +20,7 @@
  */
 
 import React, { useState } from "react";
-import { vcard } from "rdf-namespaces";
+import { foaf, vcard } from "rdf-namespaces";
 import clsx from "clsx";
 import { getThing, getUrl } from "@inrupt/solid-client";
 import {
@@ -116,7 +116,7 @@ export default function AppProfile() {
 
                 <Box p={2}>
                   <h3 data-testid={TESTCAFE_ID_NAME_TITLE}>
-                    <Text property={vcard.fn} />
+                    <Text property={foaf.name} />
                   </h3>
                 </Box>
               </Box>

--- a/components/profile/personProfile/index.jsx
+++ b/components/profile/personProfile/index.jsx
@@ -21,7 +21,7 @@
 
 import React, { useState } from "react";
 import T from "prop-types";
-import { vcard } from "rdf-namespaces";
+import { foaf, vcard } from "rdf-namespaces";
 import {
   Avatar,
   Box,
@@ -98,7 +98,7 @@ export default function PersonProfile({ profileIri, editing }) {
 
               <Box p={2}>
                 <h3 data-testid={TESTCAFE_ID_NAME_TITLE}>
-                  <Text property={vcard.fn} />
+                  <Text property={foaf.name} />
                 </h3>
               </Box>
             </Box>
@@ -109,7 +109,7 @@ export default function PersonProfile({ profileIri, editing }) {
               <Box>
                 <InputLabel>Name</InputLabel>
                 <Text
-                  property={vcard.fn}
+                  property={foaf.name}
                   edit={editing}
                   autosave
                   inputProps={{

--- a/components/profileLink/index.jsx
+++ b/components/profileLink/index.jsx
@@ -50,8 +50,8 @@ export default function ProfileLink(props) {
 
   // TODO remove this once react-sdk allows property fallbacks
   const name =
-    getStringNoLocale(thing, vcard.fn) ||
     getStringNoLocale(thing, foaf.name) ||
+    getStringNoLocale(thing, vcard.fn) ||
     profileIri;
 
   return (

--- a/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
@@ -35,7 +35,7 @@ import {
   useSession,
 } from "@inrupt/solid-ui-react";
 import { createThing, getSourceUrl } from "@inrupt/solid-client";
-import { vcard } from "rdf-namespaces";
+import { foaf } from "rdf-namespaces";
 import { serializePromises } from "../../../../src/solidClientHelpers/utils";
 import AccessControlContext from "../../../../src/contexts/accessControlContext";
 import { fetchProfile } from "../../../../src/solidClientHelpers/profile";
@@ -437,7 +437,7 @@ function AgentPickerModal(
             />
             <TableColumn
               header={<span className={classes.tableHeader}>Name</span>}
-              property={vcard.fn}
+              property={foaf.name}
               filterable
               body={({ row: { index } }) => (
                 <AddAgentRow

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -143,7 +143,7 @@ export async function getGroups(containerIri, fetch) {
     const groupThing = getThing(dataset, iri);
     return {
       iri,
-      name: getStringNoLocale(groupThing, vcard.fn),
+      name: getStringNoLocale(groupThing, foaf.name),
     };
   });
 
@@ -434,7 +434,7 @@ export async function saveContact(
       url: `${getSourceUrl(contact)}#this`,
     },
     (t) =>
-      addStringNoLocale(t, vcard.fn, contactSchema.fn || contactSchema.name),
+      addStringNoLocale(t, foaf.name, contactSchema.fn || contactSchema.name),
     (t) => addUrl(t, vcardExtras("inAddressBook"), indexIri)
   );
 

--- a/src/addressBook/index.test.js
+++ b/src/addressBook/index.test.js
@@ -158,7 +158,7 @@ describe("createContact", () => {
           streetAddress: "123 Fake St.",
         },
       ],
-      fn: "Test Person",
+      name: "Test Person",
       emails: [
         {
           type: "Home",
@@ -193,7 +193,7 @@ describe("createContact", () => {
       (memo, t) => memo.concat(getStringNoLocaleAll(t, vcard.value)),
       []
     );
-    expect(getStringNoLocale(webId, vcard.fn)).toEqual("Test Person");
+    expect(getStringNoLocale(webId, foaf.name)).toEqual("Test Person");
     expect(mockWebIdNodeFn).toHaveBeenCalledWith(webIdUrl, expect.anything());
     expect(getUrl(webId, vcard.url)).toEqual(webIdNodeUrl);
     expect(getStringNoLocale(webId, vcardExtras("organization-name"))).toEqual(
@@ -255,14 +255,14 @@ describe("getGroups", () => {
             setThing(
               d,
               chain(mockThingFrom(group1Url), (t) =>
-                setStringNoLocale(t, vcard.fn, "Group1")
+                setStringNoLocale(t, foaf.name, "Group1")
               )
             ),
           (d) =>
             setThing(
               d,
               chain(mockThingFrom(group2Url), (t) =>
-                setStringNoLocale(t, vcard.fn, "Group2")
+                setStringNoLocale(t, foaf.name, "Group2")
               )
             )
         ),
@@ -317,12 +317,12 @@ describe("getSchemaFunction", () => {
 
 describe("mapSchema", () => {
   test("it maps the schema to a thing with a generated name with a prefix", () => {
-    const schema = { fn: "test" };
+    const schema = { name: "test" };
     const fn = mapSchema("prefix");
     const { name, thing } = fn(schema);
 
     expect(name).toMatch(/prefix-[\w\d]{7}/);
-    expect(getStringNoLocale(thing, vcard.fn)).toEqual("test");
+    expect(getStringNoLocale(thing, foaf.name)).toEqual("test");
   });
 });
 

--- a/src/featureFlags/index.js
+++ b/src/featureFlags/index.js
@@ -28,6 +28,7 @@ const webIdsWithAccessToFeatures = [
   "https://megoth-demo3.inrupt.net/profile/card#me",
   "https://pod.inrupt.com/kyra/profile/card#me",
   "https://pod.inrupt.com/virginiabalseiro/profile/card#me",
+  "https://virginiabalseiro.inrupt.net/profile/card#me",
   "https://pod.inrupt.com/efe/profile/card#me",
   "https://podbrowser.inrupt.net/profile/card#me",
   "https://podbrowser2.inrupt.net/profile/card#me",

--- a/src/models/contact/group/index.js
+++ b/src/models/contact/group/index.js
@@ -39,7 +39,7 @@ import {
   setThing,
   setUrl,
 } from "@inrupt/solid-client";
-import { ldp, rdf, vcard } from "rdf-namespaces";
+import { ldp, rdf, vcard, foaf } from "rdf-namespaces";
 import { v4 as uuid } from "uuid";
 import { chain } from "../../../solidClientHelpers/utils";
 import { getContainerUrl, joinPath } from "../../../stringHelpers";
@@ -71,7 +71,7 @@ function createGroupThing(name, thingOptions) {
   return chain(
     createThing(thingOptions),
     (t) => setUrl(t, rdf.type, vcard.Group),
-    (t) => setStringNoLocale(t, vcard.fn, name)
+    (t) => setStringNoLocale(t, foaf.name, name)
   );
 }
 
@@ -159,7 +159,7 @@ export async function renameGroup(
   // update the group itself
   const updatedGroup = chain(
     group.thing,
-    (t) => setStringNoLocale(t, vcard.fn, name),
+    (t) => setStringNoLocale(t, foaf.name, name),
     ...[
       (t) => removeStringNoLocale(t, vcard.note, getGroupDescription(group)),
       (t) =>
@@ -181,7 +181,7 @@ export async function renameGroup(
     groupIndexUrl,
     setThing(
       groupIndexDataset,
-      setStringNoLocale(existingGroup, vcard.fn, name)
+      setStringNoLocale(existingGroup, foaf.name, name)
     ),
     { fetch }
   );

--- a/src/models/contact/group/index.test.js
+++ b/src/models/contact/group/index.test.js
@@ -33,7 +33,7 @@ import {
   setUrl,
 } from "@inrupt/solid-client";
 import { v4 as uuid } from "uuid";
-import { ldp, rdf, vcard } from "rdf-namespaces";
+import { foaf, ldp, rdf, vcard } from "rdf-namespaces";
 import mockAddressBook from "../../../../__testUtils/mockAddressBook";
 import {
   saveGroup,
@@ -203,7 +203,7 @@ describe("saveGroup", () => {
     ); // TODO: Remove when we have support for getThingLocal
     const groupThing = groupDatasetThings[0];
     expect(getUrl(groupThing, rdf.type)).toEqual(vcard.Group);
-    expect(getStringNoLocale(groupThing, vcard.fn)).toEqual("test");
+    expect(getStringNoLocale(groupThing, foaf.name)).toEqual("test");
     const groupIncludesTriple = groupDatasetThings[1];
     expect(
       getUrlAll(groupIncludesTriple, vcardExtras("includesGroup"))
@@ -218,7 +218,7 @@ describe("saveGroup", () => {
     const indexDataset = mockedSaveSolidDatasetAt.mock.calls[1][1];
     const indexThing = getThing(indexDataset, group1Url);
     expect(getUrl(indexThing, rdf.type)).toEqual(vcard.Group);
-    expect(getStringNoLocale(indexThing, vcard.fn)).toEqual("test");
+    expect(getStringNoLocale(indexThing, foaf.name)).toEqual("test");
     const addressBookInIndex = getThing(
       indexDataset,
       getAddressBookThingUrl(addressBookWithGroupIndex)
@@ -334,7 +334,7 @@ describe("renameGroup", () => {
       mockedSaveSolidDatasetAt.mock.calls[0][1]
     ); // TODO: Remove when we have support for getThingLocal
     const groupThing = groupDatasetThings[0];
-    expect(getStringNoLocale(groupThing, vcard.fn)).toEqual(newName);
+    expect(getStringNoLocale(groupThing, foaf.name)).toEqual(newName);
     expect(getStringNoLocale(groupThing, vcard.note)).toBeNull();
 
     // second save request is the group index
@@ -347,7 +347,7 @@ describe("renameGroup", () => {
       mockedSaveSolidDatasetAt.mock.calls[1][1]
     ); // TODO: Remove when we have support for getThingLocal
     const indexThing = indexDatasetThings[0];
-    expect(getStringNoLocale(indexThing, vcard.fn)).toEqual(newName);
+    expect(getStringNoLocale(indexThing, foaf.name)).toEqual(newName);
     expect(getStringNoLocale(indexThing, vcard.note)).toBeNull();
   });
 
@@ -376,7 +376,7 @@ describe("renameGroup", () => {
       mockedSaveSolidDatasetAt.mock.calls[0][1]
     ); // TODO: Remove when we have support for getThingLocal
     const groupThing = groupDatasetThings[0];
-    expect(getStringNoLocale(groupThing, vcard.fn)).toEqual(newName);
+    expect(getStringNoLocale(groupThing, foaf.name)).toEqual(newName);
     expect(getStringNoLocale(groupThing, vcard.note)).toEqual(newDescription);
   });
 });

--- a/src/models/contact/index.test.js
+++ b/src/models/contact/index.test.js
@@ -25,7 +25,7 @@ import {
   getStringNoLocale,
   mockSolidDatasetFrom,
 } from "@inrupt/solid-client";
-import { vcard } from "rdf-namespaces";
+import { foaf } from "rdf-namespaces";
 import mockAddressBook from "../../../__testUtils/mockAddressBook";
 import { getContactAll } from "./index";
 import { addGroupToMockedIndexDataset } from "../../../__testUtils/mockGroupContact";
@@ -96,7 +96,7 @@ describe("getContactAll", () => {
     expect(groups).toHaveLength(1);
     const [group1] = groups;
     expect(asUrl(group1.thing)).toEqual(group1Url);
-    expect(getStringNoLocale(group1.thing, vcard.fn)).toEqual(group1Name);
+    expect(getStringNoLocale(group1.thing, foaf.name)).toEqual(group1Name);
     expect(group1.dataset).toBe(groupsDataset);
   });
 
@@ -109,7 +109,7 @@ describe("getContactAll", () => {
     expect(people).toHaveLength(1);
     const [person1] = people;
     expect(asUrl(person1.thing)).toEqual(person1Url);
-    expect(getStringNoLocale(person1.thing, vcard.fn)).toEqual(person1Name);
+    expect(getStringNoLocale(person1.thing, foaf.name)).toEqual(person1Name);
     expect(person1.dataset).toBe(peopleDataset);
   });
 

--- a/src/models/contact/person/index.js
+++ b/src/models/contact/person/index.js
@@ -157,7 +157,7 @@ export async function savePerson(addressBook, contactSchema, fetch) {
       url: `${getSourceUrl(personDataset)}#this`,
     },
     (t) =>
-      addStringNoLocale(t, vcard.fn, contactSchema.fn || contactSchema.name),
+      addStringNoLocale(t, foaf.name, contactSchema.fn || contactSchema.name),
     (t) => addUrl(t, vcardExtras("inAddressBook"), indexIri)
   );
 

--- a/src/models/dataset/index.test.js
+++ b/src/models/dataset/index.test.js
@@ -27,7 +27,7 @@ import {
   setStringNoLocale,
   setThing,
 } from "@inrupt/solid-client";
-import { vcard } from "rdf-namespaces/dist/index";
+import { foaf } from "rdf-namespaces/dist/index";
 import { getOrCreateDataset, updateOrCreateDataset } from "./index";
 
 const resourceUrl = "http://example.com/random.ttl";
@@ -68,7 +68,7 @@ describe("getOrCreateDataset", () => {
 describe("updateOrCreateDataset", () => {
   const existingThing = setStringNoLocale(
     mockThingFrom("http://example.com/random.ttl#foo"),
-    vcard.fn,
+    foaf.name,
     "Test 1"
   );
   const existingDataset = setThing(
@@ -77,7 +77,7 @@ describe("updateOrCreateDataset", () => {
   );
   const newThing = setStringNoLocale(
     mockThingFrom("http://example.com/random.ttl#bar"),
-    vcard.fn,
+    foaf.name,
     "Test 2"
   );
 

--- a/src/models/group/index.js
+++ b/src/models/group/index.js
@@ -31,7 +31,7 @@ import {
   saveSolidDatasetAt,
   setThing,
 } from "@inrupt/solid-client";
-import { vcard } from "rdf-namespaces";
+import { foaf, vcard } from "rdf-namespaces";
 import { getBaseUrl } from "../../solidClientHelpers/resource";
 
 /*
@@ -52,7 +52,7 @@ export function getGroupUrl(group) {
 }
 
 export function getGroupName(group) {
-  return getStringNoLocale(group.thing, vcard.fn);
+  return getStringNoLocale(group.thing, foaf.name);
 }
 
 export function getGroupDescription(group) {

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -39,8 +39,8 @@ export function getProfileFromPersonThing(profileThing) {
   return {
     avatar: getUrl(profileThing, vcard.hasPhoto),
     name:
-      getStringNoLocale(profileThing, vcard.fn) ||
-      getStringNoLocale(profileThing, foaf.name),
+      getStringNoLocale(profileThing, foaf.name) ||
+      getStringNoLocale(profileThing, vcard.fn),
     nickname:
       getStringNoLocale(profileThing, vcard.nickname) ||
       getStringNoLocale(profileThing, foaf.nick),


### PR DESCRIPTION
# Using foaf.name instead of vcard.fn

This PR changes the uses of `vcard.fn` to `foaf.name` throughout the app.

## To test:
Verify that names are displayed correctly both on NSS and ESS for the following pages:

- User profile (own and contacts)
- Contacts
- Privacy
- Permissions (NSS)
- Sharing (ESS)
- Groups

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
