### PR TITLE
Fix/access details modal webid

### DIFF
--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import {
   Accordion,
   AccordionDetails,

--- a/components/resourceDetails/index.test.jsx
+++ b/components/resourceDetails/index.test.jsx
@@ -106,7 +106,7 @@ describe("Resource details", () => {
       expect(getByText("Permissions")).toBeInTheDocument();
     });
     expect(asFragment()).toMatchSnapshot();
-  });
+  }, 30000);
 
   it("renders Sharing component for ACP-supporting Solid servers", async () => {
     mockUseAcp.mockReturnValue({ data: true });

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/__snapshots__/index.test.jsx.snap
@@ -221,10 +221,10 @@ exports[`View consent details button and modal clicking on view details button r
                     class="PodBrowser-access-details--separator"
                   />
                   <p>
-                    <h3>
-                      fetching data in progress
-                    </h3>
-                     has access until 
+                    <span>
+                      https://example.com/profile/card#me
+                    </span>
+                    has access until 
                     <strong>
                       October 11, 2022
                     </strong>

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/agentName/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/agentName/index.jsx
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/* eslint-disable react/jsx-one-expression-per-line */
+
+import React from "react";
+import T from "prop-types";
+import { getStringNoLocale } from "@inrupt/solid-client";
+import { foaf } from "rdf-namespaces";
+import { useThing } from "@inrupt/solid-ui-react";
+
+export default function AgentName({ agentWebId, className }) {
+  const { thing } = useThing();
+  const name = thing && getStringNoLocale(thing, foaf.name);
+  return <span className={className}>{name || agentWebId}</span>;
+}
+
+AgentName.propTypes = {
+  agentWebId: T.string.isRequired,
+  className: T.string,
+};
+
+AgentName.defaultProps = {
+  className: null,
+};

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalAvatar/index.jsx
@@ -25,19 +25,19 @@
 
 import React from "react";
 import T from "prop-types";
-import { foaf, vcard, rdf } from "rdf-namespaces";
+import { vcard, rdf } from "rdf-namespaces";
 import Link from "next/link";
-import { getUrl } from "@inrupt/solid-client";
+import { asUrl, getUrl } from "@inrupt/solid-client";
 import { Avatar, Box, createStyles } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
-import { Text, Image, useThing } from "@inrupt/solid-ui-react";
+import { Image, useThing } from "@inrupt/solid-ui-react";
 import {
   buildResourcesLink,
   isPerson,
 } from "../../../../../../agentResourceAccessLink";
-
 import styles from "./styles";
+import AgentName from "../agentName";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
@@ -74,7 +74,10 @@ export default function ModalAvatar({ profileIri, closeDialog }) {
         <Link href={buildResourcesLink(profileIri, "/privacy", path)}>
           <a role="link" onClick={() => closeDialog()}>
             <h3 data-testid={TESTCAFE_ID_NAME_TITLE}>
-              <Text className={classes.avatarText} property={foaf.name} />
+              <AgentName
+                className={classes.avatarText}
+                agentWebId={asUrl(thing)}
+              />
             </h3>
           </a>
         </Link>

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/__snapshots__/index.test.jsx.snap
@@ -168,10 +168,10 @@ exports[`Renders correct consent modal content clicking on view details button r
           class="PodBrowser-access-details--separator"
         />
         <p>
-          <h3>
-            fetching data in progress
-          </h3>
-           has access until 
+          <span>
+            https://example.com/profile/card#me
+          </span>
+          has access until 
           <strong>
             October 11, 2022
           </strong>

--- a/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentAccessOptionsMenu/consentDetailsButton/consentDetailsModalContent/index.jsx
@@ -31,10 +31,9 @@ import {
   ListItemIcon,
   ListItemText,
 } from "@material-ui/core";
-import { foaf } from "rdf-namespaces";
 import { makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
-import { CombinedDataProvider, Text } from "@inrupt/solid-ui-react";
+import { CombinedDataProvider } from "@inrupt/solid-ui-react";
 import { format } from "date-fns";
 import { getAcpAccessDetails } from "../../../../../../../src/accessControl/acp";
 import { permission as permissionPropType } from "../../../../../../../constants/propTypes";
@@ -46,6 +45,7 @@ import {
 } from "../../../../../../../src/models/consent/request";
 import { getPurposeUrlsFromSignedVc } from "../../../../../../../src/models/consent/signedVc";
 import styles from "./styles";
+import AgentName from "../agentName";
 
 export const TESTCAFE_ID_CONSENT_DETAILS_CONTENT = "consent-details-content";
 
@@ -155,8 +155,8 @@ export default function ConsentDetailsModalContent({
           </h3>
           <hr className={bem("access-details", "separator")} />
           <p>
-            <Text className={classes.avatarText} property={foaf.name} /> has
-            access until <strong>{expirationDate}</strong>.
+            <AgentName agentWebId={agentWebId} />
+            has access until <strong>{expirationDate}</strong>.
           </p>
         </section>
       )}


### PR DESCRIPTION
Note: this work branches off https://github.com/inrupt/pod-browser/pull/382 due to some access control issues that were present here as well and prevented from testing properly.

This PR fixes bug #SOLIDOS-1068.

In this PR, I added a small component to handle the Agent Name in VC-based access modal, which defaults to WebID if it cannot find a name. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
