### PR TITLE
Fix/access request subfolders

### DIFF
--- a/__testUtils/mockConsentRequestDetails.js
+++ b/__testUtils/mockConsentRequestDetails.js
@@ -38,33 +38,25 @@ export function getConsentRequestDetailsOnePurpose() {
         {
           mode: ["Read", "Write"],
           hasStatus: "ConsentStatusRequested",
-          forPersonalData: [
-            "https://pod.inrupt.com/alice/private/data/",
-            "https://pod.inrupt.com/alice/private/data-2",
-            "https://pod.inrupt.com/alice/private/data-3",
-          ],
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data/"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
         },
         {
           mode: ["Read"],
           hasStatus: "ConsentStatusRequested",
-          forPersonalData: [
-            "https://pod.inrupt.com/alice/private/data",
-            "https://pod.inrupt.com/alice/private/data-2/",
-            "https://pod.inrupt.com/alice/private/data-3",
-          ],
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data/"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
         },
         {
           mode: ["Append"],
           hasStatus: "ConsentStatusRequested",
-          forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data/"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
         },
         {
           mode: ["Control"],
           hasStatus: "ConsentStatusRequested",
-          forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data/"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
         },
       ],
@@ -98,11 +90,7 @@ function getConsentRequestDetails() {
         {
           mode: ["Read", "Write"],
           hasStatus: "ConsentStatusRequested",
-          forPersonalData: [
-            "https://pod.inrupt.com/alice/private/data/",
-            "https://pod.inrupt.com/alice/private/data-2",
-            "https://pod.inrupt.com/alice/private/data-3",
-          ],
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data/"],
           forPurpose: [
             "https://example.com/SomeSpecificPurpose",
             "https://example.com/SomeSpecificPurposeA",
@@ -112,11 +100,7 @@ function getConsentRequestDetails() {
         {
           mode: ["Read"],
           hasStatus: "ConsentStatusRequested",
-          forPersonalData: [
-            "https://pod.inrupt.com/alice/private/data",
-            "https://pod.inrupt.com/alice/private/data-2/",
-            "https://pod.inrupt.com/alice/private/data-3",
-          ],
+          forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
         },
         {

--- a/components/consentRequestForm/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/__snapshots__/index.test.jsx.snap
@@ -254,102 +254,6 @@ exports[`Consent Request Form Renders a consent request form with multiple purpo
             </p>
           </span>
         </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-2"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-2"
-              >
-                data-2
-              </span>
-            </p>
-          </span>
-        </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-3"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-3"
-              >
-                data-3
-              </span>
-            </p>
-          </span>
-        </label>
       </div>
     </fieldset>
     <fieldset
@@ -430,112 +334,6 @@ exports[`Consent Request Form Renders a consent request form with multiple purpo
                 title="https://pod.inrupt.com/alice/private/data"
               >
                 data
-              </span>
-            </p>
-          </span>
-        </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  data-testid="consent-access-switch"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-2/"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-2/"
-              >
-                data-2
-              </span>
-              <button
-                class="PodBrowser-dropdown-caret"
-                data-testid="expand-section"
-                type="button"
-              >
-                <span
-                  class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
-                />
-              </button>
-            </p>
-          </span>
-        </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-3"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-3"
-              >
-                data-3
               </span>
             </p>
           </span>
@@ -891,102 +689,6 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
             </p>
           </span>
         </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-2"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-2"
-              >
-                data-2
-              </span>
-            </p>
-          </span>
-        </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-3"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-3"
-              >
-                data-3
-              </span>
-            </p>
-          </span>
-        </label>
       </div>
     </fieldset>
     <fieldset
@@ -1038,57 +740,9 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
               >
                 <input
                   class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data"
-              >
-                data
-              </span>
-            </p>
-          </span>
-        </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
                   data-testid="consent-access-switch"
                   type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-2/"
+                  value="https://pod.inrupt.com/alice/private/data/"
                 />
                 <span
                   class="PodBrowser-thumb"
@@ -1113,9 +767,9 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
               />
               <span
                 class=""
-                title="https://pod.inrupt.com/alice/private/data-2/"
+                title="https://pod.inrupt.com/alice/private/data/"
               >
-                data-2
+                data
               </span>
               <button
                 class="PodBrowser-dropdown-caret"
@@ -1126,54 +780,6 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
                   class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
                 />
               </button>
-            </p>
-          </span>
-        </label>
-        <label
-          class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-        >
-          <span
-            class="PodBrowser-root"
-          >
-            <span
-              aria-disabled="false"
-              class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-            >
-              <span
-                class="PodBrowser-label"
-              >
-                <input
-                  class="PodBrowser-input PodBrowser-input"
-                  type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data-3"
-                />
-                <span
-                  class="PodBrowser-thumb"
-                />
-              </span>
-              <span
-                class="PodBrowser-root"
-              />
-            </span>
-            <span
-              class="PodBrowser-track"
-            />
-          </span>
-          <span
-            class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-          >
-            <p
-              class="PodBrowser-root PodBrowser-body2"
-            >
-              <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-              />
-              <span
-                class=""
-                title="https://pod.inrupt.com/alice/private/data-3"
-              >
-                data-3
-              </span>
             </p>
           </span>
         </label>
@@ -1228,8 +834,9 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
               >
                 <input
                   class="PodBrowser-input PodBrowser-input"
+                  data-testid="consent-access-switch"
                   type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data"
+                  value="https://pod.inrupt.com/alice/private/data/"
                 />
                 <span
                   class="PodBrowser-thumb"
@@ -1250,14 +857,23 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
               class="PodBrowser-root PodBrowser-body2"
             >
               <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
               />
               <span
                 class=""
-                title="https://pod.inrupt.com/alice/private/data"
+                title="https://pod.inrupt.com/alice/private/data/"
               >
                 data
               </span>
+              <button
+                class="PodBrowser-dropdown-caret"
+                data-testid="expand-section"
+                type="button"
+              >
+                <span
+                  class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
+                />
+              </button>
             </p>
           </span>
         </label>
@@ -1312,8 +928,9 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
               >
                 <input
                   class="PodBrowser-input PodBrowser-input"
+                  data-testid="consent-access-switch"
                   type="checkbox"
-                  value="https://pod.inrupt.com/alice/private/data"
+                  value="https://pod.inrupt.com/alice/private/data/"
                 />
                 <span
                   class="PodBrowser-thumb"
@@ -1334,14 +951,23 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
               class="PodBrowser-root PodBrowser-body2"
             >
               <span
-                class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
+                class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
               />
               <span
                 class=""
-                title="https://pod.inrupt.com/alice/private/data"
+                title="https://pod.inrupt.com/alice/private/data/"
               >
                 data
               </span>
+              <button
+                class="PodBrowser-dropdown-caret"
+                data-testid="expand-section"
+                type="button"
+              >
+                <span
+                  class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
+                />
+              </button>
             </p>
           </span>
         </label>

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -83,7 +83,6 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
   );
   const { agentName } = agentDetails || null;
 
-  // FIXME: we will later fetch the description from the purpose Url
   const {
     confirmed,
     open,
@@ -97,7 +96,6 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
   const [confirmationSetup, setConfirmationSetup] = useState(false);
 
   const requestedAccesses = getRequestedAccesses(consentRequest);
-  // FIXME: we will later fetch the expiry date from the consent details
 
   const expirationDate = getExpiryDate(consentRequest);
   const [selectedDate, setSelectedDate] = useState(new Date());

--- a/components/consentRequestForm/requestSection/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/requestSection/__snapshots__/index.test.jsx.snap
@@ -51,57 +51,9 @@ exports[`Request Section Renders initial context data 1`] = `
             >
               <input
                 class="PodBrowser-input PodBrowser-input"
-                type="checkbox"
-                value="https://pod.inrupt.com/alice/private/data"
-              />
-              <span
-                class="PodBrowser-thumb"
-              />
-            </span>
-            <span
-              class="PodBrowser-root"
-            />
-          </span>
-          <span
-            class="PodBrowser-track"
-          />
-        </span>
-        <span
-          class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-        >
-          <p
-            class="PodBrowser-root PodBrowser-body2"
-          >
-            <span
-              class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-            />
-            <span
-              class=""
-              title="https://pod.inrupt.com/alice/private/data"
-            >
-              data
-            </span>
-          </p>
-        </span>
-      </label>
-      <label
-        class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-      >
-        <span
-          class="PodBrowser-root"
-        >
-          <span
-            aria-disabled="false"
-            class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-          >
-            <span
-              class="PodBrowser-label"
-            >
-              <input
-                class="PodBrowser-input PodBrowser-input"
                 data-testid="consent-access-switch"
                 type="checkbox"
-                value="https://pod.inrupt.com/alice/private/data-2/"
+                value="https://pod.inrupt.com/alice/private/data/"
               />
               <span
                 class="PodBrowser-thumb"
@@ -126,9 +78,9 @@ exports[`Request Section Renders initial context data 1`] = `
             />
             <span
               class=""
-              title="https://pod.inrupt.com/alice/private/data-2/"
+              title="https://pod.inrupt.com/alice/private/data/"
             >
-              data-2
+              data
             </span>
             <button
               class="PodBrowser-dropdown-caret"
@@ -139,54 +91,6 @@ exports[`Request Section Renders initial context data 1`] = `
                 class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
               />
             </button>
-          </p>
-        </span>
-      </label>
-      <label
-        class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-      >
-        <span
-          class="PodBrowser-root"
-        >
-          <span
-            aria-disabled="false"
-            class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-          >
-            <span
-              class="PodBrowser-label"
-            >
-              <input
-                class="PodBrowser-input PodBrowser-input"
-                type="checkbox"
-                value="https://pod.inrupt.com/alice/private/data-3"
-              />
-              <span
-                class="PodBrowser-thumb"
-              />
-            </span>
-            <span
-              class="PodBrowser-root"
-            />
-          </span>
-          <span
-            class="PodBrowser-track"
-          />
-        </span>
-        <span
-          class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-        >
-          <p
-            class="PodBrowser-root PodBrowser-body2"
-          >
-            <span
-              class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-            />
-            <span
-              class=""
-              title="https://pod.inrupt.com/alice/private/data-3"
-            >
-              data-3
-            </span>
           </p>
         </span>
       </label>

--- a/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
@@ -199,160 +199,23 @@ exports[`Consent Page Renders the Consent page 1`] = `
           aria-label="position"
           class="PodBrowser-root PodBrowser-request-container__section PodBrowser-request-container__section--box PodBrowser-row"
         >
-          <label
-            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
+          <div
+            class="PodBrowser-loading-indicator-container PodBrowser-loading-indicator-container--center"
           >
-            <span
-              class="PodBrowser-root"
+            <svg
+              class="PodBrowser-loading-indicator"
+              data-testid="spinner"
+              viewBox="22 22 44 44"
             >
-              <span
-                aria-disabled="false"
-                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-              >
-                <span
-                  class="PodBrowser-label"
-                >
-                  <input
-                    class="PodBrowser-input PodBrowser-input"
-                    data-testid="consent-access-switch"
-                    type="checkbox"
-                    value="https://pod.inrupt.com/alice/private/data/"
-                  />
-                  <span
-                    class="PodBrowser-thumb"
-                  />
-                </span>
-                <span
-                  class="PodBrowser-root"
-                />
-              </span>
-              <span
-                class="PodBrowser-track"
+              <circle
+                cx="44"
+                cy="44"
+                fill="none"
+                r="20.2"
+                stroke-width="3.6"
               />
-            </span>
-            <span
-              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-            >
-              <p
-                class="PodBrowser-root PodBrowser-body2"
-              >
-                <span
-                  class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
-                />
-                <span
-                  class=""
-                  title="https://pod.inrupt.com/alice/private/data/"
-                >
-                  data
-                </span>
-                <button
-                  class="PodBrowser-dropdown-caret"
-                  data-testid="expand-section"
-                  type="button"
-                >
-                  <span
-                    class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
-                  />
-                </button>
-              </p>
-            </span>
-          </label>
-          <label
-            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-          >
-            <span
-              class="PodBrowser-root"
-            >
-              <span
-                aria-disabled="false"
-                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-              >
-                <span
-                  class="PodBrowser-label"
-                >
-                  <input
-                    class="PodBrowser-input PodBrowser-input"
-                    type="checkbox"
-                    value="https://pod.inrupt.com/alice/private/data-2"
-                  />
-                  <span
-                    class="PodBrowser-thumb"
-                  />
-                </span>
-                <span
-                  class="PodBrowser-root"
-                />
-              </span>
-              <span
-                class="PodBrowser-track"
-              />
-            </span>
-            <span
-              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-            >
-              <p
-                class="PodBrowser-root PodBrowser-body2"
-              >
-                <span
-                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-                />
-                <span
-                  class=""
-                  title="https://pod.inrupt.com/alice/private/data-2"
-                >
-                  data-2
-                </span>
-              </p>
-            </span>
-          </label>
-          <label
-            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-          >
-            <span
-              class="PodBrowser-root"
-            >
-              <span
-                aria-disabled="false"
-                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-              >
-                <span
-                  class="PodBrowser-label"
-                >
-                  <input
-                    class="PodBrowser-input PodBrowser-input"
-                    type="checkbox"
-                    value="https://pod.inrupt.com/alice/private/data-3"
-                  />
-                  <span
-                    class="PodBrowser-thumb"
-                  />
-                </span>
-                <span
-                  class="PodBrowser-root"
-                />
-              </span>
-              <span
-                class="PodBrowser-track"
-              />
-            </span>
-            <span
-              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-            >
-              <p
-                class="PodBrowser-root PodBrowser-body2"
-              >
-                <span
-                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-                />
-                <span
-                  class=""
-                  title="https://pod.inrupt.com/alice/private/data-3"
-                >
-                  data-3
-                </span>
-              </p>
-            </span>
-          </label>
+            </svg>
+          </div>
         </div>
       </fieldset>
       <fieldset
@@ -433,112 +296,6 @@ exports[`Consent Page Renders the Consent page 1`] = `
                   title="https://pod.inrupt.com/alice/private/data"
                 >
                   data
-                </span>
-              </p>
-            </span>
-          </label>
-          <label
-            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-          >
-            <span
-              class="PodBrowser-root"
-            >
-              <span
-                aria-disabled="false"
-                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-              >
-                <span
-                  class="PodBrowser-label"
-                >
-                  <input
-                    class="PodBrowser-input PodBrowser-input"
-                    data-testid="consent-access-switch"
-                    type="checkbox"
-                    value="https://pod.inrupt.com/alice/private/data-2/"
-                  />
-                  <span
-                    class="PodBrowser-thumb"
-                  />
-                </span>
-                <span
-                  class="PodBrowser-root"
-                />
-              </span>
-              <span
-                class="PodBrowser-track"
-              />
-            </span>
-            <span
-              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-            >
-              <p
-                class="PodBrowser-root PodBrowser-body2"
-              >
-                <span
-                  class="PodBrowser-icon-folder PodBrowser-icon-small PodBrowser-icon-small--dark"
-                />
-                <span
-                  class=""
-                  title="https://pod.inrupt.com/alice/private/data-2/"
-                >
-                  data-2
-                </span>
-                <button
-                  class="PodBrowser-dropdown-caret"
-                  data-testid="expand-section"
-                  type="button"
-                >
-                  <span
-                    class="PodBrowser-icon-caret-down PodBrowser-icon-small--padded"
-                  />
-                </button>
-              </p>
-            </span>
-          </label>
-          <label
-            class="PodBrowser-root PodBrowser-box__content PodBrowser-labelPlacementStart"
-          >
-            <span
-              class="PodBrowser-root"
-            >
-              <span
-                aria-disabled="false"
-                class="PodBrowser-root PodBrowser-root PodBrowser-root PodBrowser-switchBase PodBrowser-colorPrimary"
-              >
-                <span
-                  class="PodBrowser-label"
-                >
-                  <input
-                    class="PodBrowser-input PodBrowser-input"
-                    type="checkbox"
-                    value="https://pod.inrupt.com/alice/private/data-3"
-                  />
-                  <span
-                    class="PodBrowser-thumb"
-                  />
-                </span>
-                <span
-                  class="PodBrowser-root"
-                />
-              </span>
-              <span
-                class="PodBrowser-track"
-              />
-            </span>
-            <span
-              class="PodBrowser-root PodBrowser-label PodBrowser-body1"
-            >
-              <p
-                class="PodBrowser-root PodBrowser-body2"
-              >
-                <span
-                  class="PodBrowser-icon-file PodBrowser-icon-small PodBrowser-icon-small--dark"
-                />
-                <span
-                  class=""
-                  title="https://pod.inrupt.com/alice/private/data-3"
-                >
-                  data-3
                 </span>
               </p>
             </span>

--- a/components/pages/privacy/consent/requests/index.test.jsx
+++ b/components/pages/privacy/consent/requests/index.test.jsx
@@ -22,16 +22,32 @@
 import React from "react";
 import * as RouterFns from "next/router";
 import { waitFor } from "@testing-library/dom";
+import { mockContainerFrom } from "@inrupt/solid-client";
 import * as resourceHelpers from "../../../../../src/solidClientHelpers/resource";
 import { renderWithTheme } from "../../../../../__testUtils/withTheme";
 import mockSessionContextProvider from "../../../../../__testUtils/mockSessionContextProvider";
 import ConsentPage from "./index";
 import getConsentRequestDetails from "../../../../../__testUtils/mockConsentRequestDetails";
 import { mockAppDataset } from "../../../../../__testUtils/mockApp";
+import useContainer from "../../../../../src/hooks/useContainer";
+import * as containerFns from "../../../../../src/models/container";
 
 jest.mock("../../../../../src/effects/auth");
+jest.mock("../../../../../src/hooks/useContainer");
+const mockedUseContainer = useContainer;
 
 describe("Consent Page", () => {
+  beforeEach(() => {
+    mockedUseContainer.mockReturnValue({
+      data: mockContainerFrom("https://pod.inrupt.com/alice/private/data/"),
+    });
+    jest
+      .spyOn(containerFns, "getContainerResourceUrlAll")
+      .mockResolvedValue([
+        "https://pod.inrupt.com/alice/private/data-2",
+        "https://pod.inrupt.com/alice/private/data-3",
+      ]);
+  });
   test("Renders the Consent page", async () => {
     const consentRequestId = "https://example.org/test-request";
     jest.spyOn(RouterFns, "useRouter").mockReturnValue({
@@ -56,7 +72,9 @@ describe("Consent Page", () => {
         <ConsentPage />
       </SessionProvider>
     );
-    await waitFor(() => expect(getByText("Mock App")).toBeInTheDocument());
+    await waitFor(() => {
+      expect(getByText("Mock App")).toBeInTheDocument();
+    });
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/components/resourceDetails/resourceSharing/agentAccess/index.test.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/index.test.jsx
@@ -267,9 +267,7 @@ describe("AgentAccess", () => {
       await waitFor(() =>
         expect(fetchProfileSpy).toHaveBeenCalledWith(webId, expect.anything())
       );
-      act(() => {
-        fetchProfileSpy.mockResolvedValue(null);
-      });
+      fetchProfileSpy.mockRejectedValue(null);
       await waitFor(() => {
         expect(queryByTestId("try-again-spinner")).toBeFalsy();
       });

--- a/src/models/consent/request/index.test.js
+++ b/src/models/consent/request/index.test.js
@@ -60,11 +60,7 @@ describe("getRequestedAccesses", () => {
       {
         mode: ["Read", "Write"],
         hasStatus: "ConsentStatusRequested",
-        forPersonalData: [
-          "https://pod.inrupt.com/alice/private/data/",
-          "https://pod.inrupt.com/alice/private/data-2",
-          "https://pod.inrupt.com/alice/private/data-3",
-        ],
+        forPersonalData: ["https://pod.inrupt.com/alice/private/data/"],
         forPurpose: [
           "https://example.com/SomeSpecificPurpose",
           "https://example.com/SomeSpecificPurposeA",
@@ -74,11 +70,7 @@ describe("getRequestedAccesses", () => {
       {
         mode: ["Read"],
         hasStatus: "ConsentStatusRequested",
-        forPersonalData: [
-          "https://pod.inrupt.com/alice/private/data",
-          "https://pod.inrupt.com/alice/private/data-2/",
-          "https://pod.inrupt.com/alice/private/data-3",
-        ],
+        forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
         forPurpose: "https://example.com/SomeSpecificPurpose",
       },
       {

--- a/src/models/container/index.test.js
+++ b/src/models/container/index.test.js
@@ -50,4 +50,7 @@ describe("getContainerResourceUrlAll", () => {
     expect(getContainerResourceUrlAll(container)[0]).toEqual(iri1);
     expect(getContainerResourceUrlAll(container)[1]).toEqual(iri2);
   });
+  it("returns an empty array if container thing is null", () => {
+    expect(getContainerResourceUrlAll({ thing: null })).toEqual([]);
+  });
 });


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-1055.

In this PR:

- replaced mocked nested resources with container's resources iris
- update tests

# To test:
- Verify that folder structure in access requests is correct for both empty containers and containers with resources.

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
