### PR TITLE
Fix: refresh container after error is cleared

### DIFF
--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -170,12 +170,9 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   });
 
   const onFileSelect = handleFileSelect({
-    fetch,
-    currentUri,
     setIsUploading,
     setFile,
     saveUploadedFile,
-    saveResource,
     setSeverity,
     setMessage,
     setAlertOpen,

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -111,7 +111,9 @@ export function handleFileSelect({
   setAlertOpen,
   resourceList,
 }) {
+  console.log("handleFileSelect is called");
   return (e) => {
+    console.log(e);
     console.log(e.target.files);
     if (!e.target.files.length) return;
     try {

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -112,6 +112,7 @@ export function handleFileSelect({
   resourceList,
 }) {
   return (e) => {
+    console.log(e.target.files);
     if (!e.target.files.length) return;
     try {
       setIsUploading(true);

--- a/components/addFileButton/index.jsx
+++ b/components/addFileButton/index.jsx
@@ -111,10 +111,7 @@ export function handleFileSelect({
   setAlertOpen,
   resourceList,
 }) {
-  console.log("handleFileSelect is called");
   return (e) => {
-    console.log(e);
-    console.log(e.target.files);
     if (!e.target.files.length) return;
     try {
       setIsUploading(true);
@@ -150,7 +147,7 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   } = useContext(ConfirmationDialogContext);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
   const [file, setFile] = useState(null);
-  const ref = useRef();
+  const ref = useRef(null);
 
   const saveResource = handleSaveResource({
     fetch,
@@ -172,9 +169,12 @@ export default function AddFileButton({ className, onSave, resourceList }) {
   });
 
   const onFileSelect = handleFileSelect({
+    fetch,
+    currentUri,
     setIsUploading,
     setFile,
     saveUploadedFile,
+    saveResource,
     setSeverity,
     setMessage,
     setAlertOpen,
@@ -205,6 +205,9 @@ export default function AddFileButton({ className, onSave, resourceList }) {
         data-testid={TESTCAFE_ID_UPLOAD_BUTTON}
         disabled={isUploading}
         onClick={(e) => {
+          if (ref.current) {
+            setIsUploading(true);
+          }
           e.target.value = null;
         }}
         onKeyUp={(e) => {
@@ -223,7 +226,10 @@ export default function AddFileButton({ className, onSave, resourceList }) {
           data-testid={TESTCAFE_ID_UPLOAD_INPUT}
           type="file"
           style={{ display: "none" }}
-          onChange={onFileSelect}
+          onChange={(e) => {
+            onFileSelect(e);
+            e.target.value = null;
+          }}
         />
       </label>
       <ConfirmationDialog />

--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -67,7 +67,7 @@ export default function Container({ iri }) {
     data: container,
     error: containerError,
     mutate: update,
-    isFetching,
+    isValidating,
   } = useContainer(iri);
 
   useEffect(() => {
@@ -95,7 +95,7 @@ export default function Container({ iri }) {
     }));
   }, [resourceUrls]);
 
-  if (!iri) return <Spinner />;
+  if (!iri || isValidating) return <Spinner />;
 
   if (containerError && isHTTPError(containerError.message, 401))
     return <AccessForbidden />;
@@ -128,7 +128,7 @@ export default function Container({ iri }) {
           {locationIsInUsersPod && accessControlError && (
             <NoControlWarning podRootIri={podRootIri} />
           )}
-          {isFetching ? (
+          {isValidating ? (
             <Spinner />
           ) : (
             <ContainerTable

--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -66,7 +66,7 @@ export default function Container({ iri }) {
   const {
     data: container,
     error: containerError,
-    update,
+    mutate: update,
     isFetching,
   } = useContainer(iri);
 

--- a/components/pages/login/index.jsx
+++ b/components/pages/login/index.jsx
@@ -60,7 +60,7 @@ const links = [
 export default function Login({ history }) {
   const filteredHistory = history.slice(0, history.indexOf("/login"));
   const previousPage = filteredHistory[filteredHistory.length - 1];
-  const redirectUrl = previousPage || "/";
+  const redirectUrl = previousPage;
   useRedirectIfLoggedIn(redirectUrl);
   const bem = useBem(useStyles());
   const buttonBem = Button.useBem();

--- a/components/pages/login/index.jsx
+++ b/components/pages/login/index.jsx
@@ -58,9 +58,9 @@ const links = [
 ];
 
 export default function Login({ history }) {
-  const filteredHistory = history.slice(0, history.indexOf("/login"));
-  const previousPage = filteredHistory[filteredHistory.length - 1];
-  const redirectUrl = previousPage;
+  const filteredHistory = history;
+  const previousPage = filteredHistory[filteredHistory.length - 2];
+  const redirectUrl = previousPage || "/";
   useRedirectIfLoggedIn(redirectUrl);
   const bem = useBem(useStyles());
   const buttonBem = Button.useBem();

--- a/components/pages/login/index.jsx
+++ b/components/pages/login/index.jsx
@@ -58,8 +58,8 @@ const links = [
 ];
 
 export default function Login({ history }) {
-  const filteredHistory = history;
-  const previousPage = filteredHistory[filteredHistory.length - 2];
+  const filteredHistory = history.slice(0, history.indexOf("/login"));
+  const previousPage = filteredHistory[filteredHistory.length - 1];
   const redirectUrl = previousPage || "/";
   useRedirectIfLoggedIn(redirectUrl);
   const bem = useBem(useStyles());

--- a/src/hooks/useContainer/index.js
+++ b/src/hooks/useContainer/index.js
@@ -26,14 +26,15 @@ import { getContainer } from "../../models/container";
 
 export default function useContainer(iri) {
   const session = useSession();
+  const { sessionRequestInProgress } = session;
   const url = getContainerUrl(iri);
 
   async function fetchContainer(fetch) {
     return getContainer(url, { fetch });
   }
 
-  return useSWR(["container", url], async () => {
-    if (!url) return null;
+  return useSWR(["container", url, sessionRequestInProgress], async () => {
+    if (!url || sessionRequestInProgress) return null;
     return fetchContainer(session.fetch);
   });
 }

--- a/src/hooks/useContainer/index.js
+++ b/src/hooks/useContainer/index.js
@@ -19,45 +19,22 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import useSWR from "swr";
 import { useSession } from "@inrupt/solid-ui-react";
 import { useEffect, useState } from "react";
 import { getContainerUrl } from "../../stringHelpers";
 import { getContainer } from "../../models/container";
 
 export default function useContainer(iri) {
-  const { fetch } = useSession();
+  const session = useSession();
   const url = getContainerUrl(iri);
-  const [container, setContainer] = useState(null);
-  const [containerError, setContainerError] = useState(null);
-  const [isFetching, setIsFetching] = useState(false);
 
-  useEffect(() => {
-    if (!url) return;
-    async function fetchContainer() {
-      setIsFetching(true);
-      try {
-        const initialData = await getContainer(url, { fetch });
-        setContainer(initialData);
-        setContainerError(null);
-        setIsFetching(false);
-      } catch (e) {
-        setContainer(null);
-        setContainerError(e);
-        setIsFetching(false);
-      }
-    }
-    fetchContainer();
-  }, [url, fetch]);
-
-  async function update() {
-    const updatedContainer = await getContainer(url, { fetch });
-    setContainer(updatedContainer);
+  async function fetchContainer(fetch) {
+    return getContainer(url, { fetch });
   }
 
-  return {
-    data: container,
-    error: containerError,
-    update,
-    isFetching,
-  };
+  return useSWR(["container"], async () => {
+    if (!url) return null;
+    return fetchContainer(session.fetch);
+  });
 }

--- a/src/hooks/useContainer/index.js
+++ b/src/hooks/useContainer/index.js
@@ -21,7 +21,6 @@
 
 import useSWR from "swr";
 import { useSession } from "@inrupt/solid-ui-react";
-import { useEffect, useState } from "react";
 import { getContainerUrl } from "../../stringHelpers";
 import { getContainer } from "../../models/container";
 
@@ -33,7 +32,7 @@ export default function useContainer(iri) {
     return getContainer(url, { fetch });
   }
 
-  return useSWR(["container"], async () => {
+  return useSWR(["container", url], async () => {
     if (!url) return null;
     return fetchContainer(session.fetch);
   });

--- a/src/hooks/useContainer/index.js
+++ b/src/hooks/useContainer/index.js
@@ -33,8 +33,12 @@ export default function useContainer(iri) {
     return getContainer(url, { fetch });
   }
 
-  return useSWR(["container", url, sessionRequestInProgress], async () => {
-    if (!url || sessionRequestInProgress) return null;
-    return fetchContainer(session.fetch);
-  });
+  return useSWR(
+    ["container", url, sessionRequestInProgress],
+    async () => {
+      if (!url || sessionRequestInProgress) return null;
+      return fetchContainer(session.fetch);
+    },
+    { revalidateOnFocus: false, refreshInterval: 0, errorRetryInterval: 2000 }
+  );
 }

--- a/src/hooks/useContainer/index.test.js
+++ b/src/hooks/useContainer/index.test.js
@@ -62,7 +62,8 @@ describe("useContainer", () => {
     expect(result.current).toEqual(swrResponse);
     expect(mockedSwrHook).toHaveBeenCalledWith(
       ["container", containerUrl, false],
-      expect.any(Function)
+      expect.any(Function),
+      { errorRetryInterval: 2000, refreshInterval: 0, revalidateOnFocus: false }
     );
   });
 

--- a/src/hooks/useContainer/index.test.js
+++ b/src/hooks/useContainer/index.test.js
@@ -19,39 +19,100 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { useSession } from "@inrupt/solid-ui-react";
 import * as solidClientFns from "@inrupt/solid-client";
 import { renderHook } from "@testing-library/react-hooks";
-import { useSession } from "@inrupt/solid-ui-react";
-import * as containerModelFns from "../../models/container";
+import useSWR from "swr";
 import useContainer from "./index";
-import { chain } from "../../solidClientHelpers/utils";
+import { ERROR_CODES } from "../../error";
+import createContainer from "../../../__testUtils/createContainer";
 
 jest.mock("@inrupt/solid-ui-react");
 const mockedSessionHook = useSession;
 
+jest.mock("swr");
+const mockedSwrHook = useSWR;
+
 describe("useContainer", () => {
-  const iri = "http://example.com/container/";
   const fetch = jest.fn();
-  const thing = solidClientFns.createThing({ url: iri });
-  const dataset = chain(solidClientFns.mockSolidDatasetFrom(iri), (t) =>
-    solidClientFns.setThing(t, thing)
+  const containerUrl = "https://example.org/container/";
+  const containerDataset = createContainer(containerUrl);
+  const containerThing = solidClientFns.getThing(
+    containerDataset,
+    containerUrl
   );
-  const container = { dataset, thing };
+  const container = { dataset: containerDataset, thing: containerThing };
+  const swrResponse = 42;
+
+  let mockedGetSolidDataset;
 
   beforeEach(() => {
-    mockedSessionHook.mockReturnValue({ fetch });
-    jest.spyOn(containerModelFns, "getContainer").mockResolvedValue(container);
+    mockedSwrHook.mockReturnValue(swrResponse);
   });
 
-  it("fetches data using getSolidDataset", async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useContainer(iri));
-    await waitForNextUpdate();
-    expect(result.current.data).toBe(container);
-    expect(containerModelFns.getContainer).toHaveBeenCalledWith(iri, { fetch });
+  it("uses SWR to cache", () => {
+    mockedGetSolidDataset = jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValue(containerDataset);
+    mockedSessionHook.mockReturnValue({
+      fetch,
+      sessionRequestInProgress: false,
+    });
+    const { result } = renderHook(() => useContainer(containerUrl));
+    expect(result.current).toEqual(swrResponse);
+    expect(mockedSwrHook).toHaveBeenCalledWith(
+      ["container", containerUrl, false],
+      expect.any(Function)
+    );
   });
 
-  it("returns null if no URL is given", async () => {
-    const { result } = renderHook(() => useContainer(null));
-    expect(result.current.data).toBeNull();
+  it("loads container", async () => {
+    mockedGetSolidDataset = jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValue(containerDataset);
+    mockedSessionHook.mockReturnValue({
+      fetch,
+      sessionRequestInProgress: false,
+    });
+    renderHook(() => useContainer(containerUrl));
+    await expect(mockedSwrHook.mock.calls[0][1]()).resolves.toEqual(container);
+  });
+
+  it("throws an error if container cannot be fetched", async () => {
+    const error = "error";
+
+    mockedGetSolidDataset = jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockRejectedValue(error);
+    mockedSessionHook.mockReturnValue({
+      fetch,
+      sessionRequestInProgress: false,
+    });
+    renderHook(() => useContainer(containerUrl));
+    await expect(mockedSwrHook.mock.calls[0][1]()).rejects.toEqual(error);
+  });
+
+  it("throws an error if it there's something wrong when fetching the container", async () => {
+    mockedSessionHook.mockReturnValue({
+      fetch,
+      sessionRequestInProgress: false,
+    });
+    mockedGetSolidDataset.mockRejectedValue(ERROR_CODES.FORBIDDEN);
+    renderHook(() => useContainer(containerUrl));
+    await expect(mockedSwrHook.mock.calls[0][1]()).rejects.toEqual(
+      ERROR_CODES.FORBIDDEN
+    );
+  });
+
+  it("returns null while session is in progress", async () => {
+    mockedGetSolidDataset = jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValue(containerDataset);
+    mockedSessionHook.mockReturnValue({
+      fetch,
+      sessionRequestInProgress: true,
+    });
+    renderHook(() => useContainer(containerUrl));
+    await expect(mockedSwrHook.mock.calls[0][1]()).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
This PR fixes bugs #SOLIDOS-977 and #SOLIDOS-981.

- Refactor `useContainer` hook to use useSWR so it revalidates after error cleared
- Added check to not display error message until it finished validating
- Update tests

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
