### PR TITLE
Fix/wrong web profile contacts

### DIFF
--- a/components/contactsList/contactsDrawer/index.test.jsx
+++ b/components/contactsList/contactsDrawer/index.test.jsx
@@ -42,6 +42,7 @@ describe("ContactsDrawer", () => {
         open
         onClose={onClose}
         onDelete={onDelete}
+        selectedContactWebId={profileIri}
         selectedContactName={selectedContactName}
         profileIri={profileIri}
       />
@@ -51,7 +52,6 @@ describe("ContactsDrawer", () => {
 });
 
 describe("Delete contact button confirmation dialog", () => {
-  const testWebId = "testWebId";
   const onClose = () => {};
   const onDelete = () => {};
   const profileIri = "https://example.com/profile#alice";
@@ -65,7 +65,7 @@ describe("Delete contact button confirmation dialog", () => {
           onClose={onClose}
           onDelete={onDelete}
           selectedContactName={selectedContactName}
-          selectedContactWebId={testWebId}
+          selectedContactWebId={profileIri}
           profileIri={profileIri}
         />
       </ConfirmationDialogProvider>
@@ -80,7 +80,7 @@ describe("Delete contact button confirmation dialog", () => {
     await waitFor(() => {
       expect(dialog).toBeInTheDocument();
       expect(dialogText).toBeInTheDocument();
-      expect(dialogText).toHaveTextContent("testWebId");
+      expect(dialogText).toHaveTextContent(profileIri);
     });
   });
 
@@ -93,7 +93,7 @@ describe("Delete contact button confirmation dialog", () => {
           onClose={onClose}
           onDelete={onDelete}
           selectedContactName={selectedContactName}
-          selectedContactWebId={testWebId}
+          selectedContactWebId={profileIri}
           profileIri={profileIri}
         />
       </ConfirmationDialogProvider>

--- a/components/pages/contacts/show/__snapshots__/index.test.jsx.snap
+++ b/components/pages/contacts/show/__snapshots__/index.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`Contact show page Renders the Contact show page 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                http://example.com/webId#me
+                https://example.com/profile/card#me
               </a>
             </h3>
           </div>

--- a/components/pages/privacy/resourceAccess/show/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/resourceAccess/show/__snapshots__/index.test.jsx.snap
@@ -66,7 +66,7 @@ exports[`Resource access show page it renders a resource access page for a perso
                 rel="noreferrer"
                 target="_blank"
               >
-                http://example.com/webId#me
+                http://bob.example.com/bob#me
               </a>
             </h3>
           </div>

--- a/components/pages/privacy/resourceAccess/show/index.test.jsx
+++ b/components/pages/privacy/resourceAccess/show/index.test.jsx
@@ -62,7 +62,7 @@ describe("Resource access show page", () => {
     );
     await waitFor(() => {
       expect(getAllByText("Bob")).toHaveLength(2);
-      expect(getAllByText("http://example.com/webId#me")).toHaveLength(1);
+      expect(getAllByText(bobWebIdUrl)).toHaveLength(1);
     });
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/pages/privacy/show/__snapshots__/index.test.jsx.snap
+++ b/components/pages/privacy/show/__snapshots__/index.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`Agent show page Renders the Agent show page 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                http://example.com/webId#me
+                https://example.com/profile/card#me
               </a>
             </h3>
           </div>

--- a/components/profile/__snapshots__/index.test.jsx.snap
+++ b/components/profile/__snapshots__/index.test.jsx.snap
@@ -54,7 +54,7 @@ exports[`Profile renders a person profile 1`] = `
                 rel="noreferrer"
                 target="_blank"
               >
-                http://example.com/webId#me
+                https://example.com/profile/card#me
               </a>
             </h3>
           </div>

--- a/components/profile/personAvatar/__snapshots__/index.test.jsx.snap
+++ b/components/profile/personAvatar/__snapshots__/index.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`Person Avatar renders a person avatar 1`] = `
           rel="noreferrer"
           target="_blank"
         >
-          http://example.com/webId#me
+          https://example.com/profile/card#me
         </a>
       </h3>
     </div>

--- a/components/profile/personAvatar/index.jsx
+++ b/components/profile/personAvatar/index.jsx
@@ -67,7 +67,7 @@ export default function PersonAvatar({ profileIri }) {
             rel="noreferrer"
             target="_blank"
           >
-            {session.info.webId}
+            {profileIri}
           </a>
         </h3>
       </Box>


### PR DESCRIPTION
## Description

This PR fixes two issues related to WebIDs/Contacts/Profiles:
- it clears a warning regarding a missing WebID prop needed for a child component of ContactsDrawer
- it fixes the incorrect WebID being displayed in profiles (the WebId displayed was for the logged in user instead of the WebID associated with the profile being displayed).

## Testing
- Verify profiles display the correct WebID

## Commit checklist

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

