### PR TITLE
Send client id when enter is pressed in the login form

### DIFF
--- a/components/login/provider/index.jsx
+++ b/components/login/provider/index.jsx
@@ -81,7 +81,7 @@ export function setupLoginHandler(login, setLoginError) {
     e.preventDefault();
 
     try {
-      await login({ oidcIssuer: providerIri });
+      await login({ ...AUTH_OPTIONS, oidcIssuer: providerIri });
       setLoginError(null);
     } catch (error) {
       if (!e.target.value && !providerIri) {

--- a/components/login/provider/index.test.jsx
+++ b/components/login/provider/index.test.jsx
@@ -35,6 +35,8 @@ import ProviderLogin, {
 import { renderWithTheme } from "../../../__testUtils/withTheme";
 import useIdpFromQuery from "../../../src/hooks/useIdpFromQuery";
 
+import { getCurrentHostname } from "../../../src/windowHelpers";
+
 jest.mock("../../../src/windowHelpers");
 jest.mock("../../../src/hooks/useIdpFromQuery");
 jest.mock("next/router");
@@ -151,9 +153,15 @@ describe("setupLoginHandler", () => {
     const setLoginError = jest.fn();
     const providerIri = "https://example.org";
     const event = { preventDefault: jest.fn() };
+
     setupLoginHandler(login, setLoginError, providerIri)(event, providerIri);
+
     expect(event.preventDefault).toHaveBeenCalled();
-    expect(login).toHaveBeenCalledWith({ oidcIssuer: providerIri });
+    expect(login).toHaveBeenCalledWith({
+      oidcIssuer: providerIri,
+      clientId: "undefined/api/app",
+      clientName: "Inrupt PodBrowser",
+    });
   });
 });
 


### PR DESCRIPTION
This fixes an issue where pressing "enter" on the login form with a custom openid provider does not include the client id.