### PR TITLE
Add jest expectations for solid things

### DIFF
--- a/src/jest-solid/index.js
+++ b/src/jest-solid/index.js
@@ -19,11 +19,12 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import "@testing-library/jest-dom";
-import jestSolid from "./src/jest-solid";
+import toHaveRDFType from "./toHaveRDFType";
+import toHaveString from "./toHaveString";
+import toHaveURL from "./toHaveURL";
 
-process.on("unhandledRejection", (reason) => {
-  throw reason;
-});
-
-expect.extend(jestSolid);
+export default {
+  toHaveRDFType,
+  toHaveString,
+  toHaveURL,
+};

--- a/src/jest-solid/toHaveRDFType.js
+++ b/src/jest-solid/toHaveRDFType.js
@@ -19,11 +19,23 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import "@testing-library/jest-dom";
-import jestSolid from "./src/jest-solid";
+import { rdf } from "rdf-namespaces";
+import { getUrlAll } from "@inrupt/solid-client";
 
-process.on("unhandledRejection", (reason) => {
-  throw reason;
-});
+export default function toHaveRDFType(received, expectedType) {
+  if (!expectedType) {
+    return {
+      pass: false,
+      message: () => "You must provide a type value",
+    };
+  }
 
-expect.extend(jestSolid);
+  const actualTypes = getUrlAll(received, rdf.type);
+  const actualTypesString = actualTypes.join(", ");
+
+  return {
+    pass: actualTypes.includes(expectedType),
+    message: () =>
+      `Expected thing to have a type of ${expectedType}, received ${actualTypesString}`,
+  };
+}

--- a/src/jest-solid/toHaveRDFType.test.js
+++ b/src/jest-solid/toHaveRDFType.test.js
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { rdf } from "rdf-namespaces";
+import { mockThingFrom, setUrl } from "@inrupt/solid-client";
+import toHaveRDFType from "./toHaveRDFType";
+
+describe("toHaveRDFType", () => {
+  it("fails when a type value is not given", () => {
+    const type = "https://example.com/type";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      rdf.type,
+      type
+    );
+
+    const { pass, message } = toHaveRDFType(thing);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual("You must provide a type value");
+  });
+
+  it("passes when the given thing contains the expected type", () => {
+    const type = "https://example.com/type";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      rdf.type,
+      type
+    );
+
+    const { pass } = toHaveRDFType(thing, type);
+
+    expect(pass).toBe(true);
+  });
+
+  it("handles multiple types", () => {
+    const type = "https://example.com/type";
+    const type2 = "https://example.com/type2";
+
+    const thing = setUrl(
+      setUrl(mockThingFrom("https://example.com/thing"), rdf.type, type),
+      rdf.type,
+      type2
+    );
+
+    const { pass } = toHaveRDFType(thing, type2);
+
+    expect(pass).toBe(true);
+  });
+
+  it("fails when the given thing does not contain the given type", () => {
+    const type = "https://example.com/type";
+    const type2 = "https://example.com/type2";
+
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      rdf.type,
+      type
+    );
+
+    const { pass, message } = toHaveRDFType(thing, type2);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have a type of ${type2}, received ${type}`
+    );
+  });
+});

--- a/src/jest-solid/toHaveString.js
+++ b/src/jest-solid/toHaveString.js
@@ -19,11 +19,32 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import "@testing-library/jest-dom";
-import jestSolid from "./src/jest-solid";
+import { getStringNoLocaleAll } from "@inrupt/solid-client";
 
-process.on("unhandledRejection", (reason) => {
-  throw reason;
-});
+export default function toHaveString(received, predicate, expectedString) {
+  if (!predicate) {
+    return {
+      pass: false,
+      message: () => "You must provide a string predicate",
+    };
+  }
 
-expect.extend(jestSolid);
+  const actualStringValues = getStringNoLocaleAll(received, predicate);
+
+  if (!expectedString) {
+    return {
+      pass: !!actualStringValues.length,
+      message: () => `Expected thing to have a predicate of ${predicate}`,
+    };
+  }
+
+  const actuallyReceived = actualStringValues.length
+    ? actualStringValues.join(", ")
+    : null;
+
+  return {
+    pass: actualStringValues.includes(expectedString),
+    message: () =>
+      `Expected thing to have an ${predicate} predicate with a value of ${expectedString}, received ${actuallyReceived}`,
+  };
+}

--- a/src/jest-solid/toHaveString.test.js
+++ b/src/jest-solid/toHaveString.test.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { foaf } from "rdf-namespaces";
+import { mockThingFrom, setStringNoLocale } from "@inrupt/solid-client";
+import toHaveString from "./toHaveString";
+
+describe("toHaveString", () => {
+  it("fails when a predicate is not given", () => {
+    const expectedValue = "test";
+    const thing = setStringNoLocale(
+      mockThingFrom("https://example.com/thing"),
+      foaf.name,
+      expectedValue
+    );
+
+    const { pass, message } = toHaveString(thing);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual("You must provide a string predicate");
+  });
+
+  it("passes when the given thing has the expected predicate", () => {
+    const expectedValue = "test";
+    const thing = setStringNoLocale(
+      mockThingFrom("https://example.com/thing"),
+      foaf.name,
+      expectedValue
+    );
+
+    const { pass } = toHaveString(thing, foaf.name);
+
+    expect(pass).toBe(true);
+  });
+
+  it("passes when the given thing has the expected predicate with the expected value", () => {
+    const expectedValue = "test";
+    const thing = setStringNoLocale(
+      mockThingFrom("https://example.com/thing"),
+      foaf.name,
+      expectedValue
+    );
+
+    const { pass } = toHaveString(thing, foaf.name, expectedValue);
+
+    expect(pass).toBe(true);
+  });
+
+  it("handles multiple values", () => {
+    const value = "test";
+    const value2 = "test2";
+
+    const thing = setStringNoLocale(
+      setStringNoLocale(
+        mockThingFrom("https://example.com/thing"),
+        foaf.name,
+        value
+      ),
+      foaf.name,
+      value2
+    );
+
+    const { pass } = toHaveString(thing, foaf.name, value2);
+
+    expect(pass).toBe(true);
+  });
+
+  it("fails when the given thing does not contain the expected predicate", () => {
+    const thing = mockThingFrom("https://example.com/thing");
+
+    const { pass, message } = toHaveString(thing, foaf.name);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have a predicate of ${foaf.name}`
+    );
+  });
+
+  it("fails when the given thing does not contain the expected predicate with the expected value", () => {
+    const actualValue = "unexpected";
+    const expectedValue = "test";
+    const thing = setStringNoLocale(
+      mockThingFrom("https://example.com/thing"),
+      foaf.name,
+      actualValue
+    );
+
+    const { pass, message } = toHaveString(thing, foaf.name, expectedValue);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have an ${foaf.name} predicate with a value of ${expectedValue}, received ${actualValue}`
+    );
+  });
+
+  it("fails when the given thing does not contain the expected predicate or the expected value", () => {
+    const thing = mockThingFrom("https://example.com/thing");
+
+    const { pass, message } = toHaveString(thing, foaf.homepage, "test");
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have an ${foaf.homepage} predicate with a value of test, received null`
+    );
+  });
+});

--- a/src/jest-solid/toHaveURL.js
+++ b/src/jest-solid/toHaveURL.js
@@ -19,11 +19,33 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import "@testing-library/jest-dom";
-import jestSolid from "./src/jest-solid";
+import { rdf } from "rdf-namespaces";
+import { getUrlAll } from "@inrupt/solid-client";
 
-process.on("unhandledRejection", (reason) => {
-  throw reason;
-});
+export default function toHaveURL(received, predicate, expectedValue) {
+  if (!predicate) {
+    return {
+      pass: false,
+      message: () => "You must provide a URL predicate",
+    };
+  }
 
-expect.extend(jestSolid);
+  const actualURLValues = getUrlAll(received, predicate);
+
+  if (!expectedValue) {
+    return {
+      pass: !!actualURLValues.length,
+      message: () => `Expected thing to have a predicate of ${predicate}`,
+    };
+  }
+
+  const actuallyReceived = actualURLValues.length
+    ? actualURLValues.join(", ")
+    : null;
+
+  return {
+    pass: actualURLValues.includes(expectedValue),
+    message: () =>
+      `Expected thing to have an ${predicate} predicate with a value of ${expectedValue}, received ${actuallyReceived}`,
+  };
+}

--- a/src/jest-solid/toHaveURL.test.js
+++ b/src/jest-solid/toHaveURL.test.js
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { foaf } from "rdf-namespaces";
+import { mockThingFrom, setUrl } from "@inrupt/solid-client";
+import toHaveURL from "./toHaveURL";
+
+describe("toHaveURL", () => {
+  it("fails when a predicate is not given", () => {
+    const expectedValue = "https://example.com/test";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      foaf.name,
+      expectedValue
+    );
+
+    const { pass, message } = toHaveURL(thing);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual("You must provide a URL predicate");
+  });
+
+  it("passes when the given thing has the expected predicate", () => {
+    const expectedValue = "https://example.com";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      foaf.homepage,
+      expectedValue
+    );
+
+    const { pass } = toHaveURL(thing, foaf.homepage);
+
+    expect(pass).toBe(true);
+  });
+
+  it("passes when the given thing has the expected predicate with the expected value", () => {
+    const expectedValue = "https://example.com";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      foaf.homepage,
+      expectedValue
+    );
+
+    const { pass } = toHaveURL(thing, foaf.homepage, expectedValue);
+
+    expect(pass).toBe(true);
+  });
+
+  it("handles multiple values", () => {
+    const value = "https://example.com/value";
+    const value2 = "https://example.com/value2";
+
+    const thing = setUrl(
+      setUrl(mockThingFrom("https://example.com/thing"), foaf.homepage, value),
+      foaf.homepage,
+      value2
+    );
+
+    const { pass } = toHaveURL(thing, foaf.homepage, value2);
+
+    expect(pass).toBe(true);
+  });
+
+  it("fails when the given thing does not contain the expected predicate", () => {
+    const thing = mockThingFrom("https://example.com/thing");
+
+    const { pass, message } = toHaveURL(thing, foaf.homepage);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have a predicate of ${foaf.homepage}`
+    );
+  });
+
+  it("fails when the given thing does not contain the expected predicate with the expected value", () => {
+    const actualValue = "https://example.com";
+    const expectedValue = "unexpected";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      foaf.homepage,
+      actualValue
+    );
+
+    const { pass, message } = toHaveURL(thing, foaf.homepage, expectedValue);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have an ${foaf.homepage} predicate with a value of ${expectedValue}, received ${actualValue}`
+    );
+  });
+
+  it("fails when the given thing does not contain the expected predicate or the expected value", () => {
+    const expectedValue = "unexpected";
+    const thing = setUrl(
+      mockThingFrom("https://example.com/thing"),
+      foaf.page,
+      "https://example.com"
+    );
+
+    const { pass, message } = toHaveURL(thing, foaf.homepage, expectedValue);
+
+    expect(pass).toBe(false);
+    expect(message()).toEqual(
+      `Expected thing to have an ${foaf.homepage} predicate with a value of ${expectedValue}, received null`
+    );
+  });
+});


### PR DESCRIPTION
## Description
I thought it might be nice to have some jest helpers to clean up our expectations around `Thing`s. I've started a small expectation library to make testing things a little more straight forward.

## Changes
- Added solid test helpers to our jest configuration
- Added an expectation to check if a thing contains a specific RDF type
- Added an expectation to check if a thing contains a specific URL predicate/value
- Added an expectation to check if a thing contains a specific String predicate/value

## Testing
- run `npm test src/jest-solid`
- verify all tests pass

## Commit checklist

- [x] Includes tests to ensure functionality and prevent regressions.

## Notes
The following are some examples of these expectations in action:

```js
expect(thing).toHaveRDFType(foaf.Person)

expect(thing).toHaveURL(foaf.homepage)
expect(thing).toHaveURL(foaf.homepage, "https://example.com")

expect(thing).toHaveString(foaf.name)
expect(thing).toHaveString(foaf.name, "Dayton Nolan")
```
