### PR TITLE
Feat/consent UI reject request

### DIFF
--- a/components/consentRequestForm/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/__snapshots__/index.test.jsx.snap
@@ -592,6 +592,7 @@ exports[`Consent Request Form Renders a consent request form 1`] = `
     >
       <button
         class="PodBrowser-button PodBrowser-button--secondary"
+        data-testid="consent-request-deny-button"
       >
         <span
           class="PodBrowser-button__text"

--- a/components/consentRequestForm/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/__snapshots__/index.test.jsx.snap
@@ -593,6 +593,7 @@ exports[`Consent Request Form Renders a consent request form 1`] = `
       <button
         class="PodBrowser-button PodBrowser-button--secondary"
         data-testid="consent-request-deny-button"
+        type="button"
       >
         <span
           class="PodBrowser-button__text"

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -44,6 +44,7 @@ import ConfirmationDialog from "../confirmationDialog";
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
 const NO_ACCESS_DIALOG_TITLE = "Your haven't selected any access";
+const DENY_ACCESS_DIALOG_TITLE = "Deny all access?";
 export const CONSENT_REQUEST_NO_ACCESS_DIALOG =
   "consent-request-no-access-dialog";
 export const TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON =
@@ -51,6 +52,7 @@ export const TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON =
 export const TESTCAFE_ID_CONSENT_REQUEST_DENY_BUTTON =
   "consent-request-deny-button";
 const CONFIRM_TEXT = "Continue with no access";
+const DENY_TEXT = "Deny All Access";
 
 export default function ConsentRequestFrom() {
   const classes = useStyles();
@@ -87,14 +89,14 @@ export default function ConsentRequestFrom() {
     setTitle(NO_ACCESS_DIALOG_TITLE);
     setConfirmText(CONFIRM_TEXT);
     setContent(DIALOG_CONTENT);
-    setContent(`${agentName} will not have access to anything in your Pod`);
   };
 
   const handleDenyAccess = () => {
     setConfirmationSetup(true);
+    setTitle(DENY_ACCESS_DIALOG_TITLE);
+    setConfirmText(DENY_TEXT);
+    setContent(DIALOG_CONTENT);
     setOpen(CONSENT_REQUEST_NO_ACCESS_DIALOG);
-    setTitle(NO_ACCESS_DIALOG_TITLE);
-    setContent(`${agentName} will not have access to anything in your Pod`);
   };
 
   useEffect(() => {
@@ -153,6 +155,7 @@ export default function ConsentRequestFrom() {
           <Button
             data-testid={TESTCAFE_ID_CONSENT_REQUEST_DENY_BUTTON}
             variant="secondary"
+            type="button"
             className={bem("request-container__button")}
             onClick={handleDenyAccess}
           >

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -76,8 +76,6 @@ export default function ConsentRequestFrom() {
 
   const DIALOG_CONTENT = `${agentName} will not have access to anything in your Pod.`;
 
-  const [confirmationSetup, setConfirmationSetup] = useState(false);
-
   const handleSubmit = (e) => {
     e.preventDefault();
     if (selectedAccess.length) {
@@ -153,6 +151,7 @@ export default function ConsentRequestFrom() {
           })}
         <div className={bem("form__controls")}>
           <Button
+            data-testid={TESTCAFE_ID_CONSENT_REQUEST_DENY_BUTTON}
             variant="secondary"
             className={bem("request-container__button")}
             onClick={handleDenyAccess}

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -92,6 +92,13 @@ export default function ConsentRequestFrom() {
     setContent(`${agentName} will not have access to anything in your Pod`);
   };
 
+  const handleDenyAccess = () => {
+    setConfirmationSetup(true);
+    setOpen(CONSENT_REQUEST_NO_ACCESS_DIALOG);
+    setTitle(NO_ACCESS_DIALOG_TITLE);
+    setContent(`${agentName} will not have access to anything in your Pod`);
+  };
+
   useEffect(() => {
     if (
       confirmationSetup &&
@@ -148,6 +155,7 @@ export default function ConsentRequestFrom() {
           <Button
             variant="secondary"
             className={bem("request-container__button")}
+            onClick={handleDenyAccess}
           >
             Deny all access
           </Button>

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -76,6 +76,8 @@ export default function ConsentRequestFrom() {
 
   const DIALOG_CONTENT = `${agentName} will not have access to anything in your Pod.`;
 
+  const [confirmationSetup, setConfirmationSetup] = useState(false);
+
   const handleSubmit = (e) => {
     e.preventDefault();
     if (selectedAccess.length) {
@@ -87,6 +89,7 @@ export default function ConsentRequestFrom() {
     setTitle(NO_ACCESS_DIALOG_TITLE);
     setConfirmText(CONFIRM_TEXT);
     setContent(DIALOG_CONTENT);
+    setContent(`${agentName} will not have access to anything in your Pod`);
   };
 
   useEffect(() => {

--- a/components/consentRequestForm/index.test.jsx
+++ b/components/consentRequestForm/index.test.jsx
@@ -24,6 +24,7 @@ import userEvent from "@testing-library/user-event";
 import { renderWithTheme } from "../../__testUtils/withTheme";
 import mockConsentRequestContext from "../../__testUtils/mockConsentRequestContext";
 import ConsentRequestForm, {
+  TESTCAFE_ID_CONSENT_REQUEST_DENY_BUTTON,
   TESTCAFE_ID_CONSENT_REQUEST_SUBMIT_BUTTON,
 } from "./index";
 import { TESTCAFE_ID_CONFIRMATION_DIALOG } from "../confirmationDialog";
@@ -69,5 +70,20 @@ describe("Consent Request Form", () => {
     await expect(findByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG)).rejects.toEqual(
       expect.anything()
     );
+  });
+  test("displays the confirmation dialog regardless of the state of the toggles when clicking 'Deny All Access' button", async () => {
+    const { getByTestId, getAllByRole } = renderWithTheme(
+      <ConfirmationDialogProvider>
+        <ConsentRequestContextProvider>
+          <ConsentRequestForm />
+        </ConsentRequestContextProvider>
+      </ConfirmationDialogProvider>
+    );
+    const toggle = getAllByRole("checkbox")[0];
+    userEvent.click(toggle);
+    const button = getByTestId(TESTCAFE_ID_CONSENT_REQUEST_DENY_BUTTON);
+    userEvent.click(button);
+    const dialog = getByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG);
+    expect(dialog).toBeInTheDocument();
   });
 });

--- a/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
@@ -596,6 +596,7 @@ exports[`Consent Page Renders the Consent page 1`] = `
         <button
           class="PodBrowser-button PodBrowser-button--secondary"
           data-testid="consent-request-deny-button"
+          type="button"
         >
           <span
             class="PodBrowser-button__text"

--- a/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
@@ -595,6 +595,7 @@ exports[`Consent Page Renders the Consent page 1`] = `
       >
         <button
           class="PodBrowser-button PodBrowser-button--secondary"
+          data-testid="consent-request-deny-button"
         >
           <span
             class="PodBrowser-button__text"


### PR DESCRIPTION
# Reject Consent Request (UI only)

- displaying confirmation dialog when clicking on Deny All Access button, regardless of the state of the toggles

*Note*: this PR is based off https://github.com/inrupt/pod-browser/pull/325 and should be merged after it.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
