### PR TITLE
Fix: handle profiles without names when sorting

### DIFF
--- a/components/resourceDetails/resourceSharing/agentAccessTable/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccessTable/index.jsx
@@ -78,7 +78,7 @@ export default function AgentAccessTable({ type, loading, setLoading }) {
     const sorted = permissionsWithProfiles
       .filter((p) => p.type === "agent")
       .sort((a, b) => {
-        return a.profile?.name.localeCompare(b.profile?.name);
+        return a.profile?.name?.localeCompare(b.profile?.name);
       });
     setTablePermissions(publicAndAuth.concat(sorted));
   }, [permissionsWithProfiles]);
@@ -278,6 +278,10 @@ export default function AgentAccessTable({ type, loading, setLoading }) {
 
 AgentAccessTable.propTypes = {
   type: PropTypes.string.isRequired,
-  loading: PropTypes.bool.isRequired,
+  loading: PropTypes.bool,
   setLoading: PropTypes.func.isRequired,
+};
+
+AgentAccessTable.defaultProps = {
+  loading: false,
 };


### PR DESCRIPTION
This PR fixes bug #SOLIDOS-1078.

Profiles without a name were causing an error when sorting the agents in the access table. 

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
