### PR TITLE
Feature/consent details modal UI

### DIFF
--- a/components/confirmationDialog/index.jsx
+++ b/components/confirmationDialog/index.jsx
@@ -66,13 +66,15 @@ export default function ConfirmationDialog() {
       aria-labelledby="confirmation-dialog"
       open={!!open}
     >
-      <DialogTitle
-        data-testid={TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE}
-        disableTypography
-        classes={{ root: classes.dialogTitle }}
-      >
-        {title}
-      </DialogTitle>
+      {title && (
+        <DialogTitle
+          data-testid={TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE}
+          disableTypography
+          classes={{ root: classes.dialogTitle }}
+        >
+          {title}
+        </DialogTitle>
+      )}
       <DialogContent>
         <DialogContentText
           data-testid={TESTCAFE_ID_CONFIRMATION_DIALOG_CONTENT}

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AgentAccessOptionsMenu clicking on view details button renders a confirmation dialog with the correct data 1`] = `
+exports[`View consent details button and modal clicking on view details button renders a confirmation dialog with the correct data 1`] = `
 <body
   style="padding-right: 0px; overflow: hidden;"
 >
@@ -108,23 +108,25 @@ exports[`AgentAccessOptionsMenu clicking on view details button renders a confir
 </body>
 `;
 
-exports[`AgentAccessOptionsMenu it renders a button which triggers the opening of the modal 1`] = `
-<DocumentFragment>
-  <div
-    aria-disabled="false"
-    class="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
-    data-testid="view-details-button"
-    role="button"
-    tabindex="0"
-  >
+exports[`View consent details button and modal it renders a button which triggers the opening of the modal 1`] = `
+<body>
+  <div>
     <div
-      class="PodBrowser-root"
+      aria-disabled="false"
+      class="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+      data-testid="view-details-button"
+      role="button"
+      tabindex="0"
     >
-      View Details
+      <div
+        class="PodBrowser-root"
+      >
+        View Details
+      </div>
+      <span
+        class="PodBrowser-root"
+      />
     </div>
-    <span
-      class="PodBrowser-root"
-    />
   </div>
-</DocumentFragment>
+</body>
 `;

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AgentAccessOptionsMenu clicking on view details button renders a confirmation dialog with the correct data 1`] = `
+<body
+  style="padding-right: 0px; overflow: hidden;"
+>
+  <div
+    aria-hidden="true"
+  >
+    <div
+      aria-disabled="false"
+      class="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+      data-testid="view-details-button"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="PodBrowser-root"
+      >
+        View Details
+      </div>
+      <span
+        class="PodBrowser-root"
+      >
+        <span
+          class="PodBrowser-ripple PodBrowser-rippleVisible"
+          style="width: 2.8284271247461903px; height: 2.8284271247461903px; top: -1.4142135623730951px; left: -1.4142135623730951px;"
+        >
+          <span
+            class="PodBrowser-child PodBrowser-childLeaving"
+          />
+        </span>
+      </span>
+    </div>
+  </div>
+  <div
+    class="PodBrowser-root"
+    data-testid="confirmation-dialog"
+    role="presentation"
+    style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px;"
+  >
+    <div
+      aria-hidden="true"
+      class="PodBrowser-root"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    />
+    <div
+      data-test="sentinelStart"
+      tabindex="0"
+    />
+    <div
+      class="PodBrowser-container PodBrowser-scrollPaper"
+      role="none presentation"
+      style="opacity: 1; webkit-transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms; transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+      tabindex="-1"
+    >
+      <div
+        aria-labelledby="confirmation-dialog"
+        class="PodBrowser-root PodBrowser-paper PodBrowser-paperScrollPaper PodBrowser-paperWidthFalse PodBrowser-dialog PodBrowser-elevation24 PodBrowser-rounded"
+        role="dialog"
+      >
+        
+        <div
+          class="PodBrowser-root"
+        >
+          <p
+            class="PodBrowser-root PodBrowser-root PodBrowser-dialogText PodBrowser-body1 PodBrowser-colorTextSecondary"
+            data-testid="confirmation-dialog-content"
+            id="alert-confirmation-dialog"
+          >
+            <span>
+              Fetching data...
+            </span>
+          </p>
+        </div>
+        <div
+          class="PodBrowser-root PodBrowser-dialogActions PodBrowser-spacing"
+        >
+          <button
+            class="PodBrowser-button PodBrowser-button--secondary"
+            data-testid="confirmation-cancel-button"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              Done
+            </span>
+          </button>
+          <button
+            class="PodBrowser-button PodBrowser-dangerButton"
+            data-testid="confirm-button"
+            type="submit"
+          >
+            <span
+              class="PodBrowser-button__text"
+            >
+              Revoke Access to iri
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      data-test="sentinelEnd"
+      tabindex="0"
+    />
+  </div>
+</body>
+`;
+
+exports[`AgentAccessOptionsMenu it renders a button which triggers the opening of the modal 1`] = `
+<DocumentFragment>
+  <div
+    aria-disabled="false"
+    class="PodBrowser-root PodBrowser-root PodBrowser-gutters PodBrowser-button"
+    data-testid="view-details-button"
+    role="button"
+    tabindex="0"
+  >
+    <div
+      class="PodBrowser-root"
+    >
+      View Details
+    </div>
+    <span
+      class="PodBrowser-root"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Person Avatar renders a person avatar 1`] = `
+<body>
+  <div>
+    <div
+      class="PodBrowser-root PodBrowser-root"
+    >
+      <div
+        class="PodBrowser-root PodBrowser-root"
+      >
+        <div
+          class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+        >
+          <div
+            class="PodBrowser-root PodBrowser-circle PodBrowser-avatar PodBrowser-colorDefault"
+          >
+            <svg
+              aria-hidden="true"
+              class="PodBrowser-root PodBrowser-fallback"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+      <div
+        class="PodBrowser-root PodBrowser-root"
+      >
+        <a
+          href="/privacy/app/https%3A%2F%2Fexample.com%2Fprofile%2Fcard%23me"
+          role="link"
+        >
+          <h3
+            data-testid="profile-name-title"
+          >
+            <span
+              class="PodBrowser-avatarText"
+            />
+          </h3>
+        </a>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`setupErrorComponent renders 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiAvatar-root MuiAvatar-circle avatar MuiAvatar-colorDefault"
+  >
+    <svg
+      aria-hidden="true"
+      class="MuiSvgIcon-root MuiAvatar-fallback"
+      focusable="false"
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"
+      />
+    </svg>
+  </div>
+</DocumentFragment>
+`;

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/index.jsx
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/interactive-supports-focus */
+
+import React from "react";
+import T from "prop-types";
+import { foaf, vcard, rdf } from "rdf-namespaces";
+import Link from "next/link";
+import { getUrl } from "@inrupt/solid-client";
+import { Avatar, Box, createStyles } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import { useBem } from "@solid/lit-prism-patterns";
+import { Text, Image, useThing } from "@inrupt/solid-ui-react";
+import {
+  buildResourcesLink,
+  isPerson,
+} from "../../../../../../agentResourceAccessLink";
+
+import styles from "./styles";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export const TESTCAFE_ID_NAME_TITLE = "profile-name-title";
+
+export function setupErrorComponent(bem) {
+  return () => (
+    <Avatar className={bem("avatar")} alt="Contact photo placeholder" />
+  );
+}
+
+export default function ModalAvatar({ profileIri, closeDialog }) {
+  const classes = useStyles();
+  const bem = useBem(classes);
+  const errorComponent = setupErrorComponent(bem);
+  const { thing } = useThing();
+
+  const type = getUrl(thing, rdf.type);
+  const path = isPerson(type) ? "person" : "app";
+
+  return (
+    <Box alignItems="center" display="flex">
+      <Box>
+        <Avatar className={classes.avatar}>
+          <Image
+            property={vcard.hasPhoto}
+            width={120}
+            errorComponent={errorComponent}
+          />
+        </Avatar>
+      </Box>
+
+      <Box p={2}>
+        <Link href={buildResourcesLink(profileIri, "/privacy", path)}>
+          <a role="link" onClick={() => closeDialog()}>
+            <h3 data-testid={TESTCAFE_ID_NAME_TITLE}>
+              <Text className={classes.avatarText} property={foaf.name} />
+            </h3>
+          </a>
+        </Link>
+      </Box>
+    </Box>
+  );
+}
+
+ModalAvatar.propTypes = {
+  profileIri: T.string.isRequired,
+  closeDialog: T.func.isRequired,
+};

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/index.test.jsx
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import { render } from "@testing-library/react";
+import * as solidClientFns from "@inrupt/solid-client";
+import { CombinedDataProvider } from "@inrupt/solid-ui-react";
+import { renderWithTheme } from "../../../../../../../__testUtils/withTheme";
+import {
+  aliceWebIdUrl,
+  mockPersonDatasetAlice,
+} from "../../../../../../../__testUtils/mockPersonResource";
+import mockSession from "../../../../../../../__testUtils/mockSession";
+import mockSessionContextProvider from "../../../../../../../__testUtils/mockSessionContextProvider";
+import ConsentDetailsModalAvatar, {
+  setupErrorComponent,
+  TESTCAFE_ID_NAME_TITLE,
+} from "./index";
+
+const { mockSolidDatasetFrom, mockThingFrom } = solidClientFns;
+const dataset = mockSolidDatasetFrom("http://example.com/dataset");
+const profile = mockThingFrom("http://example.com/profile#this");
+
+const profileIri = "https://example.com/profile/card#me";
+const closeDialog = jest.fn();
+
+describe("Person Avatar", () => {
+  beforeEach(() => {
+    jest.spyOn(solidClientFns, "getUrl").mockReturnValue("schema.Person");
+  });
+
+  test("renders a person avatar", async () => {
+    const session = mockSession();
+    const SessionProvider = mockSessionContextProvider(session);
+    const { baseElement, findByTestId } = renderWithTheme(
+      <SessionProvider>
+        <CombinedDataProvider solidDataset={dataset} thing={profile}>
+          <ConsentDetailsModalAvatar
+            profileIri={profileIri}
+            closeDialog={closeDialog}
+          />
+        </CombinedDataProvider>
+      </SessionProvider>
+    );
+    await expect(findByTestId(TESTCAFE_ID_NAME_TITLE)).resolves.not.toBeNull();
+    expect(baseElement).toMatchSnapshot();
+  });
+});
+
+describe("setupErrorComponent", () => {
+  it("renders", () => {
+    const bem = (value) => value;
+    const { asFragment } = render(setupErrorComponent(bem)());
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/styles.js
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/styles.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { createStyles } from "@solid/lit-prism-patterns";
+
+const styles = (theme) => {
+  return createStyles(theme, ["back-to-nav", "input"], {
+    avatar: {
+      width: "64px",
+      height: "64px",
+    },
+    avatarText: {
+      fontFamily: theme.typography.h1.fontFamily,
+      fontSize: "1.5rem",
+      color: theme.palette.secondary.contrastText,
+    },
+    headerLink: {
+      display: "block",
+      fontFamily: theme.typography.body2.fontFamily,
+      fontSize: "1rem",
+      fontWeight: theme.typography.body2.fontWeight,
+      color: theme.palette.secondary.contrastText,
+    },
+  });
+};
+
+export default styles;

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/index.jsx
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable react/jsx-one-expression-per-line */
+
+import React, { useState } from "react";
+import T from "prop-types";
+import { Icons } from "@inrupt/prism-react-components";
+import {
+  createStyles,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+} from "@material-ui/core";
+import { foaf } from "rdf-namespaces";
+import { makeStyles } from "@material-ui/styles";
+import { useBem } from "@solid/lit-prism-patterns";
+import { CombinedDataProvider, Text } from "@inrupt/solid-ui-react";
+import { Alert } from "@material-ui/lab";
+import { isHTTPError } from "../../../../../../../src/error";
+import styles from "./styles";
+import ModalAvatar from "../consentDetailsModalAvatar";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function ConsentDetailsModalContent({
+  agentWebId,
+  resourceIri,
+  closeDialog,
+}) {
+  const classes = useStyles();
+  const bem = useBem(classes);
+  const [error, setError] = useState(null);
+
+  // TODO replace with toast error or something?
+  if (error) {
+    if (isHTTPError(error, 404)) {
+      return (
+        <Alert severity="error">
+          {`Cannot fetch avatar for this WebID: ${agentWebId}`}
+        </Alert>
+      );
+    }
+    return error.toString();
+  }
+
+  return (
+    <CombinedDataProvider
+      datasetUrl={agentWebId}
+      thingUrl={agentWebId}
+      onError={setError}
+    >
+      <div className={bem("access-details", "wrapper")}>
+        <span className={bem("access-details", "title")}>
+          <h2>
+            <ModalAvatar profileIri={agentWebId} closeDialog={closeDialog} />
+          </h2>
+        </span>
+        {/* FIXME: display all below details based on retrieved VC */}
+        <section className={bem("access-details", "section")}>
+          <h3 className={bem("access-details", "section-header")}>Access</h3>
+          <hr className={bem("access-details", "separator")} />
+          <List>
+            <ListItem>
+              <ListItemIcon classes={{ root: classes.listItemIcon }}>
+                <Icons
+                  name="view"
+                  className={bem("access-details", "section-icon")}
+                />
+              </ListItemIcon>
+              <ListItemText
+                classes={{
+                  root: classes.listItemText,
+                  primary: classes.listItemTitleText,
+                  secondary: classes.listItemSecondaryText,
+                }}
+                primary="View"
+                secondary="can see this resource"
+              />
+            </ListItem>
+          </List>
+        </section>
+        <section className={bem("access-details", "section")}>
+          <h3 className={bem("access-details", "section-header")}>
+            Approved On
+          </h3>
+          <hr className={bem("access-details", "separator")} />
+          <p>3/12/2020</p>
+        </section>
+        <section className={bem("access-details", "section")}>
+          <h3 className={bem("access-details", "section-header")}>Purpose</h3>
+          <hr className={bem("access-details", "separator")} />
+          <p>Commercial Interest</p>
+        </section>
+        <section className={bem("access-details", "section")}>
+          <h3 className={bem("access-details", "section-header")}>
+            Access Duration
+          </h3>
+          <hr className={bem("access-details", "separator")} />
+          <p>
+            <Text className={classes.avatarText} property={foaf.name} /> has
+            access until <strong>May 20, 2022</strong>
+          </p>
+        </section>
+      </div>
+    </CombinedDataProvider>
+  );
+}
+
+ConsentDetailsModalContent.propTypes = {
+  agentWebId: T.string.isRequired,
+  resourceIri: T.string,
+  closeDialog: T.func.isRequired,
+};
+
+ConsentDetailsModalContent.defaultProps = {
+  resourceIri: null,
+};

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/styles.js
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/styles.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+const DETAILS_ICON_COLOR = "#4CAF50";
+
+export default function styles(theme) {
+  return {
+    "access-details--wrapper": {
+      display: "flex",
+      flexDirection: "column",
+    },
+    "access-details--title": {
+      "& h2": {
+        padding: 0,
+        margin: 0,
+        fontFamily: theme.typography.h2.fontFamily,
+        position: "relative",
+      },
+      "& h3": {
+        margin: 0,
+      },
+    },
+    "access-details--resource-info": {
+      flexGrow: 1,
+      "& > *": {
+        paddingLeft: "2rem",
+      },
+      "& p": {
+        fontSize: "0.8125rem",
+        margin: 0,
+        wordWrap: "break-word",
+      },
+    },
+    "access-details--icon": {
+      fontSize: "1.5rem",
+      display: "flex",
+      alignItems: "center",
+      background: "linear-gradient(to right, #0D6796, #33B2D3)",
+      "-webkit-background-clip": "text",
+      color: "transparent",
+      marginRight: "1rem",
+    },
+    "access-details--section": {
+      minWidth: "100%",
+    },
+    "access-details--section-header": {
+      fontFamily: theme.typography.h3.fontFamily,
+    },
+    "access-details--section-icon": {
+      color: DETAILS_ICON_COLOR,
+      fontSize: "1rem",
+      alignItems: "flex-start",
+    },
+    listItemIcon: {
+      minWidth: "fit-content",
+      paddingRight: "0.5rem",
+      display: "flex",
+      alignSelf: "flex-start",
+      paddingTop: "0.2rem",
+    },
+    listItemTitleText: {
+      fontFamily: theme.typography.body.fontFamily,
+      fontSize: theme.typography.body1.fontSize,
+    },
+    listItemSecondaryText: {
+      fontFamily: theme.typography.body.fontFamily,
+      fontSize: "0.8125rem",
+    },
+    "access-details--separator": {
+      backgroundColor: theme.palette.grey.A100,
+      border: "none",
+      height: "1px",
+    },
+    listItemText: {
+      marginTop: 0,
+    },
+    "access-details--remove-access-button": {
+      border: "none",
+      background: "transparent",
+      color: theme.palette.error.main,
+      textDecoration: "underline",
+      fontSize: "1rem",
+      cursor: "pointer",
+      textAlign: "left",
+      justifySelf: "flex-end",
+    },
+  };
+}

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.jsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable react/jsx-one-expression-per-line */
+
+import React, { useContext } from "react";
+import T from "prop-types";
+import { createStyles, ListItem, ListItemText } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import { getResourceName } from "../../../../../../src/solidClientHelpers/resource";
+import ConfirmationDialogContext from "../../../../../../src/contexts/confirmationDialogContext";
+import ConsentDetailsModalContent from "./consentDetailsModalContent";
+import styles from "./styles";
+
+export const TESTCAFE_ID_REVOKE_ACCESS_BUTTON = "revoke-access-button";
+
+export const REMOVE_ACCESS_CONFIRMATION_DIALOG =
+  "remove-access-confirmation-dialog";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function ConsentDetailsButton({ agentWebId, resourceIri }) {
+  const classes = useStyles();
+  const {
+    setContent,
+    setOpen,
+    setTitle,
+    setConfirmText,
+    setCancelText,
+    setIsDangerousAction,
+    closeDialog,
+  } = useContext(ConfirmationDialogContext);
+  const resourceName = getResourceName(resourceIri);
+
+  const openModal = () => {
+    setIsDangerousAction(true);
+    setOpen(REMOVE_ACCESS_CONFIRMATION_DIALOG);
+    setTitle(``);
+    setCancelText("Done");
+    setConfirmText(`Revoke Access to ${resourceName}`);
+    setContent(
+      <ConsentDetailsModalContent
+        agentWebId={agentWebId}
+        resourceIri={resourceIri}
+        closeDialog={closeDialog}
+      />
+    );
+  };
+
+  return (
+    <ListItem
+      data-testid={TESTCAFE_ID_REVOKE_ACCESS_BUTTON}
+      button
+      onClick={openModal}
+    >
+      <ListItemText
+        disableTypography
+        classes={{ primary: classes.listItemText }}
+      >
+        View Details
+      </ListItemText>
+    </ListItem>
+  );
+}
+
+ConsentDetailsButton.propTypes = {
+  agentWebId: T.string.isRequired,
+  resourceIri: T.string,
+};
+
+ConsentDetailsButton.defaultProps = {
+  resourceIri: null,
+};

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.jsx
@@ -30,10 +30,10 @@ import ConfirmationDialogContext from "../../../../../../src/contexts/confirmati
 import ConsentDetailsModalContent from "./consentDetailsModalContent";
 import styles from "./styles";
 
-export const TESTCAFE_ID_REVOKE_ACCESS_BUTTON = "revoke-access-button";
+export const TESTCAFE_ID_VIEW_DETAILS_BUTTON = "view-details-button";
 
-export const REMOVE_ACCESS_CONFIRMATION_DIALOG =
-  "remove-access-confirmation-dialog";
+export const VIEW_DETAILS_CONFIRMATION_DIALOG =
+  "view-details-confirmation-dialog";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
@@ -52,7 +52,7 @@ export default function ConsentDetailsButton({ agentWebId, resourceIri }) {
 
   const openModal = () => {
     setIsDangerousAction(true);
-    setOpen(REMOVE_ACCESS_CONFIRMATION_DIALOG);
+    setOpen(VIEW_DETAILS_CONFIRMATION_DIALOG);
     setTitle(``);
     setCancelText("Done");
     setConfirmText(`Revoke Access to ${resourceName}`);
@@ -67,7 +67,7 @@ export default function ConsentDetailsButton({ agentWebId, resourceIri }) {
 
   return (
     <ListItem
-      data-testid={TESTCAFE_ID_REVOKE_ACCESS_BUTTON}
+      data-testid={TESTCAFE_ID_VIEW_DETAILS_BUTTON}
       button
       onClick={openModal}
     >

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.test.jsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import { waitFor } from "@testing-library/dom";
+import userEvent from "@testing-library/user-event";
+import { renderWithTheme } from "../../../../../../__testUtils/withTheme";
+import mockAccessControl from "../../../../../../__testUtils/mockAccessControl";
+import ConsentDetailsButton, { TESTCAFE_ID_VIEW_DETAILS_BUTTON } from "./index";
+import { ConfirmationDialogProvider } from "../../../../../../src/contexts/confirmationDialogContext";
+import ConfirmationDialog, {
+  TESTCAFE_ID_CONFIRM_BUTTON,
+  TESTCAFE_ID_CONFIRMATION_DIALOG,
+  TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE,
+} from "../../../../../confirmationDialog";
+import AccessControlContext from "../../../../../../src/contexts/accessControlContext";
+
+const resourceIri = "/iri/";
+const resourceUrl = "http://example.com/resource";
+const webId = "https://example.com/profile/card#me";
+const name = "Example Agent";
+
+describe("AgentAccessOptionsMenu", () => {
+  test("it renders a button which triggers the opening of the modal", () => {
+    const { asFragment, getByTestId } = renderWithTheme(
+      <ConsentDetailsButton resourceIri={resourceIri} agentWebId={webId} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+    const button = getByTestId(TESTCAFE_ID_VIEW_DETAILS_BUTTON);
+    expect(button).toBeDefined();
+  });
+  test("clicking on view details button renders a confirmation dialog with the correct data", async () => {
+    const { baseElement, getByTestId, findByTestId } = renderWithTheme(
+      <ConfirmationDialogProvider>
+        <ConsentDetailsButton resourceIri={resourceIri} agentWebId={webId} />
+        <ConfirmationDialog />
+      </ConfirmationDialogProvider>
+    );
+    const button = getByTestId(TESTCAFE_ID_VIEW_DETAILS_BUTTON);
+    userEvent.click(button);
+    const dialog = await findByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG);
+    expect(dialog).toBeInTheDocument();
+    expect(baseElement).toMatchSnapshot();
+  });
+});

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/index.test.jsx
@@ -20,30 +20,38 @@
  */
 
 import React from "react";
-import { waitFor } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
+import * as solidClientFns from "@inrupt/solid-client";
 import { renderWithTheme } from "../../../../../../__testUtils/withTheme";
-import mockAccessControl from "../../../../../../__testUtils/mockAccessControl";
 import ConsentDetailsButton, { TESTCAFE_ID_VIEW_DETAILS_BUTTON } from "./index";
+import {
+  aliceWebIdUrl,
+  mockPersonDatasetAlice,
+} from "../../../../../../__testUtils/mockPersonResource";
 import { ConfirmationDialogProvider } from "../../../../../../src/contexts/confirmationDialogContext";
 import ConfirmationDialog, {
-  TESTCAFE_ID_CONFIRM_BUTTON,
   TESTCAFE_ID_CONFIRMATION_DIALOG,
-  TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE,
 } from "../../../../../confirmationDialog";
-import AccessControlContext from "../../../../../../src/contexts/accessControlContext";
 
 const resourceIri = "/iri/";
-const resourceUrl = "http://example.com/resource";
 const webId = "https://example.com/profile/card#me";
-const name = "Example Agent";
 
-describe("AgentAccessOptionsMenu", () => {
-  test("it renders a button which triggers the opening of the modal", () => {
-    const { asFragment, getByTestId } = renderWithTheme(
+describe("View consent details button and modal", () => {
+  const profileDataset = mockPersonDatasetAlice();
+  const profileThing = solidClientFns.getThing(profileDataset, aliceWebIdUrl);
+  beforeEach(() => {
+    jest
+      .spyOn(solidClientFns, "getSolidDataset")
+      .mockResolvedValue(profileDataset);
+    jest.spyOn(solidClientFns, "getThing").mockReturnValue(profileThing);
+    jest.spyOn(solidClientFns, "getUrl").mockReturnValue("schema.Person");
+  });
+
+  test("it renders a button which triggers the opening of the modal", async () => {
+    const { baseElement, getByTestId } = renderWithTheme(
       <ConsentDetailsButton resourceIri={resourceIri} agentWebId={webId} />
     );
-    expect(asFragment()).toMatchSnapshot();
+    expect(baseElement).toMatchSnapshot();
     const button = getByTestId(TESTCAFE_ID_VIEW_DETAILS_BUTTON);
     expect(button).toBeDefined();
   });

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/styles.js
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/styles.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { createStyles } from "@solid/lit-prism-patterns";
+
+const styles = (theme) => {
+  return createStyles(theme, ["back-to-nav", "input"], {
+    "revoke-button": {
+      color: theme.palette.error.main,
+      textDecoration: "underline",
+      background: "none",
+      border: "none",
+      cursor: "pointer",
+      textAlign: "left",
+      fontSize: "1rem",
+    },
+  });
+};
+
+export default styles;

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/index.jsx
@@ -32,6 +32,7 @@ import { useBem } from "@solid/lit-prism-patterns";
 import clsx from "clsx";
 import { makeStyles } from "@material-ui/styles";
 import RemoveButton from "./removeButton";
+import ConsentDetailsButton from "./consentDetailsButton";
 import styles from "./styles";
 import { profile as profilePropType } from "../../../../../constants/propTypes";
 
@@ -102,6 +103,7 @@ export default function AgentAccessOptionsMenu({
               <p className={classes.webId}>{webId}</p>
             </ListItemText>
           </ListItem>
+          <ConsentDetailsButton resourceIri={resourceIri} agentWebId={webId} />
           <RemoveButton
             resourceIri={resourceIri}
             profile={profile}


### PR DESCRIPTION
# Added consent access details modal UI

Added `View Details` button in the sharing panel for agents
<img width="500" alt="Screenshot 2021-10-19 at 09 15 52" src="https://user-images.githubusercontent.com/4271417/137870537-e09baaba-501b-4c74-8ae3-4ee0e7b8df27.png">

Clicking on the button opens the details modal with hardcoded data
<img width="657" alt="Screenshot 2021-10-19 at 09 16 54" src="https://user-images.githubusercontent.com/4271417/137870702-0d3d1c4b-6655-4637-a02d-44ad77902b45.png">

Clicking on the agent name closes the modal and opens up the privacy page access details for that agent

TODO: 

- Retrieve and display details from a consent vc
- Add the edit functionality
- Add revoke functionality

# Checklist

- [x] All acceptance criteria are met.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
