### PR TITLE
Try getProfileAll and fallback to old profile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@datapunt/matomo-tracker-react": "^0.3.1",
         "@date-io/date-fns": "^1.3.13",
         "@inrupt/prism-react-components": "^0.13.9",
-        "@inrupt/solid-client": "^1.17.0",
+        "@inrupt/solid-client": "^1.20.1",
         "@inrupt/solid-client-access-grants": "^0.4.1",
         "@inrupt/solid-client-authn-browser": "^1.11.5",
         "@inrupt/solid-ui-react": "^2.6.1",
@@ -1468,12 +1468,12 @@
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.17.0.tgz",
-      "integrity": "sha512-XJMSrzlk0X+u8kMnCVIWp+k9mOtT1xqcB800WtmGQ6NJEri6ddbs8/XWNZP9n6jVN8d5PCiktpIh3+nm5jW44A==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.20.1.tgz",
+      "integrity": "sha512-io8Aw6SHm2OeTtvy4MuqNQmFwCyzpwWz5ZAWfyDgGqFEvc6vKv3bYr4YBY5jGh0uI4LHSJ9iFd5PKbVdmD7c9A==",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.0.1",
+        "@rdfjs/types": "^1.1.0",
         "@types/n3": "^1.10.0",
         "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
@@ -2313,9 +2313,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
       "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["android"],
+      "os": [
+        "android"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2324,9 +2328,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
       "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2335,9 +2343,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
       "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2346,9 +2358,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
       "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
-      "cpu": ["arm"],
+      "cpu": [
+        "arm"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2357,9 +2373,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
       "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2368,9 +2388,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
       "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2379,9 +2403,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
       "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2390,9 +2418,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
       "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["linux"],
+      "os": [
+        "linux"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2401,9 +2433,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
       "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
-      "cpu": ["arm64"],
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2412,9 +2448,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
       "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
-      "cpu": ["ia32"],
+      "cpu": [
+        "ia32"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2423,9 +2463,13 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz",
       "integrity": "sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==",
-      "cpu": ["x64"],
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
-      "os": ["win32"],
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">= 10"
       }
@@ -2488,9 +2532,9 @@
       }
     },
     "node_modules/@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -6721,7 +6765,9 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": ["node >=0.6.0"]
+      "engines": [
+        "node >=0.6.0"
+      ]
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6933,7 +6979,9 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "hasInstallScript": true,
       "optional": true,
-      "os": ["darwin"],
+      "os": [
+        "darwin"
+      ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -14369,7 +14417,9 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": ["node >=0.6.0"],
+      "engines": [
+        "node >=0.6.0"
+      ],
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -15809,12 +15859,12 @@
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.17.0.tgz",
-      "integrity": "sha512-XJMSrzlk0X+u8kMnCVIWp+k9mOtT1xqcB800WtmGQ6NJEri6ddbs8/XWNZP9n6jVN8d5PCiktpIh3+nm5jW44A==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.20.1.tgz",
+      "integrity": "sha512-io8Aw6SHm2OeTtvy4MuqNQmFwCyzpwWz5ZAWfyDgGqFEvc6vKv3bYr4YBY5jGh0uI4LHSJ9iFd5PKbVdmD7c9A==",
       "requires": {
         "@rdfjs/dataset": "^1.1.0",
-        "@rdfjs/types": "^1.0.1",
+        "@rdfjs/types": "^1.1.0",
         "@types/n3": "^1.10.0",
         "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
@@ -16537,9 +16587,9 @@
       }
     },
     "@rdfjs/types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.0.1.tgz",
-      "integrity": "sha512-YxVkH0XrCNG3MWeZxfg596GFe+oorTVusmNxRP6ZHTsGczZ8AGvG3UchRNkg3Fy4MyysI7vBAA5YZbESL+VmHQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@datapunt/matomo-tracker-react": "^0.3.1",
     "@date-io/date-fns": "^1.3.13",
     "@inrupt/prism-react-components": "^0.13.9",
-    "@inrupt/solid-client": "^1.17.0",
+    "@inrupt/solid-client": "^1.20.1",
     "@inrupt/solid-client-access-grants": "^0.4.1",
     "@inrupt/solid-client-authn-browser": "^1.11.5",
     "@inrupt/solid-ui-react": "^2.6.1",

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -94,27 +94,21 @@ export function packageProfile(webId, dataset, pods, inbox) {
 }
 
 export async function fetchProfile(webId, fetch) {
-  try {
-    const profiles = await getProfileAll(webId, { fetch });
-    const {
-      webIdProfile,
-      altProfileAll: [altProfile],
-    } = profiles;
+  const profiles = await getProfileAll(webId);
+  const { webIdProfile, altProfileAll } = profiles;
 
-    let profileDataset = webIdProfile;
-    let webIdUrl = webId;
+  let profileDataset = webIdProfile;
+  let webIdUrl = webId;
 
-    if (altProfile) {
-      webIdUrl = getSourceUrl(altProfile);
-      profileDataset = altProfile;
-    }
-
-    const pods = getUrlAll(getThing(webIdProfile, webId), space.storage);
-    const inbox = getUrlAll(getThing(webIdProfile, webId), ldp.inbox);
-
-    return packageProfile(webIdUrl, profileDataset, pods, inbox);
-  } catch (e) {
-    const dataset = await getSolidDataset(webId, fetch);
-    return packageProfile(webId, dataset);
+  if (altProfileAll.length >= 1) {
+    // FIXME: Correctly handle multiple profiles
+    const [altProfile] = altProfileAll;
+    webIdUrl = getSourceUrl(altProfile);
+    profileDataset = altProfile;
   }
+
+  const pods = getUrlAll(getThing(webIdProfile, webId), space.storage);
+  const inbox = getUrlAll(getThing(webIdProfile, webId), ldp.inbox);
+
+  return packageProfile(webIdUrl, profileDataset, pods, inbox);
 }

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -94,22 +94,27 @@ export function packageProfile(webId, dataset, pods, inbox) {
 }
 
 export async function fetchProfile(webId, fetch) {
-  const profiles = await getProfileAll(webId, { fetch });
-  const {
-    webIdProfile,
-    altProfileAll: [altProfile],
-  } = profiles;
+  try {
+    const profiles = await getProfileAll(webId, { fetch });
+    const {
+      webIdProfile,
+      altProfileAll: [altProfile],
+    } = profiles;
 
-  let profileDataset = webIdProfile;
-  let webIdUrl = webId;
+    let profileDataset = webIdProfile;
+    let webIdUrl = webId;
 
-  if (altProfile) {
-    webIdUrl = getSourceUrl(altProfile);
-    profileDataset = altProfile;
+    if (altProfile) {
+      webIdUrl = getSourceUrl(altProfile);
+      profileDataset = altProfile;
+    }
+
+    const pods = getUrlAll(getThing(webIdProfile, webId), space.storage);
+    const inbox = getUrlAll(getThing(webIdProfile, webId), ldp.inbox);
+
+    return packageProfile(webIdUrl, profileDataset, pods, inbox);
+  } catch (e) {
+    const dataset = await getSolidDataset(webId, fetch);
+    return packageProfile(webId, dataset);
   }
-
-  const pods = getUrlAll(getThing(webIdProfile, webId), space.storage);
-  const inbox = getUrlAll(getThing(webIdProfile, webId), ldp.inbox);
-
-  return packageProfile(webIdUrl, profileDataset, pods, inbox);
 }


### PR DESCRIPTION
## Description
This PR fixes an error condition in the `getProfileAll` fetch. When the function errors out, we fall back to the minimal webId profile.

## Changes
- Update `@inrupt/solid-client`
- Fallback to the webId profile when `getProfileAll` fails
 
## Testing
- Navigate to the add contact page
- Add a webId that is known not to contain profile info (old profile)
- Verify you can successfully add the contact

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.

## Interested parties
@ThisIsMissEm @solid-akb @VirginiaBalseiro 

## Notes
It seems like `getProfileAll` should be responsible for this fallback. Either that, or the SDK is not responsible for finding a "profile" at all.

## Screenshots/captures
![Peek 2022-03-17 16-05](https://user-images.githubusercontent.com/35955/158908312-07268bb9-9368-4a2f-a914-7f8be3a046d7.gif)

