### PR TITLE
Fix: redirect on logout

### DIFF
--- a/src/hooks/useUserMenu/index.js
+++ b/src/hooks/useUserMenu/index.js
@@ -20,12 +20,21 @@
  */
 
 import { useSession } from "@inrupt/solid-ui-react";
+import { useRouter } from "next/router";
 
 export const TESTCAFE_ID_USER_MENU_PROFILE = "user-menu-profile";
 export const TESTCAFE_ID_USER_MENU_LOGOUT = "user-menu-logout";
 
 export default function useUserMenu() {
-  const { logout } = useSession();
+  const { logout, session } = useSession();
+  const router = useRouter();
+
+  async function handleLogout() {
+    await logout();
+    if (!session.info.isLoggedIn) {
+      router.push("/login");
+    }
+  }
 
   return [
     {
@@ -38,7 +47,7 @@ export default function useUserMenu() {
     {
       icon: "log-out",
       label: "Log out",
-      onClick: () => logout(),
+      onClick: handleLogout,
       "data-testid": TESTCAFE_ID_USER_MENU_LOGOUT,
     },
   ];


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-963.

In this PR:

- redirecting to login page after logout has completed in the user menu button

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
