### PR TITLE
Clear previouspage out of localstorage after reading

### DIFF
--- a/__testUtils/mockLocalStorage.js
+++ b/__testUtils/mockLocalStorage.js
@@ -28,5 +28,8 @@ export default function mockLocalStorage() {
     setItem(key, value) {
       store[key] = value.toString();
     },
+    removeItem(key) {
+      store[key] = null;
+    },
   };
 }

--- a/components/pages/index/index.jsx
+++ b/components/pages/index/index.jsx
@@ -38,20 +38,20 @@ export default function Home() {
   const { webId = "" } = session.info;
   const { data: podIris = [] } = usePodIrisFromWebId(webId);
   const [podIri] = podIris;
-  const redirectUrl = previousPage || null;
 
   useEffect(() => {
-    if (redirectUrl && redirectUrl !== "/") {
-      router.push(redirectUrl).catch((e) => {
+    if (previousPage && previousPage !== "/") {
+      router.push(previousPage).catch((e) => {
         throw e;
       });
     }
+
     if (podIri) {
       router.replace("/resource/[iri]", resourceHref(podIri)).catch((e) => {
         throw e;
       });
     }
-  }, [podIri, router, redirectUrl]);
+  }, [podIri, router, previousPage]);
 
   return null;
 }

--- a/src/hooks/usePreviousPage/index.js
+++ b/src/hooks/usePreviousPage/index.js
@@ -21,12 +21,17 @@
 
 import { useEffect, useState } from "react";
 
+export const PREVIOUS_PAGE = "previousPage";
+
 export default function usePreviousPage() {
   const [previousPage, setPreviousPage] = useState(null);
+
   useEffect(() => {
     if (!localStorage) return;
-    const url = localStorage.getItem("previousPage");
+    const url = localStorage.getItem(PREVIOUS_PAGE);
     setPreviousPage(url || null);
+    localStorage.removeItem(PREVIOUS_PAGE);
   }, []);
+
   return previousPage;
 }

--- a/src/hooks/usePreviousPage/index.test.jsx
+++ b/src/hooks/usePreviousPage/index.test.jsx
@@ -43,6 +43,12 @@ describe("usePreviousPage", () => {
       const { result } = renderHook(() => usePreviousPage());
       expect(result.current).toBe(previousPage);
     });
+
+    it("removes the value from localstorage after reading", async () => {
+      window.localStorage.setItem("previousPage", previousPage);
+      renderHook(() => usePreviousPage());
+      expect(window.localStorage.getItem("previousPage")).toBeNull();
+    });
   });
 
   describe("without Local Storage", () => {


### PR DESCRIPTION
This clears the previousPage value from localstorage after it is read to clean up localstorage and prevent a looping bug.