### PR TITLE
Up test coverage of utils to 100%

### DIFF
--- a/src/solidClientHelpers/utils.test.js
+++ b/src/solidClientHelpers/utils.test.js
@@ -42,6 +42,7 @@ import {
   namespace,
   serializePromises,
   sharedStart,
+  uniqueObjects,
 } from "./utils";
 
 describe("createResponder", () => {
@@ -181,6 +182,10 @@ describe("getTypeName", () => {
 });
 
 describe("isContainerIri", () => {
+  test("it returns false when given undefined", () => {
+    expect(isContainerIri()).toBe(false);
+  });
+
   test("it returns true when the iri ends in /", () => {
     expect(isContainerIri("https://user.dev.inrupt.net/public/")).toEqual(true);
   });
@@ -269,5 +274,19 @@ describe("serializePromises", () => {
     await expect(promiseFactories[0]()).resolves.toBe("example1");
     await expect(promiseFactories[1]()).resolves.toBe("example2");
     await expect(promiseFactories[2]()).resolves.toBe("example3");
+  });
+});
+
+describe("uniqueObjects", () => {
+  test("it returns a unique set of objects", () => {
+    const one = { one: "one" };
+    const two = { two: "two" };
+    const duplicate = { two: "two" };
+    const list = [one, two, duplicate];
+    const uniqueList = uniqueObjects(list);
+
+    expect(uniqueList).toHaveLength(2);
+    expect(uniqueList[0]).toMatchObject(one);
+    expect(uniqueList[1]).toMatchObject(two);
   });
 });


### PR DESCRIPTION
## Description
This PR adds tests to `solidClientHelpers/utils.js` to bring coverage up to 100%.

## Changes
- Added a test to cover passing `undefined` to `isContainerIri`
- Added a test to cover `uniqueObjects`

## Testing
- run `npm test src/solidClientHelpers/utils.test.js`
- verify all tests pass
- verify coverage is 100%

## Commit checklist
- [x] Includes tests to ensure functionality and prevent regressions.

## Interested parties
@VirginiaBalseiro @solid-akb 

## Screenshots/
![coverage](https://user-images.githubusercontent.com/35955/156409825-dff015ba-6aab-4c8a-a16b-d5d0e9c5bfe5.png)
captures
