### PR TITLE
Fix: pass client name to auth options

### DIFF
--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -129,6 +129,7 @@ export default function Provider({ defaultError, provider }) {
             return {
               ...prevState,
               clientId: CLIENT_APP_WEBID,
+              clientName: CLIENT_NAME,
             };
           });
         } else {


### PR DESCRIPTION
This PR fixes bug #1082.

We weren't passing the client name in the auth options during registration in one spot. 

## To test

- Log in using an incognito window with dev next.
- Verify Inrupt PodBrowser is displayed in the auth screen instead of the long ID. 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
