### PR TITLE
Removed forbid prop types

### DIFF
--- a/__testUtils/testApp.jsx
+++ b/__testUtils/testApp.jsx
@@ -49,6 +49,5 @@ TestApp.defaultProps = {
 
 TestApp.propTypes = {
   children: T.node.isRequired,
-  // eslint-disable-next-line react/forbid-prop-types
-  session: T.object,
+  session: T.oneOfType([Object]),
 };

--- a/__testUtils/withTheme.jsx
+++ b/__testUtils/withTheme.jsx
@@ -36,8 +36,7 @@ export default function WithTheme(props) {
 }
 
 WithTheme.propTypes = {
-  // eslint-disable-next-line react/forbid-prop-types
-  theme: T.object,
+  theme: T.oneOfType([Object]),
   children: T.node.isRequired,
 };
 

--- a/components/consentRequestForm/requestSection/index.jsx
+++ b/components/consentRequestForm/requestSection/index.jsx
@@ -486,6 +486,5 @@ export default function RequestSection(props) {
 RequestSection.propTypes = {
   agentName: T.string.isRequired,
   setSelectedAccess: T.func.isRequired,
-  // eslint-disable-next-line react/forbid-prop-types
-  sectionDetails: T.object.isRequired,
+  sectionDetails: T.oneOfType([Object]).isRequired,
 };

--- a/components/groupDetails/groupDetailsModal/index.jsx
+++ b/components/groupDetails/groupDetailsModal/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint react/forbid-prop-types: off, react/jsx-props-no-spreading: off */
+/* eslint react/jsx-props-no-spreading: off */
 
 import React, { useContext, useEffect, useState } from "react";
 import T from "prop-types";

--- a/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
 
 import React, { useState, useContext } from "react";
 import PropTypes from "prop-types";

--- a/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/addAgentButton/index.jsx
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-
 import React, { useState, useContext } from "react";
 import PropTypes from "prop-types";
 import { Modal } from "@material-ui/core";

--- a/components/resourceDetails/resourceSharing/advancedSharingButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/advancedSharingButton/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { createStyles, Modal } from "@material-ui/core";

--- a/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/agentProfileDetails/index.jsx
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
 /* eslint-disable react/jsx-props-no-spreading */
 
 import React from "react";

--- a/components/resourceDetails/resourceSharing/agentAccess/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccess/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React, { useContext, useEffect, useState } from "react";
 import T from "prop-types";
 import { Button, CircularProgress, createStyles } from "@material-ui/core";
@@ -177,7 +175,7 @@ export default function AgentAccess({ permission }) {
 }
 
 AgentAccess.propTypes = {
-  permission: T.object.isRequired,
+  permission: T.oneOfType([Object]).isRequired,
 };
 
 AgentAccess.defaultProps = {};

--- a/components/resourceDetails/resourceSharing/agentAccessOld/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentAccessOld/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 // TODO: this component is kept here to keep the old Permissions accordion working.
 // It can be removed after the old permissions accordion is gone.
 
@@ -303,7 +301,7 @@ export default function AgentAccess({ onLoading, permission: { acl, webId } }) {
 }
 
 AgentAccess.propTypes = {
-  permission: T.object.isRequired,
+  permission: T.oneOfType([Object]).isRequired,
   onLoading: T.func,
 };
 

--- a/components/resourceDetails/resourceSharing/agentPickerModal/addWebIdButton/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/addWebIdButton/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React from "react";
 import PropTypes from "prop-types";
 import { createStyles } from "@material-ui/core";

--- a/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/index.jsx
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
 // FIXME: ignoring this file to fix the build
 /* istanbul ignore file */
 

--- a/components/resourceDetails/resourceSharing/agentPickerModal/webIdCheckbox/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentPickerModal/webIdCheckbox/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React, { useCallback, useContext } from "react";
 import { useThing } from "@inrupt/solid-ui-react";
 import { getUrl } from "@inrupt/solid-client";

--- a/components/resourceDetails/resourceSharing/agentsSearchBar/index.jsx
+++ b/components/resourceDetails/resourceSharing/agentsSearchBar/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React from "react";
 import PropTypes from "prop-types";
 import { useBem } from "@solid/lit-prism-patterns";

--- a/components/resourceDetails/resourceSharing/index.jsx
+++ b/components/resourceDetails/resourceSharing/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable camelcase, no-console, react/forbid-prop-types */
+/* eslint-disable camelcase, no-console */
 
 import React, { useState } from "react";
 import T from "prop-types";

--- a/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
+++ b/components/resourceDetails/resourceSharing/mobileAgentsSearchBar/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { useBem } from "@solid/lit-prism-patterns";

--- a/components/resourceDetails/resourceSharing/policiesDescriptions/index.jsx
+++ b/components/resourceDetails/resourceSharing/policiesDescriptions/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React from "react";
 
 export const ViewersDescription = () => (

--- a/components/tabs/index.jsx
+++ b/components/tabs/index.jsx
@@ -19,8 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-/* eslint-disable react/forbid-prop-types */
-
 import React from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";

--- a/constants/propTypes.js
+++ b/constants/propTypes.js
@@ -72,8 +72,7 @@ export const profile = PropTypes.shape({
 export const swrResponse = PropTypes.shape({
   // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.any,
-  // eslint-disable-next-line react/forbid-prop-types
-  error: PropTypes.object,
+  error: PropTypes.oneOfType([Object]),
   isValidating: PropTypes.bool.isRequired,
   mutate: PropTypes.func.isRequired,
 });

--- a/src/contexts/accessControlContext/index.jsx
+++ b/src/contexts/accessControlContext/index.jsx
@@ -43,8 +43,7 @@ AccessControlProvider.defaultProps = {
 
 AccessControlProvider.propTypes = {
   children: T.node.isRequired,
-  // eslint-disable-next-line react/forbid-prop-types
-  accessControl: T.object,
+  accessControl: T.oneOfType([Object]),
   accessControlType: T.string,
 };
 

--- a/src/contexts/consentRequestContext/index.jsx
+++ b/src/contexts/consentRequestContext/index.jsx
@@ -44,8 +44,7 @@ function ConsentRequestProvider({
 
 ConsentRequestProvider.propTypes = {
   children: T.node.isRequired,
-  // eslint-disable-next-line react/forbid-prop-types
-  consentRequest: T.object,
+  consentRequest: T.oneOfType([Object]),
   setConsentRequest: T.func,
 };
 


### PR DESCRIPTION
## Description
We used `eslint-disable-next-line react/forbid-prop-types` pretty gratuitously throughout the code. Removed the instance when it wasn't protecting anything and when we used T.Object. From now on we should use `T.oneOfType([Object])`
## Changes
Deleted extra `eslint-disable-next-line react/forbid-prop-types` and replaced T.Object with `T.oneOfType([Object])` which does not throw a warning.
## Testing
NA
## Commit checklist

- [ NA] All acceptance criteria are met.
- [ NA] Includes tests to ensure functionality and prevent regressions.
- [x ] Relevant documentation, if any, has been written/updated.
- [ NA] The changelog has been updated, if applicable.

## Interested parties

## Notes
Use `T.oneOfType([Object])` when you want to pass in an Object as a prop.

## Screenshots/captures
