### PR TITLE
Fix: display WebID in profile instead of profile IRI

### DIFF
--- a/components/pages/contacts/show/__snapshots__/index.test.jsx.snap
+++ b/components/pages/contacts/show/__snapshots__/index.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`Contact show page Renders the Contact show page 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                https://example.com/profile/card#me
+                http://example.com/webId#me
               </a>
             </h3>
           </div>

--- a/components/pages/privacy/resourceAccess/show/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/resourceAccess/show/__snapshots__/index.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`Resource access show page it renders a resource access page for a perso
                 rel="noreferrer"
                 target="_blank"
               >
-                http://bob.example.com/bob#me
+                http://example.com/webId#me
               </a>
             </h3>
           </div>

--- a/components/pages/privacy/resourceAccess/show/index.test.jsx
+++ b/components/pages/privacy/resourceAccess/show/index.test.jsx
@@ -31,6 +31,8 @@ import {
   bobWebIdUrl,
   mockPersonDatasetBob,
 } from "../../../../../__testUtils/mockPersonResource";
+import mockSessionContextProvider from "../../../../../__testUtils/mockSessionContextProvider";
+import mockSession from "../../../../../__testUtils/mockSession";
 
 jest.mock("next/router");
 
@@ -38,6 +40,8 @@ const mockedUseRouter = useRouter;
 
 describe("Resource access show page", () => {
   const profileDataset = mockPersonDatasetBob();
+  const session = mockSession();
+  const SessionProvider = mockSessionContextProvider(session);
 
   beforeEach(() => {
     jest
@@ -52,11 +56,13 @@ describe("Resource access show page", () => {
 
   test("it renders a resource access page for a person", async () => {
     const { asFragment, getAllByText } = renderWithTheme(
-      <AgentResourceAccessShowPage type={schema.Person} />
+      <SessionProvider>
+        <AgentResourceAccessShowPage type={schema.Person} />
+      </SessionProvider>
     );
     await waitFor(() => {
       expect(getAllByText("Bob")).toHaveLength(2);
-      expect(getAllByText(bobWebIdUrl)).toHaveLength(1);
+      expect(getAllByText("http://example.com/webId#me")).toHaveLength(1);
     });
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/pages/privacy/show/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/show/__snapshots__/index.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`Agent show page Renders the Agent show page 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                https://example.com/profile/card#me
+                http://example.com/webId#me
               </a>
             </h3>
           </div>

--- a/components/profile/__snapshots__/index.test.jsx.snap
+++ b/components/profile/__snapshots__/index.test.jsx.snap
@@ -54,7 +54,7 @@ exports[`Profile renders a person profile 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                https://example.com/profile/card#me
+                http://example.com/webId#me
               </a>
             </h3>
           </div>

--- a/components/profile/personAvatar/__snapshots__/index.test.jsx.snap
+++ b/components/profile/personAvatar/__snapshots__/index.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`Person Avatar renders a person avatar 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          https://example.com/profile/card#me
+          http://example.com/webId#me
         </a>
       </h3>
     </div>

--- a/components/profile/personAvatar/index.jsx
+++ b/components/profile/personAvatar/index.jsx
@@ -25,7 +25,7 @@ import { foaf, vcard } from "rdf-namespaces";
 import { Avatar, Box, createStyles } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
-import { Text, Image } from "@inrupt/solid-ui-react";
+import { Text, Image, useSession } from "@inrupt/solid-ui-react";
 
 import styles from "./styles";
 
@@ -43,6 +43,7 @@ export default function PersonAvatar({ profileIri }) {
   const classes = useStyles();
   const bem = useBem(classes);
   const errorComponent = setupErrorComponent(bem);
+  const { session } = useSession();
 
   return (
     <Box alignItems="center" display="flex">
@@ -66,7 +67,7 @@ export default function PersonAvatar({ profileIri }) {
             rel="noreferrer"
             target="_blank"
           >
-            {profileIri}
+            {session.info.webId}
           </a>
         </h3>
       </Box>


### PR DESCRIPTION
This PR fixes bug #APPS-1155.

We were incorrectly assuming the WebID and the profile IRI were the same. This PR changes that to using the WebID from the session.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
