### PR TITLE
Feat/consent UI accept request

### DIFF
--- a/__testUtils/mockConsentRequestContext.jsx
+++ b/__testUtils/mockConsentRequestContext.jsx
@@ -19,35 +19,36 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import * as RouterFns from "next/router";
-import { renderWithTheme } from "../../../../../__testUtils/withTheme";
-import mockSessionContextProvider from "../../../../../__testUtils/mockSessionContextProvider";
-import mockSession from "../../../../../__testUtils/mockSession";
+import React, { useState } from "react";
+import T from "prop-types";
+import ConsentRequestContext from "../src/contexts/consentRequestContext";
+import getConsentRequestDetails from "./mockConsentRequestDetails";
 
-import ConsentPage from "./index";
+const defaultConsentRequest = getConsentRequestDetails();
 
-jest.mock("../../../../../src/effects/auth");
+export default function mockConsentRequestContext() {
+  function ConsentRequestContextProvider({ children }) {
+    const [consentRequest, setConsentRequest] = useState(defaultConsentRequest);
 
-describe("Consent Page", () => {
-  test("Renders the Consent page", () => {
-    jest.spyOn(RouterFns, "useRouter").mockReturnValue({
-      asPath: "/pathname/",
-      replace: jest.fn(),
-      query: {
-        id: "test-request",
-      },
-    });
-
-    const session = mockSession();
-    const SessionProvider = mockSessionContextProvider(session);
-
-    const { asFragment } = renderWithTheme(
-      <SessionProvider>
-        <ConsentPage />
-      </SessionProvider>
+    return (
+      <ConsentRequestContext.Provider
+        value={{
+          consentRequest,
+          setConsentRequest,
+        }}
+      >
+        {children}
+      </ConsentRequestContext.Provider>
     );
+  }
 
-    expect(asFragment()).toMatchSnapshot();
-  });
-});
+  ConsentRequestContextProvider.propTypes = {
+    children: T.node,
+  };
+
+  ConsentRequestContextProvider.defaultProps = {
+    children: null,
+  };
+
+  return ConsentRequestContextProvider;
+}

--- a/__testUtils/mockConsentRequestDetails.js
+++ b/__testUtils/mockConsentRequestDetails.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-async function getConsentRequestDetails() {
+function getConsentRequestDetails() {
   return {
     "@context": [
       "https://www.w3.org/2018/credentials/v1",
@@ -57,6 +57,12 @@ async function getConsentRequestDetails() {
         },
         {
           mode: ["Append"],
+          hasStatus: "ConsentStatusRequested",
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
+          forPurpose: "https://example.com/SomeSpecificPurpose",
+        },
+        {
+          mode: ["Control"],
           hasStatus: "ConsentStatusRequested",
           forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
           forPurpose: "https://example.com/SomeSpecificPurpose",

--- a/__testUtils/mockPermissionsContextProvider.jsx
+++ b/__testUtils/mockPermissionsContextProvider.jsx
@@ -104,7 +104,7 @@ const permissions = [
   },
 ];
 
-export default function mockBookmarksContextProvider(value) {
+export default function mockPermissionsContextProvider(value) {
   function PermissionsContextProvider({ children }) {
     const [newAgentsWebIds, setNewAgentsWebIds] = useState(
       value?.newAgentsWebIds || []

--- a/components/consentRequestForm/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,616 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Consent Request Form Renders a consent request form 1`] = `
+<DocumentFragment>
+  <form
+    class="PodBrowser-request-container__content"
+  >
+    <h2
+      class="PodBrowser-root PodBrowser-h1 PodBrowser-alignCenter"
+    >
+      <span
+        class="PodBrowser-agent-name"
+      >
+        Allow Mock App access?
+      </span>
+    </h2>
+    <span
+      class="PodBrowser-purpose"
+    >
+      Some Specific Purpose 
+      <div
+        class="PodBrowser-infoTooltipContainer"
+      >
+        <button
+          class="PodBrowser-root PodBrowser-root PodBrowser-infoButton PodBrowser-text"
+          tabindex="0"
+          title="https://example.com/SomeSpecificPurpose"
+          type="button"
+        >
+          <span
+            class="PodBrowser-label"
+          >
+            <i
+              aria-label="Info"
+              class="PodBrowser-icon-info PodBrowser-infoIcon"
+            />
+          </span>
+          <span
+            class="PodBrowser-root"
+          />
+        </button>
+      </div>
+    </span>
+    <fieldset
+      class="PodBrowser-root PodBrowser-request-container__section"
+    >
+      <legend
+        class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+      >
+        <span
+          class="PodBrowser-icon-edit PodBrowser-icon-small"
+        />
+        <span
+          class="PodBrowser-header__content"
+        >
+          Mock App wants to create, edit, or delete
+        </span>
+        <button
+          class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+          data-testid="request-select-all"
+          type="button"
+        >
+          <span
+            class="PodBrowser-button__text"
+          >
+            <span
+              class="PodBrowser-root PodBrowser-caption"
+            >
+              Select all
+            </span>
+          </span>
+        </button>
+      </legend>
+      <div
+        aria-label="position"
+        class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+      >
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data/"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data/"
+              >
+                data
+              </span>
+              <button
+                class="PodBrowser-dropdown-caret"
+                data-testid="expand-section"
+                type="button"
+              >
+                <span
+                  class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
+                />
+              </button>
+            </p>
+          </span>
+        </label>
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data-2"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data-2"
+              >
+                data-2
+              </span>
+            </p>
+          </span>
+        </label>
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data-3"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data-3"
+              >
+                data-3
+              </span>
+            </p>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+    <fieldset
+      class="PodBrowser-root PodBrowser-request-container__section"
+    >
+      <legend
+        class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+      >
+        <span
+          class="PodBrowser-icon-view PodBrowser-icon-small"
+        />
+        <span
+          class="PodBrowser-header__content"
+        >
+          Mock App wants to see
+        </span>
+        <button
+          class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+          data-testid="request-select-all"
+          type="button"
+        >
+          <span
+            class="PodBrowser-button__text"
+          >
+            <span
+              class="PodBrowser-root PodBrowser-caption"
+            >
+              Select all
+            </span>
+          </span>
+        </button>
+      </legend>
+      <div
+        aria-label="position"
+        class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+      >
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data"
+              >
+                data
+              </span>
+            </p>
+          </span>
+        </label>
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data-2/"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data-2/"
+              >
+                data-2
+              </span>
+              <button
+                class="PodBrowser-dropdown-caret"
+                data-testid="expand-section"
+                type="button"
+              >
+                <span
+                  class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
+                />
+              </button>
+            </p>
+          </span>
+        </label>
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data-3"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data-3"
+              >
+                data-3
+              </span>
+            </p>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+    <fieldset
+      class="PodBrowser-root PodBrowser-request-container__section"
+    >
+      <legend
+        class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+      >
+        <span
+          class="PodBrowser-icon-folder PodBrowser-icon-small"
+        />
+        <span
+          class="PodBrowser-header__content"
+        >
+          Mock App wants to add to
+        </span>
+        <button
+          class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+          data-testid="request-select-all"
+          type="button"
+        >
+          <span
+            class="PodBrowser-button__text"
+          >
+            <span
+              class="PodBrowser-root PodBrowser-caption"
+            >
+              Select all
+            </span>
+          </span>
+        </button>
+      </legend>
+      <div
+        aria-label="position"
+        class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+      >
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data"
+              >
+                data
+              </span>
+            </p>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+    <fieldset
+      class="PodBrowser-root PodBrowser-request-container__section"
+    >
+      <legend
+        class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+      >
+        <span
+          class="PodBrowser-icon-user PodBrowser-icon-small"
+        />
+        <span
+          class="PodBrowser-header__content"
+        >
+          Mock App wants to add or remove people from
+        </span>
+        <button
+          class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+          data-testid="request-select-all"
+          type="button"
+        >
+          <span
+            class="PodBrowser-button__text"
+          >
+            <span
+              class="PodBrowser-root PodBrowser-caption"
+            >
+              Select all
+            </span>
+          </span>
+        </button>
+      </legend>
+      <div
+        aria-label="position"
+        class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+      >
+        <label
+          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+        >
+          <span
+            class="PodBrowser-root"
+          >
+            <span
+              aria-disabled="false"
+              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <input
+                  class="PodBrowser-input PodBrowser-input"
+                  type="checkbox"
+                  value="https://pod.inrupt.com/alice/private/data"
+                />
+                <span
+                  class="PodBrowser-thumb"
+                />
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </span>
+            <span
+              class="PodBrowser-track"
+            />
+          </span>
+          <span
+            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+          >
+            <p
+              class="PodBrowser-root PodBrowser-body2"
+            >
+              <span
+                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+              />
+              <span
+                class=""
+                title="https://pod.inrupt.com/alice/private/data"
+              >
+                data
+              </span>
+            </p>
+          </span>
+        </label>
+      </div>
+    </fieldset>
+    <div
+      class="PodBrowser-form__controls"
+    >
+      <button
+        class="PodBrowser-button PodBrowser-button--secondary"
+      >
+        <span
+          class="PodBrowser-button__text"
+        >
+          Deny all access
+        </span>
+      </button>
+      <button
+        class="PodBrowser-button"
+        data-testid="consent-request-submit-button"
+        type="submit"
+      >
+        <span
+          class="PodBrowser-button__text"
+        >
+          Confirm Access
+        </span>
+      </button>
+    </div>
+  </form>
+</DocumentFragment>
+`;

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -36,6 +36,7 @@ import { mockApp } from "../../__testUtils/mockApp";
 import {
   getPurposeString,
   getPurposeUrl,
+  getRequestedAccesses,
 } from "../../src/models/consent/request";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
 import ConfirmationDialog from "../confirmationDialog";
@@ -103,6 +104,8 @@ export default function ConsentRequestFrom() {
     }
   }, [confirmationSetup, confirmed, closeDialog, open]);
 
+  const requestedAccesses = getRequestedAccesses(consentRequest);
+
   return (
     <>
       <form
@@ -116,9 +119,9 @@ export default function ConsentRequestFrom() {
           {purposeDescription} <InfoTooltip tooltipText={purposeUrl} />
         </span>
         {/* FIXME: place this in a loop when we know the data structure */}
-        {consentRequest?.credentialSubject?.hasConsent &&
+        {requestedAccesses &&
           agentName &&
-          consentRequest.credentialSubject.hasConsent.map((consent, index) => {
+          requestedAccesses.map((consent, index) => {
             return (
               <RequestSection
                 // eslint-disable-next-line react/no-array-index-key

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -116,7 +116,8 @@ export default function ConsentRequestFrom() {
           <span className={bem("agent-name")}>Allow {agentName} access?</span>
         </Typography>
         <span className={bem("purpose")}>
-          {purposeDescription} <InfoTooltip tooltipText={purposeUrl} />
+          {purposeDescription}{" "}
+          <InfoTooltip tooltipText={purposeUrl || "Purpose"} />
         </span>
         {/* FIXME: place this in a loop when we know the data structure */}
         {requestedAccesses &&

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -21,7 +21,7 @@
 
 /* eslint-disable react/jsx-one-expression-per-line */
 
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Button } from "@inrupt/prism-react-components";
 import { getStringNoLocale } from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
@@ -33,24 +33,82 @@ import InfoTooltip from "../infoTooltip";
 import RequestSection from "./requestSection";
 import styles from "./styles";
 import { mockApp } from "../../__testUtils/mockApp";
+import {
+  getPurposeString,
+  getPurposeUrl,
+} from "../../src/models/consent/request";
+import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
+import ConfirmationDialog from "../confirmationDialog";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+const NO_ACCESS_DIALOG_TITLE = "Your haven't selected any access";
+export const CONSENT_REQUEST_NO_ACCESS_DIALOG =
+  "consent-request-no-access-dialog";
+export const TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON =
+  "consent-request-submit-button";
 
 export default function ConsentRequestFrom() {
   const classes = useStyles();
   const bem = useBem(classes);
   const { consentRequest } = useContext(ConsentRequestContext);
+  const [selectedAccess, setSelectedAccess] = useState([]);
   // FIXME: using a mock for the app profile - we will fetch profile later
   const agentProfile = mockApp();
   const agentName = getStringNoLocale(agentProfile, foaf.name);
-  const purposeUrl =
-    consentRequest?.credentialSubject?.hasConsent[0].forPurpose; // getting the first in this array for now
+  const purposeUrl = getPurposeUrl(consentRequest);
   // FIXME: we will later fetch the description from the purpose Url
-  const purposeDescription = "Some Specific Purpose";
+  const purposeDescription = getPurposeString();
+  const {
+    confirmed,
+    open,
+    setContent,
+    setOpen,
+    setTitle,
+    closeDialog,
+  } = useContext(ConfirmationDialogContext);
+  const [confirmationSetup, setConfirmationSetup] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (selectedAccess.length) {
+      setConfirmationSetup(false);
+      return;
+    }
+    setConfirmationSetup(true);
+    setOpen(CONSENT_REQUEST_NO_ACCESS_DIALOG);
+    setTitle(NO_ACCESS_DIALOG_TITLE);
+    setContent(`${agentName} will not have access to anything in your Pod`);
+  };
+
+  useEffect(() => {
+    if (
+      confirmationSetup &&
+      confirmed === null &&
+      open === CONSENT_REQUEST_NO_ACCESS_DIALOG
+    )
+      return;
+
+    if (
+      confirmationSetup &&
+      confirmed &&
+      open === CONSENT_REQUEST_NO_ACCESS_DIALOG
+    ) {
+      closeDialog(); // FIXME: do something with the access request
+    }
+
+    if (confirmed !== null) {
+      closeDialog();
+      setConfirmationSetup(false);
+    }
+  }, [confirmationSetup, confirmed, closeDialog, open]);
 
   return (
     <>
-      <form className={bem("request-container__content", "main")}>
+      <form
+        className={bem("request-container__content", "main")}
+        onSubmit={handleSubmit}
+      >
         <Typography component="h2" align="center" variant="h1">
           <span className={bem("agent-name")}>Allow {agentName} access?</span>
         </Typography>
@@ -60,9 +118,16 @@ export default function ConsentRequestFrom() {
         {/* FIXME: place this in a loop when we know the data structure */}
         {consentRequest?.credentialSubject?.hasConsent &&
           agentName &&
-          consentRequest.credentialSubject.hasConsent.map((consent) => {
+          consentRequest.credentialSubject.hasConsent.map((consent, index) => {
             return (
-              <RequestSection agentName={agentName} sectionDetails={consent} />
+              <RequestSection
+                // eslint-disable-next-line react/no-array-index-key
+                key={`consent-request-section-${index}`}
+                agentName={agentName}
+                sectionDetails={consent}
+                selectedAccess={selectedAccess}
+                setSelectedAccess={setSelectedAccess}
+              />
             );
           })}
         <div className={bem("form__controls")}>
@@ -72,11 +137,16 @@ export default function ConsentRequestFrom() {
           >
             Deny all access
           </Button>
-          <Button type="submit" className={bem("request-container__button")}>
+          <Button
+            data-testid={TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON}
+            type="submit"
+            className={bem("request-container__button")}
+          >
             Confirm Access
           </Button>
         </div>
       </form>
+      <ConfirmationDialog />
     </>
   );
 }

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -48,6 +48,9 @@ export const CONSENT_REQUEST_NO_ACCESS_DIALOG =
   "consent-request-no-access-dialog";
 export const TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON =
   "consent-request-submit-button";
+export const TESTCAFE_ID_CONSENT_REQUEST_DENY_BUTTON =
+  "consent-request-deny-button";
+const CONFIRM_TEXT = "Continue with no access";
 
 export default function ConsentRequestFrom() {
   const classes = useStyles();
@@ -67,8 +70,11 @@ export default function ConsentRequestFrom() {
     setOpen,
     setTitle,
     closeDialog,
+    setConfirmText,
   } = useContext(ConfirmationDialogContext);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
+
+  const DIALOG_CONTENT = `${agentName} will not have access to anything in your Pod.`;
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -79,7 +85,8 @@ export default function ConsentRequestFrom() {
     setConfirmationSetup(true);
     setOpen(CONSENT_REQUEST_NO_ACCESS_DIALOG);
     setTitle(NO_ACCESS_DIALOG_TITLE);
-    setContent(`${agentName} will not have access to anything in your Pod`);
+    setConfirmText(CONFIRM_TEXT);
+    setContent(DIALOG_CONTENT);
   };
 
   useEffect(() => {

--- a/components/consentRequestForm/index.test.jsx
+++ b/components/consentRequestForm/index.test.jsx
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { renderWithTheme } from "../../__testUtils/withTheme";
+import mockConsentRequestContext from "../../__testUtils/mockConsentRequestContext";
+import ConsentRequestForm, {
+  TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON,
+} from "./index";
+import { TESTCAFE_ID_CONFIRMATION_DIALOG } from "../confirmationDialog";
+import { ConfirmationDialogProvider } from "../../src/contexts/confirmationDialogContext";
+
+const ConsentRequestContextProvider = mockConsentRequestContext();
+
+describe("Consent Request Form", () => {
+  test("Renders a consent request form", () => {
+    const { asFragment } = renderWithTheme(
+      <ConsentRequestContextProvider>
+        <ConsentRequestForm />
+      </ConsentRequestContextProvider>
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+  test("when submitting form without selecting access, it displays a confirmation dialog", () => {
+    const { getByTestId } = renderWithTheme(
+      <ConfirmationDialogProvider>
+        <ConsentRequestContextProvider>
+          <ConsentRequestForm />
+        </ConsentRequestContextProvider>
+      </ConfirmationDialogProvider>
+    );
+    const button = getByTestId(TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON);
+    userEvent.click(button);
+    const dialog = getByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG);
+    expect(dialog).toBeInTheDocument();
+  });
+  test("does not display confirmation dialog if at least one access is selected", async () => {
+    const { getByTestId, getAllByRole, findByTestId } = renderWithTheme(
+      <ConfirmationDialogProvider>
+        <ConsentRequestContextProvider>
+          <ConsentRequestForm />
+        </ConsentRequestContextProvider>
+      </ConfirmationDialogProvider>
+    );
+    const toggle = getAllByRole("checkbox")[0];
+    userEvent.click(toggle);
+    const button = getByTestId(TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON);
+    userEvent.click(button);
+    await expect(findByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG)).rejects.toEqual(
+      expect.anything()
+    );
+  });
+});

--- a/components/consentRequestForm/requestSection/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/requestSection/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`consentRequestContext Renders initial context data 1`] = `
+exports[`Request Section Renders initial context data 1`] = `
 <DocumentFragment>
   <fieldset
     class="PodBrowser-root PodBrowser-request-container__section"

--- a/components/consentRequestForm/requestSection/index.jsx
+++ b/components/consentRequestForm/requestSection/index.jsx
@@ -39,6 +39,10 @@ import {
   isContainerIri,
   uniqueObjects,
 } from "../../../src/solidClientHelpers/utils";
+import {
+  getAccessMode,
+  getRequestedResourcesIris,
+} from "../../../src/models/consent/request";
 import { getResourceName } from "../../../src/solidClientHelpers/resource";
 
 export const TESTCAFE_ID_REQUEST_SELECT_ALL_BUTTON = "request-select-all";
@@ -329,10 +333,12 @@ ContainerSwitch.defaultProps = {
 };
 export default function RequestSection(props) {
   const { agentName, sectionDetails, setSelectedAccess } = props;
+  const requestedResourcesIris = getRequestedResourcesIris(sectionDetails);
+  const accessMode = getAccessMode(sectionDetails);
   const bem = useBem(useStyles());
 
   const [isChecked, setIsChecked] = useState(
-    new Array(sectionDetails.forPersonalData.length).fill(false)
+    new Array(requestedResourcesIris.length).fill(false)
   );
 
   const [allTogglesSelected, setAllTogglesSelected] = useState(
@@ -341,12 +347,12 @@ export default function RequestSection(props) {
 
   const modesObject = useMemo(() => {
     return {
-      read: sectionDetails.mode.some((el) => el === "Read"),
-      write: sectionDetails.mode.some((el) => el === "Write"),
-      append: sectionDetails.mode.some((el) => el === "Append"),
-      control: sectionDetails.mode.some((el) => el === "Control"),
+      read: accessMode.some((el) => el === "Read"),
+      write: accessMode.some((el) => el === "Write"),
+      append: accessMode.some((el) => el === "Append"),
+      control: accessMode.some((el) => el === "Control"),
     };
-  }, [sectionDetails]);
+  }, [accessMode]);
 
   useEffect(() => {
     setAllTogglesSelected(
@@ -359,12 +365,12 @@ export default function RequestSection(props) {
       return {
         checked,
         accessModes: modesObject,
-        resourceIri: sectionDetails.forPersonalData[index],
+        resourceIri: requestedResourcesIris[index],
         index,
       };
     });
     setSelectedAccess((prevState) => removeExistingValues(prevState, accesses));
-  }, [sectionDetails, modesObject, isChecked, setSelectedAccess]);
+  }, [requestedResourcesIris, modesObject, isChecked, setSelectedAccess]);
 
   const toggleAllSwitches = () => {
     const updatedAllCheckedState = isChecked.map(() => !allTogglesSelected);
@@ -412,8 +418,8 @@ export default function RequestSection(props) {
           row
           className={bem("request-container__section", "box")}
         >
-          {sectionDetails.forPersonalData &&
-            sectionDetails.forPersonalData.map((resourceIri, index) => {
+          {requestedResourcesIris &&
+            requestedResourcesIris.map((resourceIri, index) => {
               return renderSwitch(
                 resourceIri,
                 index,

--- a/components/consentRequestForm/requestSection/index.jsx
+++ b/components/consentRequestForm/requestSection/index.jsx
@@ -136,9 +136,7 @@ const renderSwitch = (
         key={index}
         resourceIri={resourceIri}
         isChecked={isChecked}
-        handleOnChange={() => {
-          handleOnChange(index);
-        }}
+        handleOnChange={() => handleOnChange(index)}
         index={index}
         overrideCheck={overrideCheck}
         setSelectedAccess={setSelectedAccess}
@@ -151,9 +149,7 @@ const renderSwitch = (
       key={index}
       resourceIri={resourceIri}
       isChecked={isChecked}
-      handleOnChange={() => {
-        handleOnChange(index);
-      }}
+      handleOnChange={() => handleOnChange(index)}
       index={index}
       setSelectedAccess={setSelectedAccess}
       modesObject={modesObject}

--- a/components/consentRequestForm/requestSection/index.jsx
+++ b/components/consentRequestForm/requestSection/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useMemo } from "react";
 import T from "prop-types";
 import { Icons, Button } from "@inrupt/prism-react-components";
 import { makeStyles } from "@material-ui/styles";
@@ -35,13 +35,45 @@ import {
 import { useBem } from "@solid/lit-prism-patterns";
 import { getPolicyDetailFromAccess } from "../../../src/accessControl/acp";
 import styles from "../styles";
-import { isContainerIri } from "../../../src/solidClientHelpers/utils";
+import {
+  isContainerIri,
+  uniqueObjects,
+} from "../../../src/solidClientHelpers/utils";
 import { getResourceName } from "../../../src/solidClientHelpers/resource";
 
 export const TESTCAFE_ID_REQUEST_SELECT_ALL_BUTTON = "request-select-all";
 export const TESTCAFE_ID_REQUEST_EXPAND_SECTION_BUTTON = "expand-section";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export const removeExistingValues = (prevAccesses, newAccesses) => {
+  const withDeletedAccesses = prevAccesses?.map((item, i) => {
+    const shouldBeRemoved = [];
+    newAccesses.forEach((a) => {
+      if (
+        JSON.stringify(item.accessModes) === JSON.stringify(a.accessModes) &&
+        item.index === a.index &&
+        item.resourceIri === a.resourceIri &&
+        a.checked === false
+      ) {
+        shouldBeRemoved.push(i);
+      }
+    });
+    if (!shouldBeRemoved.includes(i)) {
+      return item;
+    }
+    return null;
+  });
+  const previousAccess = withDeletedAccesses?.filter(
+    (item) => !!item && item.checked === true
+  );
+  const checkedAccesses = newAccesses.filter(({ checked }) => checked);
+  return uniqueObjects(
+    previousAccess
+      ? [...previousAccess, ...checkedAccesses]
+      : [...checkedAccesses]
+  );
+};
 
 const ResourceSwitch = (props) => {
   const { resourceIri, isChecked, handleOnChange, index } = props;
@@ -90,7 +122,9 @@ const renderSwitch = (
   index,
   isChecked,
   handleOnChange,
-  overrideCheck = false
+  overrideCheck = false,
+  setSelectedAccess,
+  modesObject
 ) => {
   if (isContainerIri(resourceIri)) {
     return (
@@ -98,9 +132,13 @@ const renderSwitch = (
         key={index}
         resourceIri={resourceIri}
         isChecked={isChecked}
-        handleOnChange={handleOnChange}
+        handleOnChange={() => {
+          handleOnChange(index);
+        }}
         index={index}
         overrideCheck={overrideCheck}
+        setSelectedAccess={setSelectedAccess}
+        modesObject={modesObject}
       />
     );
   }
@@ -109,14 +147,18 @@ const renderSwitch = (
       key={index}
       resourceIri={resourceIri}
       isChecked={isChecked}
-      handleOnChange={handleOnChange}
+      handleOnChange={() => {
+        handleOnChange(index);
+      }}
       index={index}
+      setSelectedAccess={setSelectedAccess}
+      modesObject={modesObject}
     />
   );
 };
 
 const RequestSubSection = (props) => {
-  const { resourceIri, overrideCheck } = props;
+  const { resourceIri, overrideCheck, modesObject, setSelectedAccess } = props;
 
   // FIXME based on the resourceIri retrieve all resources in this container and replace the mock list below
   const mockedResources = [
@@ -139,6 +181,18 @@ const RequestSubSection = (props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [overrideCheck]);
 
+  useEffect(() => {
+    const accesses = isChecked.map((checked, index) => {
+      return {
+        checked,
+        accessModes: modesObject,
+        resourceIri,
+        index,
+      };
+    });
+    setSelectedAccess((prevState) => removeExistingValues(prevState, accesses));
+  }, [modesObject, isChecked, setSelectedAccess, resourceIri]);
+
   const handleOnChange = (position) => {
     const updatedCheckedState = isChecked.map((item, index) =>
       index === position ? !item : item
@@ -155,7 +209,9 @@ const RequestSubSection = (props) => {
           index,
           isChecked,
           handleOnChange,
-          overrideCheck
+          overrideCheck,
+          setSelectedAccess,
+          modesObject
         );
       })}
     </>
@@ -169,6 +225,13 @@ RequestSubSection.defaultProps = {
 RequestSubSection.propTypes = {
   resourceIri: T.string.isRequired,
   overrideCheck: T.bool,
+  modesObject: T.shape({
+    write: T.bool,
+    read: T.bool,
+    append: T.bool,
+    control: T.bool,
+  }).isRequired,
+  setSelectedAccess: T.func.isRequired,
 };
 
 const ContainerSwitch = (props) => {
@@ -178,6 +241,8 @@ const ContainerSwitch = (props) => {
     handleOnChange,
     index,
     overrideCheck,
+    setSelectedAccess,
+    modesObject,
   } = props;
   const bem = useBem(useStyles());
   const [isExpanded, setIsExpanded] = useState(false);
@@ -234,6 +299,8 @@ const ContainerSwitch = (props) => {
           <RequestSubSection
             resourceIri={resourceIri}
             overrideCheck={isChecked[index]}
+            setSelectedAccess={setSelectedAccess}
+            modesObject={modesObject}
           />
         </div>
       )}
@@ -248,27 +315,59 @@ ContainerSwitch.propTypes = {
   overrideCheck: T.bool,
   handleOnChange: T.func.isRequired,
   index: T.number.isRequired,
+  modesObject: T.shape({
+    write: T.bool,
+    read: T.bool,
+    append: T.bool,
+    control: T.bool,
+  }).isRequired,
+  setSelectedAccess: T.func.isRequired,
 };
 
 ContainerSwitch.defaultProps = {
   overrideCheck: false,
 };
 export default function RequestSection(props) {
-  const { agentName, sectionDetails } = props;
+  const { agentName, sectionDetails, setSelectedAccess } = props;
   const bem = useBem(useStyles());
 
   const [isChecked, setIsChecked] = useState(
     new Array(sectionDetails.forPersonalData.length).fill(false)
   );
 
-  const modesObject = {
-    read: sectionDetails.mode.some((el) => el === "Read"),
-    write: sectionDetails.mode.some((el) => el === "Write"),
-    append: sectionDetails.mode.some((el) => el === "Append"),
-  };
+  const [allTogglesSelected, setAllTogglesSelected] = useState(
+    isChecked.filter((toggle) => toggle === true).length === isChecked.length
+  );
+
+  const modesObject = useMemo(() => {
+    return {
+      read: sectionDetails.mode.some((el) => el === "Read"),
+      write: sectionDetails.mode.some((el) => el === "Write"),
+      append: sectionDetails.mode.some((el) => el === "Append"),
+      control: sectionDetails.mode.some((el) => el === "Control"),
+    };
+  }, [sectionDetails]);
+
+  useEffect(() => {
+    setAllTogglesSelected(
+      isChecked.filter((toggle) => toggle === true).length === isChecked.length
+    );
+  }, [isChecked]);
+
+  useEffect(() => {
+    const accesses = isChecked.map((checked, index) => {
+      return {
+        checked,
+        accessModes: modesObject,
+        resourceIri: sectionDetails.forPersonalData[index],
+        index,
+      };
+    });
+    setSelectedAccess((prevState) => removeExistingValues(prevState, accesses));
+  }, [sectionDetails, modesObject, isChecked, setSelectedAccess]);
 
   const toggleAllSwitches = () => {
-    const updatedAllCheckedState = isChecked.map(() => true);
+    const updatedAllCheckedState = isChecked.map(() => !allTogglesSelected);
     setIsChecked(updatedAllCheckedState);
   };
 
@@ -304,7 +403,7 @@ export default function RequestSection(props) {
             className={bem("request-container__button", "small")}
           >
             <Typography component="span" variant="caption">
-              Select all
+              {allTogglesSelected ? "Deny all" : "Select all"}
             </Typography>
           </Button>
         </legend>
@@ -319,7 +418,10 @@ export default function RequestSection(props) {
                 resourceIri,
                 index,
                 isChecked,
-                handleOnChange
+                handleOnChange,
+                false,
+                setSelectedAccess,
+                modesObject
               );
             })}
         </FormGroup>
@@ -330,6 +432,7 @@ export default function RequestSection(props) {
 
 RequestSection.propTypes = {
   agentName: T.string.isRequired,
+  setSelectedAccess: T.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   sectionDetails: T.object.isRequired,
 };

--- a/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Agent show page Renders the Agent show page 1`] = `
+exports[`Consent Page Renders the Consent page 1`] = `
 <DocumentFragment>
   <div
     class="PodBrowser-container PodBrowser-request-container"
@@ -27,6 +27,7 @@ exports[`Agent show page Renders the Agent show page 1`] = `
           <button
             class="PodBrowser-root PodBrowser-root PodBrowser-infoButton PodBrowser-text"
             tabindex="0"
+            title="https://example.com/SomeSpecificPurpose"
             type="button"
           >
             <span
@@ -43,6 +44,552 @@ exports[`Agent show page Renders the Agent show page 1`] = `
           </button>
         </div>
       </span>
+      <fieldset
+        class="PodBrowser-root PodBrowser-request-container__section"
+      >
+        <legend
+          class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+        >
+          <span
+            class="PodBrowser-icon-edit PodBrowser-icon-small"
+          />
+          <span
+            class="PodBrowser-header__content"
+          >
+            Mock App wants to create, edit, or delete
+          </span>
+          <button
+            class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+            data-testid="request-select-all"
+            type="button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              <span
+                class="PodBrowser-root PodBrowser-caption"
+              >
+                Select all
+              </span>
+            </span>
+          </button>
+        </legend>
+        <div
+          aria-label="position"
+          class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+        >
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data/"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data/"
+                >
+                  data
+                </span>
+                <button
+                  class="PodBrowser-dropdown-caret"
+                  data-testid="expand-section"
+                  type="button"
+                >
+                  <span
+                    class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
+                  />
+                </button>
+              </p>
+            </span>
+          </label>
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data-2"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data-2"
+                >
+                  data-2
+                </span>
+              </p>
+            </span>
+          </label>
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data-3"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data-3"
+                >
+                  data-3
+                </span>
+              </p>
+            </span>
+          </label>
+        </div>
+      </fieldset>
+      <fieldset
+        class="PodBrowser-root PodBrowser-request-container__section"
+      >
+        <legend
+          class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+        >
+          <span
+            class="PodBrowser-icon-view PodBrowser-icon-small"
+          />
+          <span
+            class="PodBrowser-header__content"
+          >
+            Mock App wants to see
+          </span>
+          <button
+            class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+            data-testid="request-select-all"
+            type="button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              <span
+                class="PodBrowser-root PodBrowser-caption"
+              >
+                Select all
+              </span>
+            </span>
+          </button>
+        </legend>
+        <div
+          aria-label="position"
+          class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+        >
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data"
+                >
+                  data
+                </span>
+              </p>
+            </span>
+          </label>
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data-2/"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data-2/"
+                >
+                  data-2
+                </span>
+                <button
+                  class="PodBrowser-dropdown-caret"
+                  data-testid="expand-section"
+                  type="button"
+                >
+                  <span
+                    class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
+                  />
+                </button>
+              </p>
+            </span>
+          </label>
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data-3"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data-3"
+                >
+                  data-3
+                </span>
+              </p>
+            </span>
+          </label>
+        </div>
+      </fieldset>
+      <fieldset
+        class="PodBrowser-root PodBrowser-request-container__section"
+      >
+        <legend
+          class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+        >
+          <span
+            class="PodBrowser-icon-folder PodBrowser-icon-small"
+          />
+          <span
+            class="PodBrowser-header__content"
+          >
+            Mock App wants to add to
+          </span>
+          <button
+            class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+            data-testid="request-select-all"
+            type="button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              <span
+                class="PodBrowser-root PodBrowser-caption"
+              >
+                Select all
+              </span>
+            </span>
+          </button>
+        </legend>
+        <div
+          aria-label="position"
+          class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+        >
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data"
+                >
+                  data
+                </span>
+              </p>
+            </span>
+          </label>
+        </div>
+      </fieldset>
+      <fieldset
+        class="PodBrowser-root PodBrowser-request-container__section"
+      >
+        <legend
+          class="PodBrowser-request-container__header-text PodBrowser-request-container__header-text--small"
+        >
+          <span
+            class="PodBrowser-icon-user PodBrowser-icon-small"
+          />
+          <span
+            class="PodBrowser-header__content"
+          >
+            Mock App wants to add or remove people from
+          </span>
+          <button
+            class="PodBrowser-button PodBrowser-button--secondary PodBrowser-request-container__button--small"
+            data-testid="request-select-all"
+            type="button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              <span
+                class="PodBrowser-root PodBrowser-caption"
+              >
+                Select all
+              </span>
+            </span>
+          </button>
+        </legend>
+        <div
+          aria-label="position"
+          class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
+        >
+          <label
+            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          >
+            <span
+              class="PodBrowser-root"
+            >
+              <span
+                aria-disabled="false"
+                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
+              >
+                <span
+                  class="PodBrowser-label"
+                >
+                  <input
+                    class="PodBrowser-input PodBrowser-input"
+                    type="checkbox"
+                    value="https://pod.inrupt.com/alice/private/data"
+                  />
+                  <span
+                    class="PodBrowser-thumb"
+                  />
+                </span>
+                <span
+                  class="PodBrowser-root"
+                />
+              </span>
+              <span
+                class="PodBrowser-track"
+              />
+            </span>
+            <span
+              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
+            >
+              <p
+                class="PodBrowser-root PodBrowser-body2"
+              >
+                <span
+                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                />
+                <span
+                  class=""
+                  title="https://pod.inrupt.com/alice/private/data"
+                >
+                  data
+                </span>
+              </p>
+            </span>
+          </label>
+        </div>
+      </fieldset>
       <div
         class="PodBrowser-form__controls"
       >
@@ -57,6 +604,7 @@ exports[`Agent show page Renders the Agent show page 1`] = `
         </button>
         <button
           class="PodBrowser-button"
+          data-testid="consent-request-submit-button"
           type="submit"
         >
           <span

--- a/components/pages/privacy/consent/requests/index.jsx
+++ b/components/pages/privacy/consent/requests/index.jsx
@@ -66,9 +66,8 @@ export default function ConsentShow() {
 
   useEffect(() => {
     if (!consentRequest) {
-      getConsentRequestDetails().then((res) => {
-        setConsentRequest(res);
-      });
+      const request = getConsentRequestDetails();
+      setConsentRequest(request);
     }
   }, [consentRequest]);
 

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -59,6 +59,11 @@ import { POLICIES_TYPE_MAP } from "../../../constants/policies";
 export const noAcrAccessError =
   "No access to Access Control Resource for this resource";
 
+const CONTROL_ACCESS_CONSENT = {
+  titleConsent: "wants to add or remove people from",
+  iconName: "user",
+};
+
 export function createAcpMap(read = false, write = false, append = false) {
   return {
     [ACL.READ.key]: read,
@@ -75,7 +80,7 @@ const acpMapForApplyPolicies = {
 };
 
 export const getPolicyDetailFromAccess = (access, label) => {
-  const { read, write, append } = access;
+  const { read, write, append, control } = access;
   if (read && write && !append) {
     return POLICIES_TYPE_MAP.editors[label];
   }
@@ -90,6 +95,9 @@ export const getPolicyDetailFromAccess = (access, label) => {
   }
   if (write && !append && !read) {
     return POLICIES_TYPE_MAP.editOnly[label];
+  }
+  if (control) {
+    return CONTROL_ACCESS_CONSENT[label];
   }
   return null;
 };

--- a/src/models/consent/request/index.js
+++ b/src/models/consent/request/index.js
@@ -35,3 +35,15 @@ export function getPurposeString() {
 export function getPurposeUrl(consentRequest) {
   return consentRequest?.credentialSubject?.hasConsent[0].forPurpose; // getting the first item in the array for now
 }
+
+export function getRequestedAccesses(consentRequest) {
+  return consentRequest?.credentialSubject?.hasConsent;
+}
+
+export function getRequestedResourcesIris(sectionDetails) {
+  return sectionDetails.forPersonalData;
+}
+
+export function getAccessMode(sectionDetails) {
+  return sectionDetails.mode;
+}

--- a/src/models/consent/request/index.js
+++ b/src/models/consent/request/index.js
@@ -19,35 +19,19 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import * as RouterFns from "next/router";
-import { renderWithTheme } from "../../../../../__testUtils/withTheme";
-import mockSessionContextProvider from "../../../../../__testUtils/mockSessionContextProvider";
-import mockSession from "../../../../../__testUtils/mockSession";
+// TODO: replace with solid-client functions
+// TODO: replace mock data with real data
 
-import ConsentPage from "./index";
+/* Model constants */
 
-jest.mock("../../../../../src/effects/auth");
+export const MOCK_PURPOSE_STRING = "Some Specific Purpose";
 
-describe("Consent Page", () => {
-  test("Renders the Consent page", () => {
-    jest.spyOn(RouterFns, "useRouter").mockReturnValue({
-      asPath: "/pathname/",
-      replace: jest.fn(),
-      query: {
-        id: "test-request",
-      },
-    });
+/* Model functions */
 
-    const session = mockSession();
-    const SessionProvider = mockSessionContextProvider(session);
+export function getPurposeString() {
+  return MOCK_PURPOSE_STRING;
+}
 
-    const { asFragment } = renderWithTheme(
-      <SessionProvider>
-        <ConsentPage />
-      </SessionProvider>
-    );
-
-    expect(asFragment()).toMatchSnapshot();
-  });
-});
+export function getPurposeUrl(consentRequest) {
+  return consentRequest?.credentialSubject?.hasConsent[0].forPurpose; // getting the first item in the array for now
+}

--- a/src/solidClientHelpers/utils.js
+++ b/src/solidClientHelpers/utils.js
@@ -164,3 +164,7 @@ export async function serializePromises(promiseFactories) {
     return oldResult.concat(newResult);
   }, Promise.resolve([]));
 }
+
+export function uniqueObjects(array) {
+  return Array.from(new Set(array.map(JSON.stringify))).map(JSON.parse);
+}


### PR DESCRIPTION
# Accept consent Request (UI only)

In this PR: 
- Adding the confirmation dialog check when trying to accept a consent request without any selected access
- add tests
- minor fixes (test names, etc)
- moved some of the JSON-LD destructuring into functions in a consent model, so that it's easier to swap for solid-client functions once we do (since we shouldn't be relying on destructuring JSON-LD as the consent request can be something other than JSON-LD)

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
