### PR TITLE
Fix: temporarily disable date picker and purposes checkboxes on Access Request UI

### DIFF
--- a/components/consentRequestForm/__snapshots__/index.test.jsx.snap
+++ b/components/consentRequestForm/__snapshots__/index.test.jsx.snap
@@ -140,26 +140,24 @@ exports[`Consent Request Form Renders a consent request form with multiple purpo
           placeholder="Consent expiry date"
           readonly=""
           type="text"
-          value="June 23, 2022"
+          value="Forever"
         />
       </div>
       <button
         aria-label="Set expiry date"
-        class="PodBrowser-root PodBrowser-root PodBrowser-date-button"
+        class="PodBrowser-root PodBrowser-root PodBrowser-date-button PodBrowser-disabled PodBrowser-disabled"
         data-testid="date-picker-calendar-button"
-        tabindex="0"
+        disabled=""
+        tabindex="-1"
         type="button"
       >
         <span
           class="PodBrowser-label"
         >
           <span
-            class="PodBrowser-icon-calendar PodBrowser-icon-small--primary"
+            class="PodBrowser-icon-calendar PodBrowser-icon-small--primary-disabled"
           />
         </span>
-        <span
-          class="PodBrowser-root"
-        />
       </button>
     </div>
     <fieldset
@@ -575,26 +573,24 @@ exports[`Consent Request Form Renders a consent request form with only one purpo
           placeholder="Consent expiry date"
           readonly=""
           type="text"
-          value="June 23, 2022"
+          value="Forever"
         />
       </div>
       <button
         aria-label="Set expiry date"
-        class="PodBrowser-root PodBrowser-root PodBrowser-date-button"
+        class="PodBrowser-root PodBrowser-root PodBrowser-date-button PodBrowser-disabled PodBrowser-disabled"
         data-testid="date-picker-calendar-button"
-        tabindex="0"
+        disabled=""
+        tabindex="-1"
         type="button"
       >
         <span
           class="PodBrowser-label"
         >
           <span
-            class="PodBrowser-icon-calendar PodBrowser-icon-small--primary"
+            class="PodBrowser-icon-calendar PodBrowser-icon-small--primary-disabled"
           />
         </span>
-        <span
-          class="PodBrowser-root"
-        />
       </button>
     </div>
     <fieldset

--- a/components/consentRequestForm/dateInput/index.jsx
+++ b/components/consentRequestForm/dateInput/index.jsx
@@ -80,10 +80,16 @@ export default function DateInput(props) {
         data-testid={TESTCAFE_ID_DATE_PICKER_CALENDAR_BUTTON}
         classes={{ root: bem("date-button") }}
         type="button"
+        // temporarily disabling until functionality to change date is available
+        disabled
         aria-label="Set expiry date"
         onClick={() => setDatepickerOpen(!datepickerOpen)}
       >
-        <Icons name="calendar" className={bem("icon-small--primary")} />
+        <Icons
+          name="calendar"
+          // temporarily disabling until functionality to change date is available
+          className={bem("icon-small--primary-disabled")}
+        />
       </IconButton>
       {datepickerOpen && (
         <div className={bem("date-picker")}>
@@ -92,6 +98,8 @@ export default function DateInput(props) {
             orientation="portrait"
             variant="static"
             disablePast
+            // temporarily disabling until functionality to change date is available
+            disabled
             format="MM/dd/yyyy"
             margin="normal"
             value={selectedDate}

--- a/components/consentRequestForm/dateInput/index.test.jsx
+++ b/components/consentRequestForm/dateInput/index.test.jsx
@@ -48,7 +48,7 @@ describe("DateInput component", () => {
     });
   });
   // FIXME: unskip this test when date picker is enabled again
-  test.skip("Opens datepicker when calendar is clicked", () => {
+  test.skip("Opens datepicker when calendar is clicked", async () => {
     const { getByTestId } = renderWithTheme(
       <ConsentRequestContextProvider>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/components/consentRequestForm/dateInput/index.test.jsx
+++ b/components/consentRequestForm/dateInput/index.test.jsx
@@ -47,7 +47,8 @@ describe("DateInput component", () => {
       push,
     });
   });
-  test("Opens datepicker when calendar is clicked", async () => {
+  // FIXME: unskip this test when date picker is enabled again
+  test.skip("Opens datepicker when calendar is clicked", () => {
     const { getByTestId } = renderWithTheme(
       <ConsentRequestContextProvider>
         <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -272,7 +272,9 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
           {`${agentName || agentWebId} will have access until`}
         </span>
         <DateInput
-          selectedDate={selectedDate}
+          // selectedDate={selectedDate}
+          // setting date to forever for now until we add functionality to change this
+          selectedDate={null}
           setSelectedDate={setSelectedDate}
           datepickerOpen={datepickerOpen}
           setDatepickerOpen={setDatepickerOpen}

--- a/components/consentRequestForm/purposeCheckBox/index.jsx
+++ b/components/consentRequestForm/purposeCheckBox/index.jsx
@@ -34,6 +34,7 @@ export default function PurposeCheckBox({
   handleSelectPurpose,
   url,
   description,
+  disabled,
 }) {
   const [checked, setChecked] = useState(false);
 
@@ -45,6 +46,8 @@ export default function PurposeCheckBox({
   return (
     <Checkbox
       className={classes.root}
+      // temporarily disabling until we have functionality for this
+      disabled={disabled}
       disableRipple
       checked={checked}
       checkedIcon={
@@ -64,8 +67,13 @@ export default function PurposeCheckBox({
   );
 }
 
+PurposeCheckBox.defaultProps = {
+  disabled: false,
+};
+
 PurposeCheckBox.propTypes = {
   handleSelectPurpose: T.func.isRequired,
   url: T.string.isRequired,
   description: T.string.isRequired,
+  disabled: T.bool,
 };

--- a/components/consentRequestForm/styles.js
+++ b/components/consentRequestForm/styles.js
@@ -140,6 +140,11 @@ export default function styles(theme) {
       margin: 0,
     },
 
+    "icon-small--primary-disabled": {
+      color: theme.palette.grey[700],
+      margin: 0,
+    },
+
     "icon-small--padded": {
       marginLeft: "0.5rem",
     },

--- a/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/consent/requests/__snapshots__/index.test.jsx.snap
@@ -143,26 +143,24 @@ exports[`Consent Page Renders the Consent page 1`] = `
             placeholder="Consent expiry date"
             readonly=""
             type="text"
-            value="June 23, 2022"
+            value="Forever"
           />
         </div>
         <button
           aria-label="Set expiry date"
-          class="PodBrowser-root PodBrowser-root PodBrowser-date-button"
+          class="PodBrowser-root PodBrowser-root PodBrowser-date-button PodBrowser-disabled PodBrowser-disabled"
           data-testid="date-picker-calendar-button"
-          tabindex="0"
+          disabled=""
+          tabindex="-1"
           type="button"
         >
           <span
             class="PodBrowser-label"
           >
             <span
-              class="PodBrowser-icon-calendar PodBrowser-icon-small--primary"
+              class="PodBrowser-icon-calendar PodBrowser-icon-small--primary-disabled"
             />
           </span>
-          <span
-            class="PodBrowser-root"
-          />
         </button>
       </div>
       <fieldset


### PR DESCRIPTION
In this PR:

- we haven't implemented functionality to select purposes from a list and change expiration date of access grant, so we are temporarily disabling the UI related to these.

- update snapshots and skip relevant tests until interaction is reintroduced

This PR fixes bug #PB-1095.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
