### PR TITLE
fix: ignore falsy WebID values when loading available pods

### DIFF
--- a/components/pages/index/__snapshots__/index.test.jsx.snap
+++ b/components/pages/index/__snapshots__/index.test.jsx.snap
@@ -1,3 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Index page Renders null if there are no pod iris 1`] = `<DocumentFragment />`;
+
+exports[`Index page Renders null if there is an empty array of pod iris 1`] = `<DocumentFragment />`;

--- a/components/pages/index/index.jsx
+++ b/components/pages/index/index.jsx
@@ -35,9 +35,7 @@ export default function Home() {
   useRedirectIfLoggedOut();
 
   const { session } = useSession();
-  const { webId = "" } = session.info;
-  const { data: podIris = [] } = usePodIrisFromWebId(webId);
-  const [podIri] = podIris;
+  const { data: podIris = [] } = usePodIrisFromWebId(session.info.webId);
 
   useEffect(() => {
     if (previousPage && previousPage !== "/") {
@@ -46,12 +44,12 @@ export default function Home() {
       });
     }
 
-    if (podIri) {
-      router.replace("/resource/[iri]", resourceHref(podIri)).catch((e) => {
+    if (podIris.length > 0) {
+      router.replace("/resource/[iri]", resourceHref(podIris[0])).catch((e) => {
         throw e;
       });
     }
-  }, [podIri, router, previousPage]);
+  }, [podIris, router, previousPage]);
 
   return null;
 }

--- a/components/pages/index/index.test.jsx
+++ b/components/pages/index/index.test.jsx
@@ -63,6 +63,23 @@ describe("Index page", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
+  test("Renders null if there is an empty array of pod iris", () => {
+    nextRouterFns.useRouter.mockReturnValue({
+      replace: jest.fn().mockResolvedValue(undefined),
+    });
+
+    usePodIrisFromWebId.mockReturnValue({
+      data: [],
+    });
+
+    const { asFragment } = render(
+      <TestApp>
+        <IndexPage />
+      </TestApp>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   test("Redirects to the resource page if there is a pod iri", () => {
     const replace = jest.fn().mockResolvedValue(undefined);
 

--- a/src/hooks/usePodIrisFromWebId/index.js
+++ b/src/hooks/usePodIrisFromWebId/index.js
@@ -25,6 +25,11 @@ import { getSolidDataset, getThing, getUrlAll } from "@inrupt/solid-client";
 import { space } from "rdf-namespaces";
 
 async function fetchPodIrisFromWebId(webId, fetch) {
+  // Temporary fix until we can switch to getPodUrlAll in @inrupt/solid-client@1.20.0
+  if (!webId) {
+    return [];
+  }
+
   const profileDoc = await getSolidDataset(webId, { fetch });
   const profile = getThing(profileDoc, webId);
   return getUrlAll(profile, space.storage);


### PR DESCRIPTION
## Description

There was a bug where the `Home` page component would try to load a dataset located at `""` which resulted in an error being through, this happens due to `webId` having been defaulted to `""` if `session.info.webId` isn't present. In theory that shouldn't really happen, but may have still been happening due to the entire page still rendering when you're logged out — this shouldn't be an issue with #437 merged, but this helps make this code just a little more defensive before you can move across to `getPodUrlAll` from `@inrupt/solid-client` v1.20.0 (next release)

This could've been causing some weird bugs that contained complex misdirection.

Additionally doing `getSolidDataset("")` can actually result in oAuth 2.0 / OIDC URL parameters getting stashed in a dataset struct.

## Changes

- Makes `usePodIrisFromWebId` return an empty array if passed a falsy value for the `webid` argument. Arguably this could break if your WebID is "-1", "false" or similar, but given WebID's must be IRIs / URIs, I think we're fine with that.
- Adds some test coverage, even though that code will be deleted shortly.

## Testing

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable. (I don't think it's applicable? There does not appear to be a changelog in this repo)

## Interested parties

@inrupt/apps-developers 

## Notes

## Screenshots/captures
