### PR TITLE
remove unnecessary await before act

### DIFF
--- a/src/authentication/useReturnUrl.test.js
+++ b/src/authentication/useReturnUrl.test.js
@@ -77,7 +77,7 @@ describe("useReturnUrl", () => {
 
     const { result } = renderHook(() => useReturnUrl());
 
-    await act(() => {
+    act(() => {
       result.current.restore();
     });
 
@@ -94,7 +94,7 @@ describe("useReturnUrl", () => {
 
     const { result } = renderHook(() => useReturnUrl());
 
-    await act(() => {
+    act(() => {
       result.current.restore();
     });
 


### PR DESCRIPTION
This PR removes `await` when using act in tests in the `useReturnUrl` hook because it was causing a console warning. 

`act` cannot be awaited unless used in its sync version: https://reactjs.org/docs/testing-recipes.html#act