### PR TITLE
Consent form text overflow

### DIFF
--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -247,7 +247,7 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
         </Typography>
         {Array.isArray(purposes) && purposes.length === 1 ? (
           <span className={bem("purpose")}>
-            {purposes[0].description || purposes[0]}{" "}
+            {purposes[0].description || purposes[0]}
             <InfoTooltip
               tooltipText={purposes[0].url || purposes[0] || "Purpose"}
             />

--- a/components/consentRequestForm/styles.js
+++ b/components/consentRequestForm/styles.js
@@ -202,11 +202,17 @@ export default function styles(theme) {
     "agent-name": {
       display: "flex",
       justifyContent: "center",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      wordBreak: "break-word",
     },
     purpose: {
       display: "flex",
       justifyContent: "flex-start",
       padding: "1rem",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      wordBreak: "break-word",
     },
 
     "date-container": {
@@ -307,6 +313,9 @@ export default function styles(theme) {
     },
     "purposes-container": {
       padding: "2rem 0",
+      textOverflow: "ellipsis",
+      overflow: "hidden",
+      wordBreak: "break-word",
     },
   };
 }

--- a/components/consentRequestForm/styles.js
+++ b/components/consentRequestForm/styles.js
@@ -202,19 +202,13 @@ export default function styles(theme) {
     "agent-name": {
       display: "flex",
       justifyContent: "center",
-      textOverflow: "ellipsis",
-      overflow: "hidden",
       wordBreak: "break-word",
-      whiteSpace: "nowrap"
     },
     purpose: {
       display: "flex",
       justifyContent: "flex-start",
       padding: "1rem",
-      textOverflow: "ellipsis",
-      overflow: "hidden",
       wordBreak: "break-word",
-      whiteSpace: "nowrap"
     },
 
     "date-container": {
@@ -315,10 +309,7 @@ export default function styles(theme) {
     },
     "purposes-container": {
       padding: "2rem 0",
-      textOverflow: "ellipsis",
-      overflow: "hidden",
       wordBreak: "break-word",
-      whiteSpace: "nowrap"
     },
   };
 }

--- a/components/consentRequestForm/styles.js
+++ b/components/consentRequestForm/styles.js
@@ -205,6 +205,7 @@ export default function styles(theme) {
       textOverflow: "ellipsis",
       overflow: "hidden",
       wordBreak: "break-word",
+      whiteSpace: "nowrap"
     },
     purpose: {
       display: "flex",
@@ -213,6 +214,7 @@ export default function styles(theme) {
       textOverflow: "ellipsis",
       overflow: "hidden",
       wordBreak: "break-word",
+      whiteSpace: "nowrap"
     },
 
     "date-container": {
@@ -316,6 +318,7 @@ export default function styles(theme) {
       textOverflow: "ellipsis",
       overflow: "hidden",
       wordBreak: "break-word",
+      whiteSpace: "nowrap"
     },
   };
 }


### PR DESCRIPTION
This PR fixes bug #1090.

Updated styling to help with overflowing content. Essentially the URIs are long strings, and the div looks for a white space to break it up. If there is no white space it run outside of the div. The word-break css attribute allows the string be broken into lines if necessary without the string containing whitespace.