### PR TITLE
Fix: server segfaults in development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,9 @@ process.env.SENTRY_DSN = SENTRY_DSN;
 
 /* eslint no-param-reassign: 0 */
 module.exports = {
+  experimental: {
+    esmExternals: false,
+  },
   productionBrowserSourceMaps: true,
   webpack(config, options) {
     // If the environment is the browser, we should load sentry/react instead of


### PR DESCRIPTION
## Description

This follows the information provided by the Vercel / Nextjs team over on Twitter:
https://twitter.com/_ijjk/status/1497390208853037057?s=21

## Changes

Disabled `esmExternals` experiment, seems to be what segfaults in node v14, though I'm not sure why. Hopefully soon Vercel will support v16.

## Testing

Checkout the branch, see if it works better for you. It does for me.

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.

## Interested parties

@VirginiaBalseiro @daytonn @solid-akb 
