### PR TITLE
Authenticate access grant issuance

### DIFF
--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -118,6 +118,9 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
           requestor,
           access: selectedAccess.accessModes,
           resources: selectedResources,
+        },
+        {
+          fetch: session.fetch,
         }
       );
       if (signedVc) {


### PR DESCRIPTION
Issuing the access grant requires the call to the issuer to be authenticated as the resource owner.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).