### PR TITLE
Fix: allow contacts without name, type Agent

### DIFF
--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -42,7 +42,6 @@ import useContactsContainerUrl from "../../src/hooks/useContactsContainerUrl";
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 export const EXISTING_WEBID_ERROR_MESSAGE =
   "That WebID is already in your contacts";
-export const NO_NAME_ERROR_MESSAGE = "That WebID does not have a name";
 export const FETCH_PROFILE_FAILED_ERROR_MESSAGE =
   "Unable to retrieve a profile from the given WebID";
 
@@ -81,26 +80,22 @@ export function handleSubmit({
         setIsLoading(false);
         return;
       }
+      const contact = { webId, fn: name || null };
+      const { response, error } = await saveContact(
+        addressBook,
+        addressBookContainerUrl,
+        contact,
+        types,
+        fetch
+      );
 
-      if (name) {
-        const contact = { webId, fn: name };
-        const { response, error } = await saveContact(
-          addressBook,
-          addressBookContainerUrl,
-          contact,
-          types,
-          fetch
-        );
-
-        if (error) alertError(error);
-        if (response) {
-          alertSuccess(`${contact.fn} was added to your contacts`);
-          setAgentId("");
-          peopleMutate();
-        }
-      } else {
-        alertError(NO_NAME_ERROR_MESSAGE);
+      if (error) alertError(error);
+      if (response) {
+        alertSuccess(`${contact.fn || webId} was added to your contacts`);
+        setAgentId("");
+        peopleMutate();
       }
+      setDirtyForm(false);
     } catch (error) {
       alertError(FETCH_PROFILE_FAILED_ERROR_MESSAGE);
     }

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -145,6 +145,31 @@ describe("handleSubmit", () => {
     expect(alertSuccess).not.toHaveBeenCalled();
     expect(alertError).toHaveBeenCalledWith(FETCH_PROFILE_FAILED_ERROR_MESSAGE);
   });
+  test("it saves a contact without name and alerts the user", async () => {
+    const personUri = "http://example.com/marie#me";
+    const mockProfile = { webId: personUri };
+    const handler = handleSubmit({
+      addressBook,
+      setAgentId,
+      setIsLoading,
+      alertError,
+      alertSuccess,
+      session,
+      setDirtyForm,
+    });
+    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
+    jest
+      .spyOn(addressBookFns, "findContactInAddressBook")
+      .mockResolvedValue([]);
+    jest.spyOn(addressBookFns, "saveContact").mockResolvedValue({
+      response: "peopleDataset",
+      error: null,
+    });
+    await handler(personUri);
+    expect(setAgentId).toHaveBeenCalledTimes(1);
+    expect(setIsLoading).toHaveBeenCalledTimes(2);
+    expect(alertSuccess).toHaveBeenCalled();
+  });
   test("it saves a new contact", async () => {
     const personUri = "http://example.com/alice#me";
     const personDataset = addStringNoLocale(

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -35,7 +35,6 @@ import AddContact, {
   EXISTING_WEBID_ERROR_MESSAGE,
   FETCH_PROFILE_FAILED_ERROR_MESSAGE,
   handleSubmit,
-  NO_NAME_ERROR_MESSAGE,
 } from "./index";
 import * as addressBookFns from "../../src/addressBook";
 import { contactsContainerIri } from "../../src/addressBook";
@@ -125,28 +124,6 @@ describe("handleSubmit", () => {
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertError).toHaveBeenCalledWith(EXISTING_WEBID_ERROR_MESSAGE);
     expect(setDirtyForm).toHaveBeenCalledWith(true);
-  });
-  test("it alerts the user and exits if the webid doesn't have a name", async () => {
-    const personUri = "http://example.com/marie#me";
-    const mockProfile = { webId: personUri };
-    const handler = handleSubmit({
-      addressBook,
-      setAgentId,
-      setIsLoading,
-      alertError,
-      alertSuccess,
-      session,
-      setDirtyForm,
-    });
-    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
-    jest
-      .spyOn(addressBookFns, "findContactInAddressBook")
-      .mockResolvedValue([]);
-    await handler(personUri);
-    expect(setAgentId).toHaveBeenCalledTimes(0);
-    expect(setIsLoading).toHaveBeenCalledTimes(2);
-    expect(alertSuccess).not.toHaveBeenCalled();
-    expect(alertError).toHaveBeenCalledWith(NO_NAME_ERROR_MESSAGE);
   });
   test("it alerts the user and exits if fetching the profile fails", async () => {
     const mockProfileError = new Error("error");

--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -78,6 +78,12 @@ export const TYPE_MAP = {
     indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
     contactTypeIri: vcard.Individual,
   },
+  [foaf.Agent]: {
+    indexFile: PEOPLE_INDEX_FILE,
+    container: PERSON_CONTAINER,
+    indexFilePredicate: NAME_EMAIL_INDEX_PREDICATE,
+    contactTypeIri: vcard.Individual,
+  },
 };
 
 export function vcardExtras(property) {


### PR DESCRIPTION
This PR fixes bug #1035.

## To test:

- Try to add a new ESS 1.2 style WebID to Contacts
- You should get a success message and see the contact if you navigate back to the Contacts page

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
