### PR TITLE
Fix/webid in delete contact

### DIFF
--- a/components/agentList/agentsDrawer/index.jsx
+++ b/components/agentList/agentsDrawer/index.jsx
@@ -66,6 +66,7 @@ export default function AgentsDrawer({
                 className={actionMenuBem("action-menu__trigger", "danger")}
                 onDelete={onDelete}
                 name={selectedContactName}
+                webId={profileIri}
               />
             </ActionMenuItem>
           </ActionMenu>

--- a/components/contactsList/contactsDrawer/index.jsx
+++ b/components/contactsList/contactsDrawer/index.jsx
@@ -42,6 +42,7 @@ export default function ContactsDrawer({
   onClose,
   onDelete,
   selectedContactName,
+  selectedContactWebId,
   profileIri,
 }) {
   const actionMenuBem = ActionMenu.useBem();
@@ -63,6 +64,7 @@ export default function ContactsDrawer({
                 className={actionMenuBem("action-menu__trigger", "danger")}
                 onDelete={onDelete}
                 name={selectedContactName}
+                webId={selectedContactWebId}
               />
             </ActionMenuItem>
           </ActionMenu>
@@ -77,6 +79,11 @@ ContactsDrawer.propTypes = {
   open: T.bool.isRequired,
   onClose: T.func.isRequired,
   onDelete: T.func.isRequired,
-  selectedContactName: T.string.isRequired,
+  selectedContactName: T.string,
+  selectedContactWebId: T.string.isRequired,
   profileIri: T.string.isRequired,
+};
+
+ContactsDrawer.defaultProps = {
+  selectedContactName: null,
 };

--- a/components/contactsList/contactsDrawer/index.test.jsx
+++ b/components/contactsList/contactsDrawer/index.test.jsx
@@ -22,15 +22,26 @@
 import React from "react";
 import ContactsDrawer from "./index";
 import { renderWithTheme } from "../../../__testUtils/withTheme";
+import { waitFor } from "@testing-library/dom";
+import { act, screen } from "@testing-library/react";
+
+import {
+  TESTCAFE_ID_CONFIRMATION_DIALOG,
+  TESTCAFE_ID_CONFIRMATION_DIALOG_CONTENT,
+  TESTCAFE_ID_CONFIRMATION_DIALOG_TITLE,
+  TESTCAFE_ID_CONFIRM_BUTTON,
+  ConfirmationDialog,
+} from "../confirmationDialog";
+import userEvent from "@testing-library/user-event";
 
 describe("ContactsDrawer", () => {
   const onClose = () => {};
   const onDelete = () => {};
   const selectedContactName = "Alice";
   const profileIri = "https://example.com/profile#alice";
-
-  it("renders", () => {
-    const { asFragment } = renderWithTheme(
+  let renderResult;
+  beforeEach(() => {
+    renderResult = renderWithTheme(
       <ContactsDrawer
         open
         onClose={onClose}
@@ -39,6 +50,46 @@ describe("ContactsDrawer", () => {
         profileIri={profileIri}
       />
     );
-    expect(asFragment()).toMatchSnapshot();
   });
+  it("renders", () => {
+    expect(renderResult.asFragment()).toMatchSnapshot();
+  });
+});
+
+describe("Delete contact button confirmation dialog", () => {
+  const testWebId = "testWebId";
+  let renderResult;
+  const onClose = () => {};
+  const onDelete = () => {};
+  const selectedContactName = "Alice";
+  const profileIri = "https://example.com/profile#alice";
+  beforeEach(() => {
+    renderResult = renderWithTheme(
+      <ContactsDrawer
+        open
+        onClose={onClose}
+        onDelete={onDelete}
+        selectedContactName={selectedContactName}
+        profileIri={profileIri}
+      />
+    );
+  });
+
+  test("the delete confirmation shows webId if no name is available", async () => {
+    const testName = null;
+    const deleteButton = await screen.findByTestId("delete-button");
+    userEvent.click(deleteButton);
+    const dialog = await screen.findByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG);
+
+    await waitFor(() => {
+      expect(dialog).toBeInTheDocument();
+      expect(
+        dialog.getByTestId(TESTCAFE_ID_CONFIRMATION_DIALOG_CONTENT)
+      ).toHaveTextContent("testWebId");
+    });
+  });
+
+  // test("it shows name if name is available", () => {
+
+  // });
 });

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -146,7 +146,6 @@ function ContactsList() {
     peopleMutate,
     selectedContactIndex,
   });
-
   const drawer = (
     <ContactsDrawer
       open={selectedContactIndex !== null}
@@ -154,6 +153,7 @@ function ContactsList() {
       onDelete={deleteSelectedContact}
       selectedContactName={selectedContactName}
       profileIri={selectedContactWebId}
+      selectedContactWebId={selectedContactWebId}
     />
   );
 

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -118,7 +118,9 @@ function ContactsList() {
     const contactThing = getThing(contactDataset, contactThingUrl);
     const webId = getWebIdUrl(contactDataset, contactThingUrl);
     const name =
-      getStringNoLocale(contactThing, formattedNamePredicate) || webId;
+      getStringNoLocale(contactThing, formattedNamePredicate) ||
+      getStringNoLocale(contactThing, vcard.fn) ||
+      webId;
     setSelectedContactName(name);
     setSelectedContactWebId(webId);
   }, [selectedContactIndex, formattedNamePredicate, people, fetch]);

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -103,7 +103,6 @@ function ContactsList() {
   const profiles = useProfiles(people);
   const formattedNamePredicate = foaf.name;
   const hasPhotoPredicate = vcard.hasPhoto;
-
   const {
     session: { fetch },
   } = useSession();
@@ -118,8 +117,10 @@ function ContactsList() {
     const contactThingUrl = people[selectedContactIndex]?.iri;
     const contactThing = getThing(contactDataset, contactThingUrl);
     const webId = getWebIdUrl(contactDataset, contactThingUrl);
+    console.log({ contactThing });
     const name =
       getStringNoLocale(contactThing, formattedNamePredicate) || webId;
+    console.log({ name });
     setSelectedContactName(name);
     setSelectedContactWebId(webId);
   }, [selectedContactIndex, formattedNamePredicate, people, fetch]);

--- a/components/contactsList/index.jsx
+++ b/components/contactsList/index.jsx
@@ -117,10 +117,8 @@ function ContactsList() {
     const contactThingUrl = people[selectedContactIndex]?.iri;
     const contactThing = getThing(contactDataset, contactThingUrl);
     const webId = getWebIdUrl(contactDataset, contactThingUrl);
-    console.log({ contactThing });
     const name =
       getStringNoLocale(contactThing, formattedNamePredicate) || webId;
-    console.log({ name });
     setSelectedContactName(name);
     setSelectedContactWebId(webId);
   }, [selectedContactIndex, formattedNamePredicate, people, fetch]);

--- a/components/deleteContactButton/index.jsx
+++ b/components/deleteContactButton/index.jsx
@@ -23,6 +23,9 @@ import React from "react";
 import T from "prop-types";
 import DeleteButton from "../deleteButton";
 
+export const TESTCAFE_CONTACT_DELETE_BUTTON = "delete-contact-button";
+export const confirmationTitle = "Delete Contact";
+export const deleteContactSuccessMessage = "Contact was successfully deleted.";
 /* eslint react/jsx-props-no-spreading: 0 */
 export default function DeleteContactButton({
   onDelete,
@@ -30,16 +33,15 @@ export default function DeleteContactButton({
   webId,
   ...buttonProps
 }) {
-  console.log({ webId });
   return (
     <DeleteButton
-      confirmationTitle="Delete Contact"
+      confirmationTitle={confirmationTitle}
       confirmationContent={`Are you sure you wish to delete ${
         name || webId
       } from your contacts?`}
       dialogId="delete-contact"
       onDelete={onDelete}
-      successMessage="Contact was successfully deleted."
+      successMessage={deleteContactSuccessMessage}
       {...buttonProps}
     >
       Delete

--- a/components/deleteContactButton/index.jsx
+++ b/components/deleteContactButton/index.jsx
@@ -27,12 +27,16 @@ import DeleteButton from "../deleteButton";
 export default function DeleteContactButton({
   onDelete,
   name,
+  webId,
   ...buttonProps
 }) {
+  console.log({ webId });
   return (
     <DeleteButton
       confirmationTitle="Delete Contact"
-      confirmationContent={`Are you sure you wish to delete ${name} from your contacts?`}
+      confirmationContent={`Are you sure you wish to delete ${
+        name || webId
+      } from your contacts?`}
       dialogId="delete-contact"
       onDelete={onDelete}
       successMessage="Contact was successfully deleted."
@@ -45,5 +49,10 @@ export default function DeleteContactButton({
 
 DeleteContactButton.propTypes = {
   onDelete: T.func.isRequired,
-  name: T.string.isRequired,
+  name: T.string,
+  webId: T.string.isRequired,
+};
+
+DeleteContactButton.defaultProps = {
+  name: null,
 };

--- a/components/login/index.jsx
+++ b/components/login/index.jsx
@@ -59,11 +59,18 @@ export default function Login() {
   const INFO_BUTTON_LABEL = "Where is your Pod hosted?";
 
   const oidcSupported = useClientId(PROVIDER_IRI);
+  let authOptions;
 
-  const authOptions = {
-    clientName: CLIENT_NAME,
-    clientId: oidcSupported ? CLIENT_APP_WEBID : null,
-  };
+  if (oidcSupported && CLIENT_APP_WEBID) {
+    authOptions = {
+      clientName: CLIENT_NAME,
+      clientId: CLIENT_APP_WEBID,
+    };
+  } else {
+    authOptions = {
+      clientName: CLIENT_NAME,
+    };
+  }
 
   useEffect(() => {
     if (!idp) return;

--- a/components/login/index.jsx
+++ b/components/login/index.jsx
@@ -59,18 +59,11 @@ export default function Login() {
   const INFO_BUTTON_LABEL = "Where is your Pod hosted?";
 
   const oidcSupported = useClientId(PROVIDER_IRI);
-  let authOptions;
 
-  if (oidcSupported && CLIENT_APP_WEBID) {
-    authOptions = {
-      clientName: CLIENT_NAME,
-      clientId: CLIENT_APP_WEBID,
-    };
-  } else {
-    authOptions = {
-      clientName: CLIENT_NAME,
-    };
-  }
+  const authOptions = {
+    clientName: CLIENT_NAME,
+    clientId: oidcSupported ? CLIENT_APP_WEBID : null,
+  };
 
   useEffect(() => {
     if (!idp) return;


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes bug #1087
If the contact does not have a name, we will show their webID instead of null (what is currently displayed) Also found a bug where webID was being passed through instead of name if contact profile was using vcard instead of foaf.

- [ x] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->
