### PR TITLE
Fix: use legacy functions in 1.1 to get policies urls

### DIFF
--- a/components/deleteResourceButton/index.jsx
+++ b/components/deleteResourceButton/index.jsx
@@ -61,10 +61,10 @@ export default function DeleteResourceButton({
   const { fetch } = useSession();
   const router = useRouter();
   const { alertError } = useContext(AlertContext);
-  const policiesContainerUrl = usePoliciesContainerUrl(resourceIri);
   const { data: resourceInfo, error: resourceError } = useResourceInfo(
     resourceIri
   );
+  const policiesContainerUrl = usePoliciesContainerUrl(resourceInfo);
 
   if (resourceError) {
     alertError(resourceError.message);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,5 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/accessControl/acp/index.js
+++ b/src/accessControl/acp/index.js
@@ -549,9 +549,14 @@ function ensureApplyControl(policyUrl, datasetWithAcr, changed) {
 
 export function getPodBrowserPolicyUrlAll(
   resourceWithAcr,
-  policiesContainerUrl
+  policiesContainerUrl,
+  legacy
 ) {
-  const policies = acp.getPolicyUrlAll(resourceWithAcr);
+  const policies = legacy
+    ? legacyAcp
+        .getMemberPolicyUrlAll(resourceWithAcr)
+        .concat(legacyAcp.getPolicyUrlAll(resourceWithAcr))
+    : acp.getPolicyUrlAll(resourceWithAcr);
   return policies.filter((policyUrl) =>
     policyUrl.startsWith(policiesContainerUrl)
   );
@@ -565,7 +570,8 @@ export async function getPodBrowserPermissions(
 ) {
   const policiesUrls = getPodBrowserPolicyUrlAll(
     resourceWithAcr,
-    policiesContainerUrl
+    policiesContainerUrl,
+    legacy
   );
   if (!policiesUrls.length) return [];
   try {

--- a/src/accessControl/acp/index.test.js
+++ b/src/accessControl/acp/index.test.js
@@ -111,8 +111,8 @@ describe("AcpAccessControlStrategy", () => {
 
   const datasetWithLegacyAcr = chain(
     mockSolidDatasetFrom(datasetWithAcrUrl),
-    (d) => acpFns4.addMockAcrTo(d, acr),
-    (d) => acpFns4.addPolicyUrl(d, mockEditorsPolicyUrl(true))
+    (d) => acpFns3.addMockAcrTo(d, acr),
+    (d) => acpFns3.addPolicyUrl(d, mockEditorsPolicyUrl(true))
   );
   const datasetWithLatestAcr = chain(
     mockSolidDatasetFrom(datasetWithAcrUrl),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "incremental": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR fixes bug #PB-1118.

In this PR: 

- Using the right legacy functions to get the permissions
- Using the right legacy functions in the test as well to add the policies to the policy resource (as this was causing our tests not to catch this at all)

## To test:

- Log in with 1.1
- Verify that agents can be added to policies and are displayed correctly in the Sharing panel 

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).