### PR TITLE
Refactor error responder to accept unauthorized message

### DIFF
--- a/src/addressBook/index.js
+++ b/src/addressBook/index.js
@@ -218,15 +218,10 @@ export async function saveNewAddressBook(
   { iri, owner, title = "Contacts" },
   fetch
 ) {
-  const { respond, error } = createResponder();
+  const { respond, error } = createResponder({
+    unauthorizedMessage: "You do not have permission to create an address book",
+  });
   const { response: existingAddressBook } = await getResource(iri, fetch);
-  const respondWithError = (msg) => {
-    if (isHTTPError(msg, ERROR_CODES.UNAUTHORIZED)) {
-      return error("You do not have permission to create an address book");
-    }
-
-    return error(msg);
-  };
 
   if (existingAddressBook) return error("Address book already exists.");
 
@@ -249,9 +244,9 @@ export async function saveNewAddressBook(
     fetch
   );
 
-  if (saveIndexError) return respondWithError(saveIndexError);
-  if (saveGroupsError) return respondWithError(saveGroupsError);
-  if (savePeopleError) return respondWithError(savePeopleError);
+  if (saveIndexError) return error(saveIndexError);
+  if (saveGroupsError) return error(saveGroupsError);
+  if (savePeopleError) return error(savePeopleError);
 
   return respond({ iri, index, groups, people });
 }

--- a/src/solidClientHelpers/utils.js
+++ b/src/solidClientHelpers/utils.js
@@ -31,7 +31,7 @@ import {
   setThing,
 } from "@inrupt/solid-client";
 import { ldp, rdf } from "rdf-namespaces";
-
+import { ERROR_CODES, isHTTPError } from "../error";
 import { parseUrl } from "../stringHelpers";
 
 function mirrorKeysAndValues(obj) {
@@ -102,9 +102,17 @@ export function displayTypes(types) {
   return types?.length ? types.map((t) => getTypeName(t)) : [];
 }
 
-export function createResponder() {
+export function createResponder(
+  { unauthorizedMessage } = {
+    unauthorizedMessage: "You are not authorized for that action",
+  }
+) {
   const respond = (response) => ({ response });
-  const error = (e) => ({ error: e });
+  const error = (e) => {
+    const unauthorized = isHTTPError(e, ERROR_CODES.UNAUTHORIZED);
+    const msg = unauthorized ? unauthorizedMessage : e;
+    return { error: msg };
+  };
 
   return { respond, error };
 }

--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -51,6 +51,26 @@ describe("createResponder", () => {
     expect(respond("data")).toMatchObject({ response: "data" });
     expect(error("message")).toMatchObject({ error: "message" });
   });
+
+  describe("given an unauthorized error", () => {
+    test("it returns a more human-friendly unauthorized message", () => {
+      const { error } = createResponder();
+
+      expect(error("Unauthorized 401")).toMatchObject({
+        error: "You are not authorized for that action",
+      });
+    });
+
+    test("it accepts a custom unauthorized message", () => {
+      const { error } = createResponder({
+        unauthorizedMessage: "Custom error",
+      });
+
+      expect(error("Unauthorized 401")).toMatchObject({
+        error: "Custom error",
+      });
+    });
+  });
 });
 
 describe("chain", () => {


### PR DESCRIPTION
## Description
As I've been working with the address book code I noticed that there was some extra juggling necessary to respond with the correct error message using `createResponder` in `src/solidClientHelpers/utils.js`. I pulled that logic out of address book and put it in the responder code.

## Changes
- Refactored `addressBook.js` to use the refactored code
- Refactored `createResponder` to respond with an error function that can handle unauthorized requests

## Testing
- run `npm test`
- verify all tests still pass

## Commit checklist

- [x] Includes tests to ensure functionality and prevent regressions.

## Interested parties
@VirginiaBalseiro @solid-akb @ajacksified 

## Notes
I'm not 100% sold on this myself. It does seem like this code does not belong in `addressBook` (with the exception of the configurable message). It does seem like we might want to handle unauthorized requests like this in the error responder because it seems silly to modify the error message provided by the thing responsible for the error message. I can see this pattern possibly getting out of hand but at that point we'd have to question the sanity of using these responders more generally if they're so diverse they defy consolidation.

I should also note that even though all the tests pass, I'm not confident that the UI remains the same. We will now be showing unauthorized errors where we were otherwise deferring to the fetch error. I _think_ this would be a good thing but I'm not confident that is the case.