### PR TITLE
Added action menu to agent resource access page

### DIFF
--- a/components/pages/privacy/resourceAccess/RevokeAccessButton/styles.js
+++ b/components/pages/privacy/resourceAccess/RevokeAccessButton/styles.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { createStyles } from "@solid/lit-prism-patterns";
+
+const styles = (theme) => {
+  return createStyles(theme, ["back-to-nav", "input"], {
+    "revoke-button": {
+      color: theme.palette.error.main,
+      textDecoration: "underline",
+    },
+  });
+};
+
+export default styles;

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.jsx
@@ -267,7 +267,6 @@ export default function ResourceAccessDrawer({
           >
             Remove Access to {resourceName}
           </button>
-          {/* <ConfirmationDialog /> */}
         </div>
       )}
     </Drawer>

--- a/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.test.jsx
+++ b/components/pages/privacy/resourceAccess/resourceAccessDrawer/index.test.jsx
@@ -29,7 +29,7 @@ import ResourceDrawer, {
   TESTCAFE_ID_ACCESS_DETAILS_REMOVE_BUTTON,
 } from "./index";
 import useAccessControl from "../../../../../src/hooks/useAccessControl";
-import {
+import ConfirmationDialog, {
   TESTCAFE_ID_CONFIRMATION_DIALOG,
   TESTCAFE_ID_CONFIRM_BUTTON,
 } from "../../../../confirmationDialog";
@@ -96,6 +96,7 @@ describe("ResourceDrawer", () => {
           accessList={accessListEditors}
           resourceIri={resourceIri}
         />
+        <ConfirmationDialog />
       </ConfirmationDialogProvider>
     );
     const button = getByTestId(TESTCAFE_ID_ACCESS_DETAILS_REMOVE_BUTTON);
@@ -125,6 +126,7 @@ describe("ResourceDrawer", () => {
           accessList={accessListEditors}
           resourceIri={resourceIri}
         />
+        <ConfirmationDialog />
       </ConfirmationDialogProvider>
     );
     const button = getByTestId(TESTCAFE_ID_ACCESS_DETAILS_REMOVE_BUTTON);

--- a/components/pages/privacy/resourceAccess/show/index.jsx
+++ b/components/pages/privacy/resourceAccess/show/index.jsx
@@ -20,7 +20,7 @@
  */
 
 /* eslint-disable react/jsx-props-no-spreading */
-
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React, { useEffect, useState, useMemo } from "react";
 import { CombinedDataProvider, useSession, Text } from "@inrupt/solid-ui-react";
 import { useRouter } from "next/router";
@@ -334,10 +334,10 @@ export default function AgentResourceAccessShowPage({ type }) {
                       const resourcePathAndName = `${
                         resourcePath + resourceName.trim()
                       }`;
-                      const resurceAccess = accessList.filter(
+                      const resourceAccess = accessList.filter(
                         ({ resource }) => resource === row.original
                       );
-                      const allowModes = getAllowModes(resurceAccess);
+                      const allowModes = getAllowModes(resourceAccess);
                       const modes = allowModes?.map((mode) => {
                         return {
                           read: !!mode.includes("Read"),
@@ -373,6 +373,8 @@ export default function AgentResourceAccessShowPage({ type }) {
                           </td>
                           <td
                             className={bem("table__body-cell", "interactive")}
+                            onClick={() => setSelectedResourceIndex(i)}
+                            onKeyDown={() => setSelectedResourceIndex(i)}
                           >
                             {decodeURIComponent(resourcePathAndName)}
                           </td>
@@ -388,7 +390,7 @@ export default function AgentResourceAccessShowPage({ type }) {
                               <Button
                                 onClick={handleAction(
                                   resources[i],
-                                  podRoot,
+                                  getParentContainerUrl(details),
                                   router
                                 )}
                                 variant="in-menu"
@@ -399,7 +401,7 @@ export default function AgentResourceAccessShowPage({ type }) {
                               <RevokeAccessButton
                                 variant="in-menu"
                                 onClose={() => setSelectedResourceIndex(null)}
-                                accessList={resurceAccess}
+                                accessList={resourceAccess}
                                 resourceIri={resources[i]}
                                 setShouldUpdate={setShouldUpdate}
                               />

--- a/components/pages/privacy/resourceAccess/show/index.jsx
+++ b/components/pages/privacy/resourceAccess/show/index.jsx
@@ -31,14 +31,18 @@ import { useSortBy, useTable } from "react-table";
 import clsx from "clsx";
 import { useBem } from "@solid/lit-prism-patterns";
 import {
-  DrawerContainer,
-  Table as PrismTable,
+  ActionButton,
+  Button,
   BackToNav,
   BackToNavLink,
+  DrawerContainer,
   Icons,
+  Table as PrismTable,
 } from "@inrupt/prism-react-components";
-import { Box, createStyles } from "@material-ui/core";
+import { Box, createStyles, Divider } from "@material-ui/core";
 import Link from "next/link";
+import ConfirmationDialog from "../../../../confirmationDialog";
+import { handleAction } from "../../../../containerTableRow";
 import { useRedirectIfLoggedOut } from "../../../../../src/effects/auth";
 import PersonAvatar from "../../../../profile/personAvatar";
 import AppAvatar from "../../../../profile/appAvatar";
@@ -47,6 +51,7 @@ import AppProfile from "../../../../profile/appProfile";
 import Tabs from "../../../../tabs";
 import usePodRootUri from "../../../../../src/hooks/usePodRootUri";
 import Spinner from "../../../../spinner";
+import RevokeAccessButton from "../RevokeAccessButton";
 import ResourceAccessDrawer, { getAllowModes } from "../resourceAccessDrawer";
 import SortedTableCarat from "../../../../sortedTableCarat";
 import { getAcpAccessDetails } from "../../../../../src/accessControl/acp";
@@ -201,6 +206,11 @@ export default function AgentResourceAccessShowPage({ type }) {
       {
         Header: "Access",
       },
+      {
+        header: "Actions",
+        accessor: "actions",
+        disableSortBy: true,
+      },
     ],
     []
   );
@@ -345,8 +355,11 @@ export default function AgentResourceAccessShowPage({ type }) {
                       return (
                         <tr
                           key={details}
-                          className={bem("table__body-row")}
-                          onClick={() => setSelectedResourceIndex(i)}
+                          className={`${
+                            selectedResourceIndex === i
+                              ? bem("table__body-row", "active")
+                              : bem("table__body-row")
+                          }`}
                         >
                           <td className={bem("table__body-cell")}>
                             <Icons
@@ -364,6 +377,34 @@ export default function AgentResourceAccessShowPage({ type }) {
                             {decodeURIComponent(resourcePathAndName)}
                           </td>
                           <td>{accessDetailsName?.join(", ")}</td>
+                          <td className={bem("table__body-cell")}>
+                            <ActionButton>
+                              <Button
+                                variant="in-menu"
+                                onClick={() => setSelectedResourceIndex(i)}
+                              >
+                                Details
+                              </Button>
+                              <Button
+                                onClick={handleAction(
+                                  resources[i],
+                                  podRoot,
+                                  router
+                                )}
+                                variant="in-menu"
+                              >
+                                View Resource
+                              </Button>
+                              <Divider />
+                              <RevokeAccessButton
+                                variant="in-menu"
+                                onClose={() => setSelectedResourceIndex(null)}
+                                accessList={resurceAccess}
+                                resourceIri={resources[i]}
+                                setShouldUpdate={setShouldUpdate}
+                              />
+                            </ActionButton>
+                          </td>
                         </tr>
                       );
                     })}
@@ -375,6 +416,7 @@ export default function AgentResourceAccessShowPage({ type }) {
           <TabPanel value={selectedTabValue} index="Profile">
             {renderProfile()}
           </TabPanel>
+          <ConfirmationDialog />
         </div>
       </DrawerContainer>
     </ConditionalWrapper>

--- a/components/pages/privacy/resourceAccess/show/styles.js
+++ b/components/pages/privacy/resourceAccess/show/styles.js
@@ -21,6 +21,9 @@
 
 import { createStyles } from "@solid/lit-prism-patterns";
 
+const secondaryTeal80 = "#3D85AB";
+const secondaryTeal10 = "#E6EFF4";
+
 const styles = (theme) => {
   return createStyles(theme, ["back-to-nav", "input"], {
     avatar: {
@@ -59,6 +62,7 @@ const styles = (theme) => {
       borderCollapse: "collapse",
       boxShadow: "0 4px 12px 1px rgba(208,208,208,0.22)",
       borderRadius: 8,
+      paddingBottom: "0.5em",
     },
     table: {
       borderCollapse: "collapse",
@@ -72,13 +76,21 @@ const styles = (theme) => {
       padding: "1em",
     },
     "table__body-row": {
+      borderBottom: "0 !important",
+      borderTop: "1px solid",
+      borderTopColor: theme.palette.grey["200"],
+      position: "relative",
       "&:hover": {
-        cursor: "pointer",
+        // cursor: "pointer",
         background: theme.palette.grey["50"],
       },
       "&:last-child": {
         borderBottom: 0,
       },
+    },
+    "table__body-row--active": {
+      border: `2px solid ${secondaryTeal80} !important`,
+      backgroundColor: secondaryTeal10,
     },
     "table__body-cell": {
       width: "2em",


### PR DESCRIPTION
# Added action menu to agent resource table rows

- Added action menu with details/view resource and revoke access buttons
- Removed details action from entire row 
- Added details action to resource name only

_NOTE: Removing the details view trigger was necessary as it was causing unexpected results when clicking the action menu. Clicking the action menu would trigger the row click event and open the drawer while ignoring the action menu listener._

# Checklist

- [x] All acceptance criteria are met.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
