### PR TITLE
Fix/delete resource policy resource

### DIFF
--- a/components/deleteResourceButton/index.jsx
+++ b/components/deleteResourceButton/index.jsx
@@ -64,7 +64,7 @@ export default function DeleteResourceButton({
   const { data: resourceInfo, error: resourceError } = useResourceInfo(
     resourceIri
   );
-  const policiesContainerUrl = usePoliciesContainerUrl(resourceInfo);
+  const policiesContainerUrl = usePoliciesContainerUrl(resourceIri);
 
   if (resourceError) {
     alertError(resourceError.message);

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -76,6 +76,7 @@ export default function ResourceDetails({
   const type = getContentType(dataset);
   const actionMenuBem = ActionMenu.useBem();
   const { accessControl } = useContext(AccessControlContext);
+  console.log(accessControl)
   const { data: isAcpControlled } = useAcp(datasetUrl);
   const { data: isWacControlled } = useWac(datasetUrl);
   const [actionsAccordion, setActionsAccordion] = useLocalStorage(

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -76,7 +76,6 @@ export default function ResourceDetails({
   const type = getContentType(dataset);
   const actionMenuBem = ActionMenu.useBem();
   const { accessControl } = useContext(AccessControlContext);
-  console.log(accessControl)
   const { data: isAcpControlled } = useAcp(datasetUrl);
   const { data: isWacControlled } = useWac(datasetUrl);
   const [actionsAccordion, setActionsAccordion] = useLocalStorage(

--- a/components/resourceDrawer/index.jsx
+++ b/components/resourceDrawer/index.jsx
@@ -74,6 +74,8 @@ export default function ResourceDrawer({ onUpdate, onDeleteCurrentContainer }) {
   });
   const { data: accessControlData, isValidating } = accessControlResponse;
 
+  console.log("at the provider level", accessControl)
+
   useEffect(() => {
     setMenuOpen(!!(action && resourceIri));
   }, [action, resourceIri, setMenuOpen]);

--- a/components/resourceDrawer/index.jsx
+++ b/components/resourceDrawer/index.jsx
@@ -72,10 +72,7 @@ export default function ResourceDrawer({ onUpdate, onDeleteCurrentContainer }) {
   const accessControlResponse = useAccessControl(resourceInfo, {
     revalidateOnFocus: false,
   });
-  const { data: accessControlData, isValidating } = accessControlResponse;
-
-  console.log("at the provider level", accessControl)
-
+  const { data: accessControl, isValidating } = accessControlResponse;
   useEffect(() => {
     setMenuOpen(!!(action && resourceIri));
   }, [action, resourceIri, setMenuOpen]);
@@ -106,7 +103,7 @@ export default function ResourceDrawer({ onUpdate, onDeleteCurrentContainer }) {
         <DetailsLoading iri={resourceIri} />
       ) : (
         <ResourceInfoProvider swr={resourceInfoSwrResponse}>
-          <AccessControlProvider accessControl={accessControlData}>
+          <AccessControlProvider accessControl={accessControl}>
             <DatasetProvider solidDataset={resourceInfo}>
               <ResourceDetails
                 onDelete={onUpdate}

--- a/src/accessControl/acp/helpers/index.js
+++ b/src/accessControl/acp/helpers/index.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import LinkHeader from "http-link-header";
+
+/**
+ * Discover whether an authorization server advertizes its configuration as descibed
+ * in https://solid.github.io/authorization-panel/acp-specification/#capabilities-discovery.
+ * This is used to determine whether an authorization server conforms to the legacy
+ * ACP specification, or if it implements the latest version. The retrieved configuration
+ * itself is irrelevant in this case, what is important is its presence or absence.
+ *
+ * TODO: Part of this should be moved to `@inrupt/solid-client`. When doing so,
+ * make sure to remove the dependency on `http-link-header`, which will no longer
+ * be necessary.
+ *
+ * @param {*} acrUrl The URL of the Access Control Resource
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export async function hasAcpConfiguration(acrUrl, authFetch) {
+  // Defaults to the latest system.
+  if (typeof acrUrl !== "string") {
+    return false;
+  }
+  const response = await authFetch(acrUrl, {
+    // The specification requires that this should be an OPTIONS request, but
+    // this causes issues for cross-origin requests from a browser. ESS currently
+    // allows to work around this issuing a HEAD request instead.
+    method: "HEAD",
+  });
+  const linkHeader = response.headers.get("Link");
+  if (linkHeader === null) {
+    return false;
+  }
+  const parsedLinks = LinkHeader.parse(linkHeader);
+  return (
+    parsedLinks.get("rel", "http://www.w3.org/ns/solid/acp#grant").length > 0 ||
+    parsedLinks.get("rel", "http://www.w3.org/ns/solid/acp#attribute").length >
+      0
+  );
+}

--- a/src/accessControl/acp/helpers/index.test.jsx
+++ b/src/accessControl/acp/helpers/index.test.jsx
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { hasAcpConfiguration } from ".";
+import "whatwg-fetch"; // must be imported so that Response class is available
+
+describe("hasAcpConfiguration", () => {
+  it("returns false if the request to the target ACR returns no Link headers", async () => {
+    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
+      new global.Response(undefined, {
+        headers: {
+          "Not-Link": "some value",
+        },
+      })
+    );
+    await expect(
+      hasAcpConfiguration("https://some.acr", mockedFetch)
+    ).resolves.toBe(false);
+  });
+
+  it("returns false if the request to the target ACR returns no ACP configuration", async () => {
+    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
+      new Response(undefined, {
+        headers: {
+          Link: '<http://some.link>; rel="someRel"',
+        },
+      })
+    );
+    await expect(
+      hasAcpConfiguration("https://some.acr", mockedFetch)
+    ).resolves.toBe(false);
+  });
+
+  it("returns true if the request to the target ACR returns an ACP configuration", async () => {
+    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
+      new Response(undefined, {
+        headers: {
+          Link:
+            '<http://www.w3.org/ns/solid/acp#agent>; rel="http://www.w3.org/ns/solid/acp#attribute"',
+        },
+      })
+    );
+    await expect(
+      hasAcpConfiguration("https://some.acr", mockedFetch)
+    ).resolves.toBe(true);
+  });
+});

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -32,7 +32,6 @@ import {
   saveSolidDatasetAt,
   setThing,
 } from "@inrupt/solid-client";
-import LinkHeader from "http-link-header";
 import {
   ACL,
   createAccessMap,
@@ -40,7 +39,6 @@ import {
   isEmptyAccess,
 } from "../../solidClientHelpers/permissions";
 import { chain, createResponder } from "../../solidClientHelpers/utils";
-// eslint-disable-next-line import/no-cycle
 import { getOrCreateDatasetOld } from "../../solidClientHelpers/resource";
 import {
   isCustomPolicy,
@@ -114,42 +112,6 @@ export const getPolicyDetailFromAccess = (access, label) => {
   }
   return null;
 };
-
-/**
- * Discover whether an authorization server advertizes its configuration as descibed
- * in https://solid.github.io/authorization-panel/acp-specification/#capabilities-discovery.
- * This is used to determine whether an authorization server conforms to the legacy
- * ACP specification, or if it implements the latest version. The retrieved configuration
- * itself is irrelevant in this case, what is important is its presence or absence.
- *
- * TODO: Part of this should be moved to `@inrupt/solid-client`. When doing so,
- * make sure to remove the dependency on `http-link-header`, which will no longer
- * be necessary.
- *
- * @param {*} acrUrl The URL of the Access Control Resource
- */
-export async function hasAcpConfiguration(acrUrl, authFetch) {
-  // Defaults to the latest system.
-  if (typeof acrUrl !== "string") {
-    return false;
-  }
-  const response = await authFetch(acrUrl, {
-    // The specification requires that this should be an OPTIONS request, but
-    // this causes issues for cross-origin requests from a browser. ESS currently
-    // allows to work around this issuing a HEAD request instead.
-    method: "HEAD",
-  });
-  const linkHeader = response.headers.get("Link");
-  if (linkHeader === null) {
-    return false;
-  }
-  const parsedLinks = LinkHeader.parse(linkHeader);
-  return (
-    parsedLinks.get("rel", "http://www.w3.org/ns/solid/acp#grant").length > 0 ||
-    parsedLinks.get("rel", "http://www.w3.org/ns/solid/acp#attribute").length >
-      0
-  );
-}
 
 // The following functions multiplex between the latest and legacy ACP API
 function switchIfLegacy(legacyFunction, latestFunction, parameters, isLegacy) {

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -40,14 +40,13 @@ import {
   isEmptyAccess,
 } from "../../solidClientHelpers/permissions";
 import { chain, createResponder } from "../../solidClientHelpers/utils";
-import {
-  deletePoliciesContainer,
-  getOrCreateDatasetOld,
-} from "../../solidClientHelpers/resource";
+// eslint-disable-next-line import/no-cycle
+import { getOrCreateDatasetOld } from "../../solidClientHelpers/resource";
 import {
   isCustomPolicy,
   getPolicyUrl,
   getPolicyResourceUrl,
+  deletePoliciesContainer,
 } from "../../models/policy";
 import { isHTTPError } from "../../error";
 import {

--- a/src/accessControl/acp/index.test.js
+++ b/src/accessControl/acp/index.test.js
@@ -38,7 +38,6 @@ import AcpAccessControlStrategy, {
   getNamedPolicyModesAndAgents,
   getWebIdsFromPermissions,
   getWebIdsFromInheritedPermissions,
-  hasAcpConfiguration,
 } from "./index";
 import { createAccessMap } from "../../solidClientHelpers/permissions";
 import { chain } from "../../solidClientHelpers/utils";
@@ -1908,47 +1907,5 @@ describe("getWebIdsFromInheritedPermissions", () => {
       ])
     ).toEqual([webId1]);
     expect(getWebIdsFromInheritedPermissions(null)).toEqual([]);
-  });
-});
-
-describe("hasAcpConfiguration", () => {
-  it("returns false if the request to the target ACR returns no Link headers", async () => {
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(undefined, {
-        headers: {
-          "Not-Link": "some value",
-        },
-      })
-    );
-    await expect(
-      hasAcpConfiguration("https://some.acr", mockedFetch)
-    ).resolves.toBe(false);
-  });
-
-  it("returns false if the request to the target ACR returns no ACP configuration", async () => {
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(undefined, {
-        headers: {
-          Link: '<http://some.link>; rel="someRel"',
-        },
-      })
-    );
-    await expect(
-      hasAcpConfiguration("https://some.acr", mockedFetch)
-    ).resolves.toBe(false);
-  });
-
-  it("returns true if the request to the target ACR returns an ACP configuration", async () => {
-    const mockedFetch = jest.fn(global.fetch).mockResolvedValueOnce(
-      new Response(undefined, {
-        headers: {
-          Link:
-            '<http://www.w3.org/ns/solid/acp#agent>; rel="http://www.w3.org/ns/solid/acp#attribute"',
-        },
-      })
-    );
-    await expect(
-      hasAcpConfiguration("https://some.acr", mockedFetch)
-    ).resolves.toBe(true);
   });
 });

--- a/src/accessControl/index.js
+++ b/src/accessControl/index.js
@@ -37,10 +37,9 @@ export function hasAccess(resourceInfo) {
 }
 
 export async function isAcp(resourceUrl, fetch) {
-  const isAcpControlledResource = await acp3.isAcpControlled(resourceUrl, {
+  return acp3.isAcpControlled(resourceUrl, {
     fetch,
   });
-  return resourceUrl && isAcpControlledResource;
 }
 
 export async function isWac(resourceUrl, resourceInfo, fetch) {

--- a/src/accessControl/index.js
+++ b/src/accessControl/index.js
@@ -60,9 +60,7 @@ export async function getAccessControl(
 ) {
   const resourceUrl = getSourceUrl(resourceInfo);
   const isWacControlledResource = await isWac(resourceUrl, resourceInfo, fetch);
-  const isAcpControlledResource = await acp3.isAcpControlled(resourceUrl, {
-    fetch,
-  });
+  const isAcpControlledResource = await isAcp(resourceUrl, fetch);
   if (isWacControlledResource) {
     return WacAccessControlStrategy.init(resourceInfo, fetch);
   }

--- a/src/hooks/useAccessControl/index.jsx
+++ b/src/hooks/useAccessControl/index.jsx
@@ -27,7 +27,7 @@ import usePoliciesContainerUrl from "../usePoliciesContainerUrl";
 import useIsLegacyAcp from "../useIsLegacyAcp";
 
 export default function useAccessControl(resourceInfo, swrOptions = {}) {
-  const resourceUrl = resourceInfo ? getSourceUrl(resourceInfo) : null;
+  const resourceUrl = resourceInfo && getSourceUrl(resourceInfo);
   const policiesContainerUrl = usePoliciesContainerUrl(resourceUrl);
   const { data: isLegacy } = useIsLegacyAcp(resourceInfo);
   const { session } = useSession();

--- a/src/hooks/useAccessControl/index.jsx
+++ b/src/hooks/useAccessControl/index.jsx
@@ -20,13 +20,15 @@
  */
 
 import { useSession } from "@inrupt/solid-ui-react";
+import { getSourceUrl } from "@inrupt/solid-client";
 import useSWR from "swr";
 import { getAccessControl } from "../../accessControl";
 import usePoliciesContainerUrl from "../usePoliciesContainerUrl";
 import useIsLegacyAcp from "../useIsLegacyAcp";
 
 export default function useAccessControl(resourceInfo, swrOptions = {}) {
-  const policiesContainerUrl = usePoliciesContainerUrl(resourceInfo);
+  const resourceUrl = resourceInfo ? getSourceUrl(resourceInfo) : null;
+  const policiesContainerUrl = usePoliciesContainerUrl(resourceUrl);
   const { data: isLegacy } = useIsLegacyAcp(resourceInfo);
   const { session } = useSession();
   const { fetch } = session;

--- a/src/hooks/useAccessControl/index.test.jsx
+++ b/src/hooks/useAccessControl/index.test.jsx
@@ -58,7 +58,6 @@ describe("useAccessControl", () => {
   const resourceUrl = joinPath(authenticatedProfile.pods[0], "test");
   const resourceInfo = mockSolidDatasetFrom(resourceUrl);
   const error = "error";
-  const isValidating = false;
 
   const session = mockSession();
   const SessionProvider = mockSessionContextProvider(session);

--- a/src/hooks/useAccessControl/index.test.jsx
+++ b/src/hooks/useAccessControl/index.test.jsx
@@ -76,7 +76,7 @@ describe("useAccessControl", () => {
     mockedSwrHook.mockReturnValue(swrResponse);
   });
 
-  it("returns undefined if given no resourceUri", async () => {
+  it("returns undefined if given no resourceInfo", async () => {
     mockedIsLegacyAcp.mockReturnValue({ data: false });
     const { result } = renderHook(() => useAccessControl(null), {
       wrapper,

--- a/src/hooks/useAccessControl/index.test.jsx
+++ b/src/hooks/useAccessControl/index.test.jsx
@@ -58,6 +58,7 @@ describe("useAccessControl", () => {
   const resourceUrl = joinPath(authenticatedProfile.pods[0], "test");
   const resourceInfo = mockSolidDatasetFrom(resourceUrl);
   const error = "error";
+  const isValidating = false;
 
   const session = mockSession();
   const SessionProvider = mockSessionContextProvider(session);

--- a/src/hooks/useIsLegacyAcp/index.js
+++ b/src/hooks/useIsLegacyAcp/index.js
@@ -23,7 +23,7 @@ import useSWR from "swr";
 import { acp_v3 as acp } from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
 
-import { hasAcpConfiguration } from "../../accessControl/acp/index";
+import { hasAcpConfiguration } from "../../accessControl/acp/helpers/index";
 
 export default function useIsLegacyAcp(resourceInfo) {
   const { fetch } = useSession();

--- a/src/hooks/useIsLegacyAcp/index.js
+++ b/src/hooks/useIsLegacyAcp/index.js
@@ -28,7 +28,7 @@ import { hasAcpConfiguration } from "../../accessControl/acp/index";
 export default function useIsLegacyAcp(resourceInfo) {
   const { fetch } = useSession();
   return useSWR(
-    resourceInfo ? acp.getLinkedAcrUrl(resourceInfo) : null,
+    [resourceInfo ? acp.getLinkedAcrUrl(resourceInfo) : null, fetch],
     // A legacy ACP server is one which does _not_ implement the ACP configuration discovery.
     // Since we mock SWR, the following line never runs.
     /* istanbul ignore next */

--- a/src/hooks/useIsLegacyAcp/index.test.jsx
+++ b/src/hooks/useIsLegacyAcp/index.test.jsx
@@ -24,9 +24,9 @@ import { renderHook } from "@testing-library/react-hooks";
 import { useSession } from "@inrupt/solid-ui-react";
 import { acp_v3 as acp, mockSolidDatasetFrom } from "@inrupt/solid-client";
 import useIsLegacyAcp from ".";
-import { hasAcpConfiguration } from "../../accessControl/acp/index";
+import { hasAcpConfiguration } from "../../accessControl/acp/helpers/index";
 
-jest.mock("../../accessControl/acp/index");
+jest.mock("../../accessControl/acp/helpers/index");
 hasAcpConfiguration.mockResolvedValue(true);
 
 jest.mock("swr");

--- a/src/hooks/useIsLegacyAcp/index.test.jsx
+++ b/src/hooks/useIsLegacyAcp/index.test.jsx
@@ -64,7 +64,7 @@ describe("useIsLegacyAcp", () => {
     const { result } = renderHook(() => useIsLegacyAcp(mockedResource));
     expect(result.current.data).toBe(true);
     expect(mockedSwrHook).toHaveBeenCalledWith(
-      mockedAcrUrl,
+      [mockedAcrUrl, fetch],
       expect.any(Function)
     );
   });
@@ -72,6 +72,9 @@ describe("useIsLegacyAcp", () => {
   it("returns null if no resource info is given", async () => {
     jest.spyOn(mockedAcp, "getLinkedAcrUrl").mockReturnValue(mockedAcrUrl);
     renderHook(() => useIsLegacyAcp(undefined));
-    expect(mockedSwrHook).toHaveBeenCalledWith(null, expect.any(Function));
+    expect(mockedSwrHook).toHaveBeenCalledWith(
+      [null, fetch],
+      expect.any(Function)
+    );
   });
 });

--- a/src/hooks/usePoliciesContainerUrl/index.js
+++ b/src/hooks/usePoliciesContainerUrl/index.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { acp_v3 as acp, getSourceIri } from "@inrupt/solid-client";
+import { acp_v3 as acp } from "@inrupt/solid-client";
 import { useEffect, useState } from "react";
 import usePodRootUri from "../usePodRootUri";
 import { getPoliciesContainerUrl } from "../../models/policy";
@@ -29,18 +29,15 @@ import useResourceInfo from "../useResourceInfo";
 export default function usePoliciesContainerUrl(resourceUrl) {
   const { data: resourceInfo } = useResourceInfo(resourceUrl);
   const [policiesContainerUrl, setPoliciesContainerUrl] = useState();
-  const rootUrl = usePodRootUri(getSourceIri(resourceInfo));
+  const rootUrl = usePodRootUri(resourceUrl);
   const { data: isLegacy } = useIsLegacyAcp(resourceInfo);
-  console.log({ isLegacy });
   useEffect(() => {
+    if (!resourceUrl) return;
     if (isLegacy === undefined) {
       setPoliciesContainerUrl(null);
       return;
     }
     if (isLegacy) {
-      console.log({ rootUrl });
-      console.log({ resourceInfo });
-      console.log("the container", rootUrl && getPoliciesContainerUrl(rootUrl));
       setPoliciesContainerUrl(
         rootUrl ? getPoliciesContainerUrl(rootUrl) : null
       );
@@ -51,6 +48,6 @@ export default function usePoliciesContainerUrl(resourceUrl) {
           : null
       );
     }
-  }, [isLegacy, resourceInfo, rootUrl]);
+  }, [isLegacy, resourceInfo, resourceUrl, rootUrl]);
   return policiesContainerUrl;
 }

--- a/src/hooks/usePoliciesContainerUrl/index.js
+++ b/src/hooks/usePoliciesContainerUrl/index.js
@@ -24,18 +24,23 @@ import { useEffect, useState } from "react";
 import usePodRootUri from "../usePodRootUri";
 import { getPoliciesContainerUrl } from "../../models/policy";
 import useIsLegacyAcp from "../useIsLegacyAcp";
+import useResourceInfo from "../useResourceInfo";
 
-export default function usePoliciesContainerUrl(resourceInfo) {
+export default function usePoliciesContainerUrl(resourceUrl) {
+  const { data: resourceInfo } = useResourceInfo(resourceUrl);
   const [policiesContainerUrl, setPoliciesContainerUrl] = useState();
   const rootUrl = usePodRootUri(getSourceIri(resourceInfo));
   const { data: isLegacy } = useIsLegacyAcp(resourceInfo);
-
+  console.log({ isLegacy });
   useEffect(() => {
     if (isLegacy === undefined) {
       setPoliciesContainerUrl(null);
       return;
     }
     if (isLegacy) {
+      console.log({ rootUrl });
+      console.log({ resourceInfo });
+      console.log("the container", rootUrl && getPoliciesContainerUrl(rootUrl));
       setPoliciesContainerUrl(
         rootUrl ? getPoliciesContainerUrl(rootUrl) : null
       );
@@ -47,6 +52,5 @@ export default function usePoliciesContainerUrl(resourceInfo) {
       );
     }
   }, [isLegacy, resourceInfo, rootUrl]);
-
   return policiesContainerUrl;
 }

--- a/src/hooks/usePoliciesContainerUrl/index.test.js
+++ b/src/hooks/usePoliciesContainerUrl/index.test.js
@@ -43,7 +43,8 @@ describe("usePoliciesContainerUrl", () => {
 
     it("returns null when podRootUrl is yet undetermined", () => {
       mockedIsLegacyAcp.mockReturnValue({ data: true });
-      const { result } = renderHook(() => usePoliciesContainerUrl(null));
+      mockedPodRootUri.mockReturnValue(null);
+      const { result } = renderHook(() => usePoliciesContainerUrl("iri"));
       expect(result.current).toBeNull();
     });
 

--- a/src/models/policy/index.js
+++ b/src/models/policy/index.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { getSourceUrl } from "@inrupt/solid-client";
+import { deleteContainer, getSourceUrl } from "@inrupt/solid-client";
 import { sharedStart } from "../../solidClientHelpers/utils";
 import { getContainerUrl, joinPath } from "../../stringHelpers";
 import {
@@ -27,6 +27,7 @@ import {
   namedPolicies,
   POLICIES_TYPE_MAP,
 } from "../../../constants/policies";
+import { isHTTPError } from "../../error";
 
 const POLICIES_CONTAINER = "pb_policies/";
 
@@ -97,3 +98,17 @@ export function isCustomPolicy(type) {
 export function isNamedPolicy(type) {
   return namedPolicies.find((policy) => policy.name === type) !== undefined;
 }
+
+export const deletePoliciesContainer = async (containerIri, fetch) => {
+  try {
+    await deleteContainer(containerIri, { fetch });
+  } catch (err) {
+    if (
+      !isHTTPError(err.message, 409) &&
+      !isHTTPError(err.message, 404) &&
+      !isHTTPError(err.message, 403)
+    ) {
+      throw new Error(err);
+    }
+  }
+};

--- a/src/models/policy/index.test.js
+++ b/src/models/policy/index.test.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { mockSolidDatasetFrom } from "@inrupt/solid-client";
+import * as SolidClientFns from "@inrupt/solid-client";
 import {
   getPolicyUrl,
   getPoliciesContainerUrl,
@@ -28,6 +28,7 @@ import {
   isCustomPolicy,
   isNamedPolicy,
   getPolicyType,
+  deletePoliciesContainer,
 } from "./index";
 
 const podUrl = "http://example.com/";
@@ -38,52 +39,64 @@ describe("getPolicyUrl", () => {
   describe("legacy ACP systems", () => {
     it("returns corresponding policy URLs", () => {
       expect(
-        getPolicyUrl(mockSolidDatasetFrom(podUrl), containerUrl, true)
+        getPolicyUrl(
+          SolidClientFns.mockSolidDatasetFrom(podUrl),
+          containerUrl,
+          true
+        )
       ).toEqual("http://example.com/pb_policies/.ttl");
       expect(
-        getPolicyUrl(mockSolidDatasetFrom(`${podUrl}test`), containerUrl, true)
+        getPolicyUrl(
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}test`),
+          containerUrl,
+          true
+        )
       ).toEqual("http://example.com/pb_policies/test.ttl");
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}test.ttl`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}test.ttl`),
           containerUrl,
           true
         )
       ).toEqual("http://example.com/pb_policies/test.ttl.ttl");
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}foo/bar`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}foo/bar`),
           containerUrl,
           true
         )
       ).toEqual("http://example.com/pb_policies/foo/bar.ttl");
       expect(
-        getPolicyUrl(mockSolidDatasetFrom(containerUrl), containerUrl, true)
+        getPolicyUrl(
+          SolidClientFns.mockSolidDatasetFrom(containerUrl),
+          containerUrl,
+          true
+        )
       ).toEqual("http://example.com/pb_policies/pb_policies/.ttl");
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${containerUrl}test`),
+          SolidClientFns.mockSolidDatasetFrom(`${containerUrl}test`),
           containerUrl,
           true
         )
       ).toEqual("http://example.com/pb_policies/pb_policies/test.ttl");
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}public`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}public`),
           containerUrl,
           true
         )
       ).toEqual("http://example.com/pb_policies/public.ttl");
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}pb_policies/.ttl`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}pb_policies/.ttl`),
           containerUrl,
           true
         )
       ).toEqual("http://example.com/pb_policies/pb_policies/.ttl.ttl");
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}pb_policies/test/`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}pb_policies/test/`),
           containerUrl,
           true
         )
@@ -94,18 +107,26 @@ describe("getPolicyUrl", () => {
   describe("latest ACP systems", () => {
     it("returns corresponding policy URLs", () => {
       expect(
-        getPolicyUrl(mockSolidDatasetFrom(podUrl), containerUrl, false)
+        getPolicyUrl(
+          SolidClientFns.mockSolidDatasetFrom(podUrl),
+          containerUrl,
+          false
+        )
       ).toEqual(
         "http://example.com/pb_policies/#aHR0cDovL2V4YW1wbGUuY29tLw%3D%3D"
       );
       expect(
-        getPolicyUrl(mockSolidDatasetFrom(`${podUrl}test`), containerUrl, false)
+        getPolicyUrl(
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}test`),
+          containerUrl,
+          false
+        )
       ).toEqual(
         "http://example.com/pb_policies/#aHR0cDovL2V4YW1wbGUuY29tL3Rlc3Q%3D"
       );
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}test.ttl`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}test.ttl`),
           containerUrl,
           false
         )
@@ -114,7 +135,7 @@ describe("getPolicyUrl", () => {
       );
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}foo/bar`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}foo/bar`),
           containerUrl,
           false
         )
@@ -122,13 +143,17 @@ describe("getPolicyUrl", () => {
         "http://example.com/pb_policies/#aHR0cDovL2V4YW1wbGUuY29tL2Zvby9iYXI%3D"
       );
       expect(
-        getPolicyUrl(mockSolidDatasetFrom(containerUrl), containerUrl, false)
+        getPolicyUrl(
+          SolidClientFns.mockSolidDatasetFrom(containerUrl),
+          containerUrl,
+          false
+        )
       ).toEqual(
         "http://example.com/pb_policies/#aHR0cDovL2V4YW1wbGUuY29tL3BiX3BvbGljaWVzLw%3D%3D"
       );
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${containerUrl}test`),
+          SolidClientFns.mockSolidDatasetFrom(`${containerUrl}test`),
           containerUrl,
           false
         )
@@ -137,7 +162,7 @@ describe("getPolicyUrl", () => {
       );
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}public`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}public`),
           containerUrl,
           false
         )
@@ -146,7 +171,7 @@ describe("getPolicyUrl", () => {
       );
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}pb_policies/.ttl`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}pb_policies/.ttl`),
           containerUrl,
           false
         )
@@ -155,7 +180,7 @@ describe("getPolicyUrl", () => {
       );
       expect(
         getPolicyUrl(
-          mockSolidDatasetFrom(`${podUrl}pb_policies/test/`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}pb_policies/test/`),
           containerUrl,
           false
         )
@@ -173,7 +198,7 @@ describe("getResourcePoliciesContainerPath", () => {
     it("returns corresponding policy resource container for a given resource", () => {
       expect(
         getResourcePoliciesContainerPath(
-          mockSolidDatasetFrom(`${podUrl}foo/`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}foo/`),
           policiesUrl,
           true
         )
@@ -185,7 +210,7 @@ describe("getResourcePoliciesContainerPath", () => {
     it("returns corresponding policy resource container for a given resource", () => {
       expect(
         getResourcePoliciesContainerPath(
-          mockSolidDatasetFrom(`${podUrl}foo/`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}foo/`),
           policiesUrl,
           false
         )
@@ -209,7 +234,7 @@ describe("getPolicyResourceUrl", () => {
     it("returns the policies container url", () => {
       expect(
         getPolicyResourceUrl(
-          mockSolidDatasetFrom(`${podUrl}foo/`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}foo/`),
           policiesUrl,
           "editors",
           true
@@ -222,7 +247,7 @@ describe("getPolicyResourceUrl", () => {
     it("returns the policies container url", () => {
       expect(
         getPolicyResourceUrl(
-          mockSolidDatasetFrom(`${podUrl}foo/`),
+          SolidClientFns.mockSolidDatasetFrom(`${podUrl}foo/`),
           policiesUrl,
           "editors",
           false
@@ -262,5 +287,36 @@ describe("isNamedPolicy", () => {
     expect(isNamedPolicy("viewAndAdd")).toBe(false);
     expect(isNamedPolicy("editOnly")).toBe(false);
     expect(isNamedPolicy("addOnly")).toBe(false);
+  });
+});
+
+describe("deletePoliciesContainer", () => {
+  const mockDeleteContainer = jest
+    .spyOn(SolidClientFns, "deleteContainer")
+    .mockImplementation(jest.fn());
+
+  const fetch = jest.fn();
+  const containerIri = "https://example.org/policies/resource/";
+
+  test("it deletes the policies container", async () => {
+    await deletePoliciesContainer(containerIri, fetch);
+
+    expect(mockDeleteContainer).toHaveBeenCalledWith(containerIri, {
+      fetch,
+    });
+  });
+
+  it("ignores 403 errors when deleting the policy resource", async () => {
+    SolidClientFns.deleteContainer.mockRejectedValue(new Error("403"));
+    await expect(
+      deletePoliciesContainer(containerIri, fetch)
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws errors which aren't 403, 404 or 409 when deleting the policy resource", async () => {
+    SolidClientFns.deleteContainer.mockRejectedValue(new Error("400"));
+    await expect(
+      deletePoliciesContainer(containerIri, fetch)
+    ).rejects.toThrow();
   });
 });

--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -152,12 +152,13 @@ export async function deleteResource(
   fetch
 ) {
   const iri = getSourceUrl(resourceInfo);
-  await deleteFile(iri, {
-    fetch,
-  });
+  // await deleteFile(iri, {
+  //   fetch,
+  // });
   // FIXME: Discover whether legacy ACPs are used
   const legacyAcp = true;
-  if (!policiesContainerUrl) return;
+  // if (!policiesContainerUrl) return;
+  console.log(policiesContainerUrl)
   const policyUrl = getPolicyUrl(resourceInfo, policiesContainerUrl, legacyAcp);
   const resourcePoliciesContainerPath = getResourcePoliciesContainerPath(
     resourceInfo,
@@ -184,26 +185,26 @@ export async function deleteResource(
     policyUrl,
   ].filter((url) => Boolean(url));
 
-  Promise.allSettled(
-    urlsToDelete.map(async (url) => {
-      await deleteFile(url, { fetch });
-    })
-  )
-    .then(() => {
-      if (
-        resourcePoliciesContainerPath &&
-        isContainer(resourcePoliciesContainerPath)
-      ) {
-        deletePoliciesContainer(resourcePoliciesContainerPath, fetch);
-      }
-    })
-    .catch((err) => {
-      if (
-        !isHTTPError(err.message, 404) &&
-        !isHTTPError(err.message, 403) &&
-        !isHTTPError(err.message, 409)
-      ) {
-        throw err;
-      }
-    });
+  // Promise.allSettled(
+  //   urlsToDelete.map(async (url) => {
+  //     await deleteFile(url, { fetch });
+  //   })
+  // )
+  //   .then(() => {
+  //     if (
+  //       resourcePoliciesContainerPath &&
+  //       isContainer(resourcePoliciesContainerPath)
+  //     ) {
+  //       deletePoliciesContainer(resourcePoliciesContainerPath, fetch);
+  //     }
+  //   })
+  //   .catch((err) => {
+  //     if (
+  //       !isHTTPError(err.message, 404) &&
+  //       !isHTTPError(err.message, 403) &&
+  //       !isHTTPError(err.message, 409)
+  //     ) {
+  //       throw err;
+  //     }
+  //   });
 }

--- a/src/solidClientHelpers/resource.js
+++ b/src/solidClientHelpers/resource.js
@@ -43,8 +43,7 @@ import {
 } from "../models/policy";
 import { createResponder, isContainerIri } from "./utils";
 import { ERROR_CODES, isHTTPError } from "../error";
-// eslint-disable-next-line import/no-cycle
-import { hasAcpConfiguration } from "../accessControl/acp/index";
+import { hasAcpConfiguration } from "../accessControl/acp/helpers/index";
 import { customPolicies, namedPolicies } from "../../constants/policies";
 
 export function getResourceName(iri) {

--- a/src/solidClientHelpers/resource.test.js
+++ b/src/solidClientHelpers/resource.test.js
@@ -41,7 +41,7 @@ import {
   getBaseUrl,
   getProfileResource,
 } from "./resource";
-import { getPolicyUrl, deletePoliciesContainer } from "../models/policy";
+import { getPolicyUrl } from "../models/policy";
 import { chain } from "./utils";
 
 jest.mock("../models/policy");

--- a/src/solidClientHelpers/resource.test.js
+++ b/src/solidClientHelpers/resource.test.js
@@ -39,10 +39,9 @@ import {
   saveResource,
   deleteResource,
   getBaseUrl,
-  deletePoliciesContainer,
   getProfileResource,
 } from "./resource";
-import { getPolicyUrl } from "../models/policy";
+import { getPolicyUrl, deletePoliciesContainer } from "../models/policy";
 import { chain } from "./utils";
 
 jest.mock("../models/policy");
@@ -383,36 +382,5 @@ describe("deleteResource", () => {
     await expect(
       deleteResource(resourceInfo, policiesContainerUrl, fetch)
     ).resolves.toBeUndefined();
-  });
-});
-
-describe("deletePoliciesContainer", () => {
-  const mockDeleteContainer = jest
-    .spyOn(SolidClientFns, "deleteContainer")
-    .mockImplementation(jest.fn());
-
-  const fetch = jest.fn();
-  const containerIri = "https://example.org/policies/resource/";
-
-  test("it deletes the policies container", async () => {
-    await deletePoliciesContainer(containerIri, fetch);
-
-    expect(mockDeleteContainer).toHaveBeenCalledWith(containerIri, {
-      fetch,
-    });
-  });
-
-  it("ignores 403 errors when deleting the policy resource", async () => {
-    SolidClientFns.deleteContainer.mockRejectedValue(new Error("403"));
-    await expect(
-      deletePoliciesContainer(containerIri, fetch)
-    ).resolves.toBeUndefined();
-  });
-
-  it("throws errors which aren't 403, 404 or 409 when deleting the policy resource", async () => {
-    SolidClientFns.deleteContainer.mockRejectedValue(new Error("400"));
-    await expect(
-      deletePoliciesContainer(containerIri, fetch)
-    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
This PR fixes bug #PB-1109.

- we were not correctly checking that we were using legacy ACP, therefore the policy URL was not correctly found and the policy resource was not being deleted

- updating several hooks to get the correct policies containers and URL

- update tests

- [x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
