### PR TITLE
Ignore .next directory when testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
 
   setupFilesAfterEnv: ["<rootDir>/jest-setup.js"],
 
-  testPathIgnorePatterns: ["/node_modules/", "/__testUtils/"],
+  testPathIgnorePatterns: ["/node_modules/", "/__testUtils/", "/.next"],
 
   transform: {
     "^.+\\.jsx?$": "babel-jest",


### PR DESCRIPTION
This prevents jest from looking at the .next directory, which includes some copied test files.