### PR TITLE
Feat: add ACP info drawer

### DIFF
--- a/components/agentList/agentsDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/agentList/agentsDrawer/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AgentsDrawer renders 1`] = `
+exports[`AgentsDrawer renders for a Person 1`] = `
+<DocumentFragment>
+  <section
+    class="PodBrowser-drawer PodBrowser-drawer--open"
+  >
+    <div
+      class="PodBrowser-drawer__content"
+    >
+      <div
+        class="PodBrowser-drawer__content-wrapper"
+      >
+        <div
+          class="PodBrowser-drawer__article PodBrowser-drawer__article--close-button"
+        >
+          <button
+            class="PodBrowser-button PodBrowser-button--text PodBrowser-drawer__close-button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              <span
+                class="PodBrowser-icon-cancel"
+              />
+               Close
+            </span>
+          </button>
+        </div>
+        <div
+          class="PodBrowser-root PodBrowser-root PodBrowser-expanded PodBrowser-elevation1"
+        >
+          <div
+            aria-disabled="false"
+            aria-expanded="true"
+            class="PodBrowser-root PodBrowser-root PodBrowser-expanded"
+            role="button"
+            tabindex="0"
+          >
+            <div
+              class="PodBrowser-content PodBrowser-expanded"
+            >
+              Actions
+            </div>
+            <div
+              aria-disabled="false"
+              aria-hidden="true"
+              class="PodBrowser-root PodBrowser-root PodBrowser-expandIcon PodBrowser-expanded PodBrowser-edgeEnd"
+            >
+              <span
+                class="PodBrowser-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="PodBrowser-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="PodBrowser-root"
+              />
+            </div>
+          </div>
+          <div
+            class="PodBrowser-container PodBrowser-entered"
+            style="min-height: 0px;"
+          >
+            <div
+              class="PodBrowser-wrapper"
+            >
+              <div
+                class="PodBrowser-wrapperInner"
+              >
+                <div
+                  role="region"
+                >
+                  <div
+                    class="PodBrowser-root"
+                  >
+                    <ul
+                      class="PodBrowser-action-menu"
+                    >
+                      <li
+                        class="PodBrowser-action-menu__item"
+                      >
+                        <a
+                          class="PodBrowser-action-menu__trigger"
+                          href="/privacy/person/https%3A%2F%2Fexample.com%2Fprofile%23alice"
+                        >
+                          View Profile
+                        </a>
+                      </li>
+                      <li
+                        class="PodBrowser-action-menu__item"
+                      >
+                        <button
+                          class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
+                          data-testid="delete-button"
+                          type="button"
+                        >
+                          Delete
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`AgentsDrawer renders for an App 1`] = `
 <DocumentFragment>
   <section
     class="PodBrowser-drawer PodBrowser-drawer--open"

--- a/components/agentList/index.jsx
+++ b/components/agentList/index.jsx
@@ -41,7 +41,7 @@ import styles from "./styles";
 
 import { useRedirectIfLoggedOut } from "../../src/effects/auth";
 import { mockApp } from "../../__testUtils/mockApp";
-import ProfileLink from "../profileLink";
+import AgentResourceAccessLink from "../agentResourceAccessLink";
 import SearchContext from "../../src/contexts/searchContext";
 import usePodRootUri from "../../src/hooks/usePodRootUri";
 import useAgentsProfiles from "../../src/hooks/useAgentsProfiles";
@@ -195,7 +195,7 @@ function AgentList({ contactType, setSearchValues }) {
           header="Name"
           filterable
           sortable
-          body={ProfileLink}
+          body={AgentResourceAccessLink}
         />
         <TableColumn
           property={namePredicate}

--- a/components/agentResourceAccessLink/__snapshots__/index.test.jsx.snap
+++ b/components/agentResourceAccessLink/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AgentResourceAccessLink renders correct path for privacy contacts 1`] = `
+<DocumentFragment>
+  <a
+    data-testid="resource-access-link"
+    href="/privacy/resourceAccess/https%3A%2F%2Fexample.com%2Fbob"
+  >
+    Bob
+  </a>
+</DocumentFragment>
+`;
+
+exports[`AgentResourceAccessLink renders iri if name is not found 1`] = `
+<DocumentFragment>
+  <a
+    data-testid="resource-access-link"
+    href="/privacy/resourceAccess/https%3A%2F%2Fmockiri.com"
+  >
+    https://mockiri.com
+  </a>
+</DocumentFragment>
+`;
+
+exports[`AgentResourceAccessLink supports rendering name from foaf.name 1`] = `
+<DocumentFragment>
+  <a
+    data-testid="resource-access-link"
+    href="/privacy/resourceAccess/https%3A%2F%2Fexample.com%2Fbob"
+  >
+    Bob
+  </a>
+</DocumentFragment>
+`;
+
+exports[`AgentResourceAccessLink supports rendering name from vcard.fn 1`] = `
+<DocumentFragment>
+  <a
+    data-testid="resource-access-link"
+    href="/privacy/resourceAccess/https%3A%2F%2Fexample.com%2Falice"
+  >
+    Alice
+  </a>
+</DocumentFragment>
+`;

--- a/components/agentResourceAccessLink/index.jsx
+++ b/components/agentResourceAccessLink/index.jsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import T from "prop-types";
+import Link from "next/link";
+import { useThing } from "@inrupt/solid-ui-react";
+import { getStringNoLocale } from "@inrupt/solid-client";
+import { vcard, foaf } from "rdf-namespaces";
+import { useRouter } from "next/router";
+import { getProfileIriFromContactThing } from "../../src/addressBook";
+
+export const TESTCAFE_ID_RESOURCE_ACCESS_LINK = "resource-access-link";
+
+export function buildResourcesLink(webId, route) {
+  return `${route}/resourceAccess/${encodeURIComponent(webId)}`;
+}
+
+export default function AgentResourceAccessLink(props) {
+  const { route } = useRouter();
+  const { webId } = props;
+  const { thing } = useThing();
+  const contact = getProfileIriFromContactThing(thing);
+
+  // Pass in an iri, or use the thing from context (such as for the contacts list)
+  const profileIri = webId || contact;
+
+  // TODO remove this once react-sdk allows property fallbacks
+  const name =
+    getStringNoLocale(thing, foaf.name) ||
+    getStringNoLocale(thing, vcard.fn) ||
+    profileIri;
+
+  return (
+    <Link href={buildResourcesLink(profileIri, route)}>
+      <a data-testid={TESTCAFE_ID_RESOURCE_ACCESS_LINK}>{name}</a>
+    </Link>
+  );
+}
+
+AgentResourceAccessLink.propTypes = {
+  webId: T.string,
+};
+
+AgentResourceAccessLink.defaultProps = {
+  webId: null,
+};

--- a/components/agentResourceAccessLink/index.test.jsx
+++ b/components/agentResourceAccessLink/index.test.jsx
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import { useRouter } from "next/router";
+import { render } from "@testing-library/react";
+import { addUrl, mockThingFrom, setStringNoLocale } from "@inrupt/solid-client";
+import { ThingProvider } from "@inrupt/solid-ui-react";
+import { foaf, rdf, vcard, schema } from "rdf-namespaces";
+import AgentResourceAccessLink, { buildResourcesLink } from "./index";
+import { chain } from "../../src/solidClientHelpers/utils";
+
+jest.mock("next/router");
+
+const mockedUseRouter = useRouter;
+
+const alice = chain(mockThingFrom("https://example.com/alice"), (t) =>
+  setStringNoLocale(t, vcard.fn, "Alice")
+);
+const bob = chain(
+  mockThingFrom("https://example.com/bob"),
+  (t) => setStringNoLocale(t, foaf.name, "Bob"),
+  (t) => addUrl(t, rdf.type, schema.Person)
+);
+const iri = "/iri with spaces";
+
+describe("AgentResourceAccessLink", () => {
+  beforeEach(() => {
+    mockedUseRouter.mockReturnValue({
+      route: "/privacy",
+    });
+  });
+  it("supports rendering name from vcard.fn", () => {
+    const { asFragment } = render(
+      <ThingProvider thing={alice}>
+        <AgentResourceAccessLink iri={iri} />
+      </ThingProvider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("supports rendering name from foaf.name", () => {
+    const { asFragment } = render(
+      <ThingProvider thing={bob}>
+        <AgentResourceAccessLink />
+      </ThingProvider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders iri if name is not found", () => {
+    const { asFragment } = render(
+      <ThingProvider thing={mockThingFrom("https://mockiri.com")}>
+        <AgentResourceAccessLink />
+      </ThingProvider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders correct path for privacy contacts", () => {
+    mockedUseRouter.mockReturnValueOnce({
+      route: "/privacy",
+    });
+    const { asFragment } = render(
+      <ThingProvider thing={bob}>
+        <AgentResourceAccessLink />
+      </ThingProvider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});
+
+describe("buildProfileLink", () => {
+  it("generates a valid path", () => {
+    expect(buildResourcesLink(iri, "/privacy")).toEqual(
+      `/privacy/resourceAccess/${encodeURIComponent(iri)}`
+    );
+  });
+});

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,164 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResourceDrawer Renders the ResourceDrawer with correct title and access list 1`] = `
+<DocumentFragment>
+  <section
+    class="PodBrowser-drawer PodBrowser-drawer--open"
+  >
+    <div
+      class="PodBrowser-drawer__content"
+    >
+      <div
+        class="PodBrowser-drawer__content-wrapper"
+      >
+        <div
+          class="PodBrowser-drawer__article PodBrowser-drawer__article--close-button"
+        >
+          <button
+            class="PodBrowser-button PodBrowser-button--text PodBrowser-drawer__close-button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              <span
+                class="PodBrowser-icon-cancel"
+              />
+               Close
+            </span>
+          </button>
+        </div>
+        <div
+          class="PodBrowser-access-details--wrapper"
+        >
+          <span
+            class="PodBrowser-access-details--title"
+          >
+            <span
+              class="PodBrowser-icon-folder PodBrowser-access-details--icon"
+            />
+            <h2>
+              resource
+            </h2>
+          </span>
+          <section
+            class="PodBrowser-access-details--section"
+          >
+            <h3
+              class="PodBrowser-access-details--section-header"
+            >
+              Access
+            </h3>
+            <hr
+              class="PodBrowser-access-details--separator"
+            />
+            <ul
+              class="PodBrowser-root PodBrowser-padding"
+            >
+              <li
+                class="PodBrowser-root PodBrowser-gutters"
+              >
+                <div
+                  class="PodBrowser-root PodBrowser-listItemIcon"
+                >
+                  <span
+                    class="PodBrowser-icon-view PodBrowser-access-details--section-icon"
+                  />
+                </div>
+                <div
+                  class="PodBrowser-root PodBrowser-listItemText PodBrowser-multiline"
+                >
+                  <span
+                    class="PodBrowser-root PodBrowser-primary PodBrowser-listItemTitleText PodBrowser-body1 PodBrowser-displayBlock"
+                  >
+                    View
+                  </span>
+                  <p
+                    class="PodBrowser-root PodBrowser-secondary PodBrowser-listItemSecondaryText PodBrowser-body2 PodBrowser-colorTextSecondary PodBrowser-displayBlock"
+                  >
+                    Can see this resource
+                  </p>
+                </div>
+              </li>
+              <li
+                class="PodBrowser-root PodBrowser-gutters"
+              >
+                <div
+                  class="PodBrowser-root PodBrowser-listItemIcon"
+                >
+                  <span
+                    class="PodBrowser-icon-editor PodBrowser-access-details--section-icon"
+                  />
+                </div>
+                <div
+                  class="PodBrowser-root PodBrowser-listItemText PodBrowser-multiline"
+                >
+                  <span
+                    class="PodBrowser-root PodBrowser-primary PodBrowser-listItemTitleText PodBrowser-body1 PodBrowser-displayBlock"
+                  >
+                    Edit
+                  </span>
+                  <p
+                    class="PodBrowser-root PodBrowser-secondary PodBrowser-listItemSecondaryText PodBrowser-body2 PodBrowser-colorTextSecondary PodBrowser-displayBlock"
+                  >
+                    Can change, download or delete this resource
+                  </p>
+                </div>
+              </li>
+              <li
+                class="PodBrowser-root PodBrowser-gutters"
+              >
+                <div
+                  class="PodBrowser-root PodBrowser-listItemIcon"
+                >
+                  <span
+                    class="PodBrowser-icon-add PodBrowser-access-details--section-icon"
+                  />
+                </div>
+                <div
+                  class="PodBrowser-root PodBrowser-listItemText PodBrowser-multiline"
+                >
+                  <span
+                    class="PodBrowser-root PodBrowser-primary PodBrowser-listItemTitleText PodBrowser-body1 PodBrowser-displayBlock"
+                  >
+                    Add
+                  </span>
+                  <p
+                    class="PodBrowser-root PodBrowser-secondary PodBrowser-listItemSecondaryText PodBrowser-body2 PodBrowser-colorTextSecondary PodBrowser-displayBlock"
+                  >
+                    Can upload to this resource
+                  </p>
+                </div>
+              </li>
+              <li
+                class="PodBrowser-root PodBrowser-gutters"
+              >
+                <div
+                  class="PodBrowser-root PodBrowser-listItemIcon"
+                >
+                  <span
+                    class="PodBrowser-icon-user PodBrowser-access-details--section-icon"
+                  />
+                </div>
+                <div
+                  class="PodBrowser-root PodBrowser-listItemText PodBrowser-multiline"
+                >
+                  <span
+                    class="PodBrowser-root PodBrowser-primary PodBrowser-listItemTitleText PodBrowser-body1 PodBrowser-displayBlock"
+                  >
+                    Share
+                  </span>
+                  <p
+                    class="PodBrowser-root PodBrowser-secondary PodBrowser-listItemSecondaryText PodBrowser-body2 PodBrowser-colorTextSecondary PodBrowser-displayBlock"
+                  >
+                    Can share this resource with others
+                  </p>
+                </div>
+              </li>
+            </ul>
+          </section>
+        </div>
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
@@ -73,7 +73,10 @@ export default function ResourceAccessDrawer({
   const accessDetails = modes?.map((mode) => {
     return getAcpAccessDetails(mode);
   });
-
+  const order = ["View", "Edit", "Add", "Share", "View Sharing"];
+  const sortedAccessDetails = accessDetails.sort((a, b) => {
+    return order.indexOf(a.name) - order.indexOf(b.name);
+  });
   const resourceName = resourceIri && getResourceName(resourceIri);
   return (
     <Drawer open={open} close={onClose}>
@@ -91,7 +94,7 @@ export default function ResourceAccessDrawer({
           <h3 className={bem("access-details", "section-header")}>Access</h3>
           <hr className={bem("access-details", "separator")} />
           <List>
-            {accessDetails?.map(({ name, icon, description }) => {
+            {sortedAccessDetails?.map(({ name, icon, description }) => {
               return (
                 <ListItem key={name}>
                   <ListItemIcon classes={{ root: classes.listItemIcon }}>

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
@@ -1,0 +1,140 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import T from "prop-types";
+import { Drawer, Icons } from "@inrupt/prism-react-components";
+import {
+  createStyles,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import { useBem } from "@solid/lit-prism-patterns";
+import { getAcpAccessDetails } from "../../../../../src/accessControl/acp";
+import { getResourceName } from "../../../../../src/solidClientHelpers/resource";
+import styles from "./styles";
+import { isContainerIri } from "../../../../../src/solidClientHelpers/utils";
+
+const getAllowModes = (accessList) => {
+  if (!accessList) return null;
+  const accessModes = [
+    ...new Set(
+      [
+        ...accessList.map(({ allow }) => {
+          return allow.map((mode) => mode);
+        }),
+      ].reduce((acc, modes) => [...acc, ...modes], [])
+    ),
+  ];
+  return accessModes;
+};
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function ResourceAccessDrawer({
+  open,
+  onClose,
+  accessList,
+  resourceIri,
+}) {
+  const classes = useStyles();
+  const bem = useBem(classes);
+
+  const allowModes = getAllowModes(accessList);
+  const modes = allowModes?.map((mode) => {
+    return {
+      read: !!mode.includes("Read"),
+      write: !!mode.includes("Write"),
+      append: !!mode.includes("Append"),
+      control: !!mode.includes("Control"),
+    };
+  });
+  const accessDetails = modes?.map((mode) => {
+    return getAcpAccessDetails(mode);
+  });
+
+  const resourceName = resourceIri && getResourceName(resourceIri);
+  return (
+    <Drawer open={open} close={onClose}>
+      <div className={bem("access-details", "wrapper")}>
+        <span className={bem("access-details", "title")}>
+          <Icons
+            name={
+              resourceIri && isContainerIri(resourceIri) ? "folder" : "file"
+            }
+            className={bem("access-details", "icon")}
+          />
+          <h2>{resourceName}</h2>
+        </span>
+        <section className={bem("access-details", "section")}>
+          <h3 className={bem("access-details", "section-header")}>Access</h3>
+          <hr className={bem("access-details", "separator")} />
+          <List>
+            {accessDetails?.map(({ name, icon, description }) => {
+              return (
+                <ListItem key={name}>
+                  <ListItemIcon classes={{ root: classes.listItemIcon }}>
+                    <Icons
+                      name={icon}
+                      className={bem("access-details", "section-icon")}
+                    />
+                  </ListItemIcon>
+                  <ListItemText
+                    classes={{
+                      root: classes.listItemText,
+                      primary: classes.listItemTitleText,
+                      secondary: classes.listItemSecondaryText,
+                    }}
+                    key={name}
+                    primary={name}
+                    secondary={description}
+                  />
+                </ListItem>
+              );
+            })}
+          </List>
+        </section>
+      </div>
+    </Drawer>
+  );
+}
+
+ResourceAccessDrawer.propTypes = {
+  open: T.bool.isRequired,
+  accessList: T.arrayOf(
+    T.shape({
+      agent: T.string,
+      allow: T.arrayOf(T.string),
+      deny: T.arrayOf(T.string),
+      resource: T.string,
+    })
+  ),
+  onClose: T.func.isRequired,
+  resourceIri: T.string,
+};
+
+ResourceAccessDrawer.defaultProps = {
+  accessList: [],
+  resourceIri: null,
+};

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
@@ -74,7 +74,7 @@ export default function ResourceAccessDrawer({
     return getAcpAccessDetails(mode);
   });
   const order = ["View", "Edit", "Add", "Share", "View Sharing"];
-  const sortedAccessDetails = accessDetails.sort((a, b) => {
+  const sortedAccessDetails = accessDetails?.sort((a, b) => {
     return order.indexOf(a.name) - order.indexOf(b.name);
   });
   const resourceName = resourceIri && getResourceName(resourceIri);

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.test.jsx
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.test.jsx
@@ -20,40 +20,40 @@
  */
 
 import React from "react";
-import { schema } from "rdf-namespaces";
-import AgentsDrawer from "./index";
-import { renderWithTheme } from "../../../__testUtils/withTheme";
+import { renderWithTheme } from "../../../../../__testUtils/withTheme";
 
-describe("AgentsDrawer", () => {
-  const onClose = () => {};
-  const onDelete = () => {};
-  const selectedContactName = "Alice";
-  const profileIri = "https://example.com/profile#alice";
+import ResourceDrawer from "./index";
 
-  it("renders for a Person", () => {
+jest.mock("../../../../../src/effects/auth");
+
+describe("ResourceDrawer", () => {
+  test("Renders the ResourceDrawer with correct title and access list", () => {
+    const onClose = jest.fn();
+    const webId = "https://example.com/profile/card#me";
+    const resourceIri = "https://example.com/resource/";
+    const accessList = [
+      {
+        agent: webId,
+        allow: [
+          "http://www.w3.org/ns/solid/acp#Read",
+          "http://www.w3.org/ns/solid/acp#Write",
+          "http://www.w3.org/ns/solid/acp#Append",
+          "http://www.w3.org/ns/solid/acp#Control",
+        ],
+        deny: [],
+        resource: resourceIri,
+      },
+    ];
+
     const { asFragment } = renderWithTheme(
-      <AgentsDrawer
+      <ResourceDrawer
         open
         onClose={onClose}
-        onDelete={onDelete}
-        selectedContactName={selectedContactName}
-        profileIri={profileIri}
-        agentType={schema.Person}
+        accessList={accessList}
+        resourceIri={resourceIri}
       />
     );
-    expect(asFragment()).toMatchSnapshot();
-  });
-  it("renders for an App", () => {
-    const { asFragment } = renderWithTheme(
-      <AgentsDrawer
-        open
-        onClose={onClose}
-        onDelete={onDelete}
-        selectedContactName={selectedContactName}
-        profileIri={profileIri}
-        agentType={schema.SoftwareApplication}
-      />
-    );
+
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/styles.js
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/styles.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+const DETAILS_ICON_COLOR = "#4CAF50";
+
+export default function styles(theme) {
+  return {
+    "access-details--wrapper": {
+      padding: "1.5rem",
+    },
+    "access-details--title": {
+      display: "flex",
+      "& h2": {
+        padding: 0,
+        margin: 0,
+        fontFamily: theme.typography.h2.fontFamily,
+      },
+    },
+    "access-details--icon": {
+      fontSize: "1.5rem",
+      display: "flex",
+      alignItems: "center",
+      background: "linear-gradient(to right, #0D6796, #33B2D3)",
+      "-webkit-background-clip": "text",
+      color: "transparent",
+      marginRight: "1rem",
+    },
+    "access-details--section": {
+      minWidth: "100%",
+    },
+    "access-details--section-header": {
+      fontFamily: theme.typography.h3.fontFamily,
+    },
+    "access-details--section-icon": {
+      color: DETAILS_ICON_COLOR,
+      fontSize: "1rem",
+      alignItems: "flex-start",
+    },
+    listItemIcon: {
+      minWidth: "fit-content",
+      paddingRight: "0.5rem",
+      display: "flex",
+      alignSelf: "flex-start",
+      paddingTop: "0.2rem",
+    },
+    listItemTitleText: {
+      fontFamily: theme.typography.body.fontFamily,
+      fontSize: theme.typography.body1.fontSize,
+    },
+    listItemSecondaryText: {
+      fontFamily: theme.typography.body.fontFamily,
+      fontSize: "0.8125rem",
+    },
+    "access-details--separator": {
+      backgroundColor: theme.palette.grey.A100,
+      border: "none",
+      height: "1px",
+    },
+    listItemText: {
+      marginTop: 0,
+    },
+  };
+}

--- a/components/pages/privacy/resourceAccess/show/index.jsx
+++ b/components/pages/privacy/resourceAccess/show/index.jsx
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable react/jsx-props-no-spreading */
+
+import React, { useEffect, useState, useMemo } from "react";
+import { useSession } from "@inrupt/solid-ui-react";
+import { useTable } from "react-table";
+import clsx from "clsx";
+import { useRouter } from "next/router";
+import {
+  DrawerContainer,
+  Table as PrismTable,
+} from "@inrupt/prism-react-components";
+import { useRedirectIfLoggedOut } from "../../../../../src/effects/auth";
+import usePodRootUri from "../../../../../src/hooks/usePodRootUri";
+import ResourceAccessDrawer from "../resourceAccessDrawer";
+
+export default function AgentResourceAccessShowPage() {
+  const tableClass = PrismTable.useTableClass("table", "inherits");
+  const bem = PrismTable.useBem();
+  useRedirectIfLoggedOut();
+  const router = useRouter();
+  const { session, fetch } = useSession();
+  const decodedIri = decodeURIComponent(router.query.webId);
+  const podRoot = usePodRootUri(session.info.webId);
+  const [resources, setResources] = useState([]);
+  const [accessList, setAccessList] = useState([]);
+  const [selectedResourceIndex, setSelectedResourceIndex] = useState(null);
+  const [selectedAccessList, setSelectedAccessList] = useState(null);
+  const [resourcesError, setResourcesError] = useState(null);
+
+  const query = `
+  {
+    pod(iri: "${podRoot}" ) {
+        accessByAgent(agent: "${decodedIri}" ) {
+        agent
+        allow
+        deny
+        resource
+        }
+    }
+ }
+  `;
+  useEffect(() => {
+    if (!podRoot) return;
+    fetch("https://access.pod.inrupt.com/graphql/", {
+      method: "POST",
+      headers: { "Content-type": "application/json" },
+      body: JSON.stringify({ query }),
+    })
+      .then((response) => {
+        return response.json();
+      })
+      .catch((error) => {
+        setResourcesError(error);
+      })
+      .then(({ data }) => {
+        if (!data) return;
+        const { accessByAgent } = data.pod;
+        setAccessList(accessByAgent);
+        const resourceList = [
+          ...new Set(data.pod.accessByAgent.map(({ resource }) => resource)),
+        ];
+        setResources(resourceList);
+      });
+  }, [query, podRoot, fetch, session]);
+
+  useEffect(() => {
+    const selectedAccess = accessList.filter(
+      ({ resource }) => resource === resources[selectedResourceIndex]
+    );
+    setSelectedAccessList(selectedAccess);
+  }, [accessList, resources, selectedResourceIndex]);
+
+  const drawer = (
+    <ResourceAccessDrawer
+      accessList={selectedAccessList}
+      open={selectedResourceIndex !== null}
+      onClose={() => setSelectedResourceIndex(null)}
+      resourceIri={resources[selectedResourceIndex]}
+      agentWebId={decodedIri}
+    />
+  );
+
+  const columns = useMemo(
+    () => [
+      {
+        header: "",
+        accessor: "resource",
+        modifiers: ["align-center", "width-preview"],
+      },
+    ],
+    []
+  );
+
+  const data = useMemo(() => {
+    if (!resources) {
+      return [];
+    }
+    // showing the first 3 resources for dev purposes
+    return resources.slice(0, 3);
+  }, [resources]);
+
+  const { getTableProps, getTableBodyProps } = useTable({ columns, data });
+
+  if (resourcesError) {
+    return resourcesError.toString();
+  }
+
+  return (
+    <DrawerContainer drawer={drawer} open={selectedResourceIndex !== null}>
+      <div>
+        <h3>
+          FIXME: Ignore this page while testing - it will be replaced with
+          SOLIDOS-322
+        </h3>
+        <table className={clsx(tableClass, bem("table"))} {...getTableProps()}>
+          <tbody className={bem("table__body")} {...getTableBodyProps()}>
+            {data.map((resource, i) => {
+              return (
+                <tr
+                  key={resource}
+                  className={bem("table__body-row")}
+                  onClick={() => setSelectedResourceIndex(i)}
+                >
+                  <td className={bem("table__body-cell")}>{resource}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </DrawerContainer>
+  );
+}

--- a/constants/policies.js
+++ b/constants/policies.js
@@ -57,6 +57,34 @@ const customPolicyVariables = {
   emptyStateText: "",
 };
 
+export const ACP_TYPE_MAP = {
+  write: {
+    name: "Edit",
+    icon: "editor",
+    description: "Can change, download or delete this resource",
+  },
+  read: {
+    name: "View",
+    icon: "view",
+    description: "Can see this resource",
+  },
+  append: {
+    name: "Add",
+    icon: "add",
+    description: "Can upload to this resource",
+  },
+  control: {
+    name: "Share",
+    icon: "user",
+    description: "Can share this resource with others",
+  },
+  accessToAcr: {
+    name: "View Sharing",
+    icon: "users",
+    description: "Can see who else has access to this resource",
+  },
+};
+
 // eslint-disable-next-line import/prefer-default-export
 export const POLICIES_TYPE_MAP = {
   custom: customPolicyVariables,

--- a/pages/privacy/resourceAccess/[webId].jsx
+++ b/pages/privacy/resourceAccess/[webId].jsx
@@ -20,40 +20,9 @@
  */
 
 import React from "react";
-import { schema } from "rdf-namespaces";
-import AgentsDrawer from "./index";
-import { renderWithTheme } from "../../../__testUtils/withTheme";
 
-describe("AgentsDrawer", () => {
-  const onClose = () => {};
-  const onDelete = () => {};
-  const selectedContactName = "Alice";
-  const profileIri = "https://example.com/profile#alice";
+import AgentResourceAccessShowPage from "../../../components/pages/privacy/resourceAccess/show";
 
-  it("renders for a Person", () => {
-    const { asFragment } = renderWithTheme(
-      <AgentsDrawer
-        open
-        onClose={onClose}
-        onDelete={onDelete}
-        selectedContactName={selectedContactName}
-        profileIri={profileIri}
-        agentType={schema.Person}
-      />
-    );
-    expect(asFragment()).toMatchSnapshot();
-  });
-  it("renders for an App", () => {
-    const { asFragment } = renderWithTheme(
-      <AgentsDrawer
-        open
-        onClose={onClose}
-        onDelete={onDelete}
-        selectedContactName={selectedContactName}
-        profileIri={profileIri}
-        agentType={schema.SoftwareApplication}
-      />
-    );
-    expect(asFragment()).toMatchSnapshot();
-  });
-});
+export default function AgentResourceAccessShow() {
+  return <AgentResourceAccessShowPage />;
+}

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -54,7 +54,7 @@ import {
   AUTHENTICATED_AGENT_PREDICATE,
   AUTHENTICATED_AGENT_TYPE,
 } from "../../models/contact/authenticated";
-import { POLICIES_TYPE_MAP } from "../../../constants/policies";
+import { ACP_TYPE_MAP, POLICIES_TYPE_MAP } from "../../../constants/policies";
 
 export const noAcrAccessError =
   "No access to Access Control Resource for this resource";
@@ -77,6 +77,16 @@ const acpMapForApplyPolicies = {
   viewAndAdd: createAcpMap(true, false, true),
   editOnly: createAcpMap(false, true),
   addOnly: createAcpMap(false, false, true),
+};
+
+export const getAcpAccessDetails = (access) => {
+  const { read, write, append, control } = access;
+  const key =
+    (read && "read") ||
+    (write && "write") ||
+    (append && "append") ||
+    (control && "control");
+  return ACP_TYPE_MAP[key];
 };
 
 export const getPolicyDetailFromAccess = (access, label) => {


### PR DESCRIPTION
# ACP Access details drawer

In this PR: adding drawer displaying details about ACP access

Not in this PR: 
- Edit access button
- Consent details info

# Notes for testing:

- Some icons don't match the designs: these will be added to Prism and updated in PB in separate PRs.
- Ignore the resource for agents page: it will be replaces in another ticket

- # Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
