### PR TITLE
Use client identifiers with abritrary provider

### DIFF
--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -35,7 +35,7 @@ import { useBem } from "@solid/lit-prism-patterns";
 import { LoginButton, useSession } from "@inrupt/solid-ui-react";
 
 import { Button } from "@inrupt/prism-react-components";
-import { checkOidcSupport } from "../../../src/hooks/useClientId";
+import useClientId, { checkOidcSupport } from "../../../src/hooks/useClientId";
 import {
   generateRedirectUrl,
   getCurrentHostname,
@@ -111,8 +111,10 @@ export default function Provider({ defaultError, provider }) {
   const [loginError, setLoginError] = useState(defaultError);
   const theme = useTheme();
   const [providerIri, setProviderIri] = useState(provider?.iri || "");
+  const oidcSupported = useClientId(providerIri);
   const [authOptions, setAuthOptions] = useState({
     clientName: CLIENT_NAME,
+    clientId: oidcSupported ? CLIENT_APP_WEBID : null,
   });
   const loginFieldRef = createRef();
 


### PR DESCRIPTION
This enforces that the client identifier for PodBrowser is used with any OIDC provider supporting it, and not only with the default one. Previously, providing a custom Solid-OIDC provider would default to dynamic client registration.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
