### PR TITLE
updated client_id logic

### DIFF
--- a/components/login/index.jsx
+++ b/components/login/index.jsx
@@ -62,8 +62,9 @@ export default function Login() {
 
   const authOptions = {
     clientName: CLIENT_NAME,
-    clientId: oidcSupported ? CLIENT_APP_WEBID : null,
   };
+  if (oidcSupported && CLIENT_APP_WEBID)
+    authOptions.clientId = CLIENT_APP_WEBID;
 
   useEffect(() => {
     if (!idp) return;

--- a/components/login/index.jsx
+++ b/components/login/index.jsx
@@ -63,7 +63,7 @@ export default function Login() {
   const authOptions = {
     clientName: CLIENT_NAME,
   };
-  if (oidcSupported) authOptions.clientId = CLIENT_APP_WEBID || null;
+  if (oidcSupported) authOptions.clientId = CLIENT_APP_WEBID;
 
   useEffect(() => {
     if (!idp) return;

--- a/components/login/index.jsx
+++ b/components/login/index.jsx
@@ -63,8 +63,7 @@ export default function Login() {
   const authOptions = {
     clientName: CLIENT_NAME,
   };
-  if (oidcSupported && CLIENT_APP_WEBID)
-    authOptions.clientId = CLIENT_APP_WEBID;
+  if (oidcSupported) authOptions.clientId = CLIENT_APP_WEBID || null;
 
   useEffect(() => {
     if (!idp) return;


### PR DESCRIPTION
There has been an error during login where no client_id is being passed in to the login form. This fix provides the login form with the client_id if the login is oidc supported, otherwise it uses a default value. 