### PR TITLE
Only send clientId if it has a value

### DIFF
--- a/components/login/index.jsx
+++ b/components/login/index.jsx
@@ -45,7 +45,7 @@ const PROVIDER_IRI = "https://broker.pod.inrupt.com/";
 const hostname = getCurrentHostname();
 
 const CLIENT_APP_WEBID = isLocalhost(hostname)
-  ? null
+  ? undefined
   : `${getCurrentOrigin()}/api/app`;
 
 export default function Login() {
@@ -64,6 +64,10 @@ export default function Login() {
     clientName: CLIENT_NAME,
   };
   if (oidcSupported) authOptions.clientId = CLIENT_APP_WEBID;
+
+  if (oidcSupported && CLIENT_APP_WEBID) {
+    authOptions.clientId = CLIENT_APP_WEBID;
+  }
 
   useEffect(() => {
     if (!idp) return;


### PR DESCRIPTION
This PR makes sure that client_id is not sent in as a null value, but rather is omitted entirely if it should not be sent.