### PR TITLE
Fix: remove previousPage from localStorage after use

### DIFF
--- a/components/pages/index/index.jsx
+++ b/components/pages/index/index.jsx
@@ -42,9 +42,12 @@ export default function Home() {
 
   useEffect(() => {
     if (redirectUrl && redirectUrl !== "/") {
-      router.push(redirectUrl).catch((e) => {
-        throw e;
-      });
+      router
+        .push(redirectUrl)
+        .then(() => localStorage.removeItem("previousPage"))
+        .catch((e) => {
+          throw e;
+        });
     }
     if (podIri) {
       router.replace("/resource/[iri]", resourceHref(podIri)).catch((e) => {


### PR DESCRIPTION
This PR fixes bug #APPS-1172.

We now remove `previousPage` from localStorage after using it to redirect the user back to the previous page after logging in.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
