### PR TITLE
Fix: redirect browser bookmark

### DIFF
--- a/__testUtils/mockLocalStorage.js
+++ b/__testUtils/mockLocalStorage.js
@@ -19,19 +19,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import PropTypes from "prop-types";
-
-import LoginPage from "../components/pages/login";
-
-export default function Login({ history }) {
-  return <LoginPage history={history} />;
+export default function mockLocalStorage() {
+  const store = {};
+  return {
+    getItem(key) {
+      return store[key];
+    },
+    setItem(key, value) {
+      store[key] = value.toString();
+    },
+  };
 }
-
-Login.propTypes = {
-  history: PropTypes.arrayOf(PropTypes.string),
-};
-
-Login.defaultProps = {
-  history: [],
-};

--- a/components/pages/index/index.jsx
+++ b/components/pages/index/index.jsx
@@ -32,22 +32,26 @@ import usePreviousPage from "../../../src/hooks/usePreviousPage";
 export default function Home() {
   const router = useRouter();
   const previousPage = usePreviousPage();
-  useRedirectIfLoggedOut(previousPage);
+  useRedirectIfLoggedOut();
 
   const { session } = useSession();
   const { webId = "" } = session.info;
   const { data: podIris = [] } = usePodIrisFromWebId(webId);
   const [podIri] = podIris;
+  const redirectUrl = previousPage || null;
 
   useEffect(() => {
-    if (previousPage) {
-      router.push(previousPage);
-    } else if (podIri) {
+    if (redirectUrl && redirectUrl !== "/") {
+      router.push(redirectUrl).catch((e) => {
+        throw e;
+      });
+    }
+    if (podIri) {
       router.replace("/resource/[iri]", resourceHref(podIri)).catch((e) => {
         throw e;
       });
     }
-  }, [podIri, router, previousPage]);
+  }, [podIri, router, redirectUrl]);
 
   return null;
 }

--- a/components/pages/index/index.jsx
+++ b/components/pages/index/index.jsx
@@ -27,23 +27,27 @@ import { useRedirectIfLoggedOut } from "../../../src/effects/auth";
 
 import { resourceHref } from "../../../src/navigator";
 import usePodIrisFromWebId from "../../../src/hooks/usePodIrisFromWebId";
+import usePreviousPage from "../../../src/hooks/usePreviousPage";
 
 export default function Home() {
-  useRedirectIfLoggedOut();
-
   const router = useRouter();
+  const previousPage = usePreviousPage();
+  useRedirectIfLoggedOut(previousPage);
+
   const { session } = useSession();
   const { webId = "" } = session.info;
   const { data: podIris = [] } = usePodIrisFromWebId(webId);
   const [podIri] = podIris;
 
   useEffect(() => {
-    if (podIri) {
+    if (previousPage) {
+      router.push(previousPage);
+    } else if (podIri) {
       router.replace("/resource/[iri]", resourceHref(podIri)).catch((e) => {
         throw e;
       });
     }
-  }, [podIri, router]);
+  }, [podIri, router, previousPage]);
 
   return null;
 }

--- a/components/pages/index/index.test.jsx
+++ b/components/pages/index/index.test.jsx
@@ -28,10 +28,12 @@ import IndexPage from "./index";
 import { mockUnauthenticatedSession } from "../../../__testUtils/mockSession";
 import { resourceHref } from "../../../src/navigator";
 import usePodIrisFromWebId from "../../../src/hooks/usePodIrisFromWebId";
+import usePreviousPage from "../../../src/hooks/usePreviousPage";
 import TestApp from "../../../__testUtils/testApp";
 
 jest.mock("../../../src/effects/auth");
 jest.mock("../../../src/hooks/usePodIrisFromWebId");
+jest.mock("../../../src/hooks/usePreviousPage");
 jest.mock("next/router");
 
 describe("Index page", () => {
@@ -76,6 +78,22 @@ describe("Index page", () => {
       "/resource/[iri]",
       resourceHref(podIri)
     );
+  });
+
+  test("Redirects to the previous page if it is available", () => {
+    const push = jest.fn().mockResolvedValue(undefined);
+    const previousPage = "https://pod.example.com/someresource.txt";
+
+    nextRouterFns.useRouter.mockReturnValue({ push });
+    usePreviousPage.mockReturnValue(previousPage);
+
+    render(
+      <TestApp>
+        <IndexPage />
+      </TestApp>
+    );
+
+    expect(push).toHaveBeenCalledWith(previousPage);
   });
 
   test("Redirects if the user is logged out", () => {

--- a/components/pages/index/index.test.jsx
+++ b/components/pages/index/index.test.jsx
@@ -82,9 +82,10 @@ describe("Index page", () => {
 
   test("Redirects to the previous page if it is available", () => {
     const push = jest.fn().mockResolvedValue(undefined);
-    const previousPage = "https://pod.example.com/someresource.txt";
+    const replace = jest.fn().mockResolvedValue(undefined);
+    const previousPage = "/resource/https://pod.example.com/someresource.txt";
 
-    nextRouterFns.useRouter.mockReturnValue({ push });
+    nextRouterFns.useRouter.mockReturnValue({ push, replace });
     usePreviousPage.mockReturnValue(previousPage);
 
     render(
@@ -97,6 +98,11 @@ describe("Index page", () => {
   });
 
   test("Redirects if the user is logged out", () => {
+    usePreviousPage.mockReturnValue(null);
+    const replace = jest.fn().mockResolvedValue(undefined);
+
+    nextRouterFns.useRouter.mockReturnValue({ replace });
+
     render(
       <TestApp session={mockUnauthenticatedSession()}>
         <IndexPage />

--- a/components/pages/login/__snapshots__/index.test.jsx.snap
+++ b/components/pages/login/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Login page Renders a login button 1`] = `
+exports[`Login page renders a login button 1`] = `
 <DocumentFragment>
   <div
     class="PodBrowser-login-page"

--- a/components/pages/login/index.jsx
+++ b/components/pages/login/index.jsx
@@ -58,9 +58,10 @@ const links = [
 ];
 
 export default function Login({ history }) {
-  const filteredHistory = history.filter((url) => url !== "/login");
+  const filteredHistory = history.slice(0, history.indexOf("/login"));
   const previousPage = filteredHistory[filteredHistory.length - 1];
-  useRedirectIfLoggedIn(previousPage);
+  const redirectUrl = previousPage || "/";
+  useRedirectIfLoggedIn(redirectUrl);
   const bem = useBem(useStyles());
   const buttonBem = Button.useBem();
 

--- a/components/pages/login/index.jsx
+++ b/components/pages/login/index.jsx
@@ -67,7 +67,9 @@ export default function Login({ history }) {
 
   useEffect(() => {
     if (!localStorage) return;
-    localStorage.setItem("previousPage", previousPage);
+    if (previousPage) {
+      localStorage.setItem("previousPage", previousPage);
+    }
   }, [previousPage]);
 
   return (

--- a/components/pages/login/index.jsx
+++ b/components/pages/login/index.jsx
@@ -19,7 +19,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
+import React, { useEffect } from "react";
+import PropTypes from "prop-types";
 import { createStyles, makeStyles } from "@material-ui/styles";
 import { Button } from "@inrupt/prism-react-components";
 import clsx from "clsx";
@@ -56,10 +57,17 @@ const links = [
   },
 ];
 
-export default function Login() {
-  useRedirectIfLoggedIn();
+export default function Login({ history }) {
+  const filteredHistory = history.filter((url) => url !== "/login");
+  const previousPage = filteredHistory[filteredHistory.length - 1];
+  useRedirectIfLoggedIn(previousPage);
   const bem = useBem(useStyles());
   const buttonBem = Button.useBem();
+
+  useEffect(() => {
+    if (!localStorage) return;
+    localStorage.setItem("previousPage", previousPage);
+  }, [previousPage]);
 
   return (
     <div className={bem("login-page")}>
@@ -101,3 +109,11 @@ export default function Login() {
     </div>
   );
 }
+
+Login.propTypes = {
+  history: PropTypes.arrayOf(PropTypes.string),
+};
+
+Login.defaultProps = {
+  history: [],
+};

--- a/components/pages/login/index.test.jsx
+++ b/components/pages/login/index.test.jsx
@@ -33,13 +33,50 @@ describe("Login page", () => {
     useIdpFromQuery.mockReturnValue(null);
   });
 
-  test("Renders a login button", () => {
+  it("renders a login button", () => {
     const { asFragment } = renderWithTheme(<LoginPage />);
     expect(asFragment()).toMatchSnapshot();
   });
 
-  test("Redirects if the user is logged out", () => {
+  it("redirects if the user is logged out", () => {
     renderWithTheme(<LoginPage />);
     expect(useRedirectIfLoggedIn).toHaveBeenCalled();
+  });
+
+  it("redirects with correct location if logged out", () => {
+    const previousPage = "https://pod.example.com/someresource.txt";
+    renderWithTheme(<LoginPage history={[previousPage, "/login"]} />);
+    expect(useRedirectIfLoggedIn).toHaveBeenCalledWith(previousPage);
+  });
+
+  it("sets previous page in local storage is available", () => {
+    const previousPage = "https://pod.example.com/someresource.txt";
+    const mockedLocalStorage = {
+      setItem: jest.fn(),
+    };
+    Object.defineProperty(window, "localStorage", {
+      value: mockedLocalStorage,
+      writable: true,
+    });
+    renderWithTheme(<LoginPage history={[previousPage, "/login"]} />);
+
+    expect(mockedLocalStorage.setItem).toHaveBeenCalledWith(
+      "previousPage",
+      previousPage
+    );
+  });
+
+  it("does not call setItem if local storage unavailable", () => {
+    const previousPage = "https://pod.example.com/someresource.txt";
+    const mockedLocalStorage = {
+      setItem: jest.fn(),
+    };
+    Object.defineProperty(window, "localStorage", {
+      value: undefined,
+      writable: true,
+    });
+    renderWithTheme(<LoginPage history={[previousPage, "/login"]} />);
+
+    expect(mockedLocalStorage.setItem).not.toHaveBeenCalled();
   });
 });

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -92,12 +92,19 @@ export function hasSolidAuthClientHash() {
   return false;
 }
 
+const updateHistory = (prevState, path) => {
+  return [...prevState, path].filter(
+    (historyItem) => historyItem !== "/undefined"
+  );
+};
+
 export default function App(props) {
   const { Component, pageProps } = props;
   const bem = useBem(useStyles());
   const router = useRouter();
   const { pathname, asPath } = router;
   const [history, setHistory] = useState([]);
+
   useEffect(() => {
     // Remove injected serverside JSS
     const jssStyles = document.querySelector("#jss-server-side");
@@ -113,7 +120,7 @@ export default function App(props) {
     matomoInstance?.trackPageView({
       href: pathname,
     });
-    setHistory((prevState) => [...prevState, asPath]);
+    setHistory((prevState) => updateHistory(prevState, asPath));
   }, [pathname, asPath]);
 
   return (

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import * as Sentry from "@sentry/node";
 import { MatomoProvider, createInstance } from "@datapunt/matomo-tracker-react";
 
@@ -97,7 +97,7 @@ export default function App(props) {
   const bem = useBem(useStyles());
   const router = useRouter();
   const { pathname, asPath } = router;
-
+  const [history, setHistory] = useState([]);
   useEffect(() => {
     // Remove injected serverside JSS
     const jssStyles = document.querySelector("#jss-server-side");
@@ -113,6 +113,7 @@ export default function App(props) {
     matomoInstance?.trackPageView({
       href: pathname,
     });
+    setHistory((prevState) => [...prevState, asPath]);
   }, [pathname, asPath]);
 
   return (
@@ -149,7 +150,7 @@ export default function App(props) {
                       <PodBrowserHeader />
 
                       <main className={bem("app-layout__main")}>
-                        <Component {...pageProps} />
+                        <Component {...pageProps} history={history} />
                       </main>
                     </div>
                     <Notification />

--- a/src/hooks/usePreviousPage/index.js
+++ b/src/hooks/usePreviousPage/index.js
@@ -19,19 +19,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
 
-import LoginPage from "../components/pages/login";
-
-export default function Login({ history }) {
-  return <LoginPage history={history} />;
+export default function usePreviousPage() {
+  const [previousPage, setPreviousPage] = useState(null);
+  useEffect(() => {
+    if (!localStorage) return;
+    const url = localStorage.getItem("previousPage");
+    setPreviousPage(url);
+  }, []);
+  return previousPage;
 }
-
-Login.propTypes = {
-  history: PropTypes.arrayOf(PropTypes.string),
-};
-
-Login.defaultProps = {
-  history: [],
-};

--- a/src/hooks/usePreviousPage/index.js
+++ b/src/hooks/usePreviousPage/index.js
@@ -26,7 +26,7 @@ export default function usePreviousPage() {
   useEffect(() => {
     if (!localStorage) return;
     const url = localStorage.getItem("previousPage");
-    setPreviousPage(url);
+    setPreviousPage(url || null);
   }, []);
   return previousPage;
 }

--- a/src/hooks/usePreviousPage/index.test.jsx
+++ b/src/hooks/usePreviousPage/index.test.jsx
@@ -33,9 +33,9 @@ describe("usePreviousPage", () => {
         writable: true,
       });
     });
-    it("returns undefined when no previousPage is available in local storage", () => {
+    it("returns null when no previousPage is available in local storage", () => {
       const { result } = renderHook(() => usePreviousPage());
-      expect(result.current).toBeUndefined();
+      expect(result.current).toBeNull();
     });
 
     it("returns previous page url when available in local storage", async () => {

--- a/src/hooks/usePreviousPage/index.test.jsx
+++ b/src/hooks/usePreviousPage/index.test.jsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { renderHook } from "@testing-library/react-hooks";
+import usePreviousPage from "./index";
+import mockLocalStorage from "../../../__testUtils/mockLocalStorage";
+
+describe("usePreviousPage", () => {
+  const previousPage = "http://example.com/";
+
+  describe("with Local Storage", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "localStorage", {
+        value: mockLocalStorage(),
+        writable: true,
+      });
+    });
+    it("returns undefined when no previousPage is available in local storage", () => {
+      const { result } = renderHook(() => usePreviousPage());
+      expect(result.current).toBeUndefined();
+    });
+
+    it("returns previous page url when available in local storage", async () => {
+      window.localStorage.setItem("previousPage", previousPage);
+      const { result } = renderHook(() => usePreviousPage());
+      expect(result.current).toBe(previousPage);
+    });
+  });
+
+  describe("without Local Storage", () => {
+    beforeEach(() => {
+      Object.defineProperty(window, "localStorage", {
+        value: undefined,
+        writable: true,
+      });
+    });
+    it("returns null when local storage is not available", () => {
+      const { result } = renderHook(() => usePreviousPage());
+      expect(result.current).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-657.

- save previous page in localStorage to be able to redirect when logged out

- add usePreviousPage hook

- add tests

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
