### PR TITLE
fix: ignore errors thrown from localstorage when persisting the returnTo URL

### DIFF
--- a/src/authentication/useReturnUrl.js
+++ b/src/authentication/useReturnUrl.js
@@ -29,7 +29,12 @@ const useReturnUrl = () => {
 
   const persist = useCallback(() => {
     if (router.query.returnTo && router.query.returnTo.startsWith("/")) {
-      localStorage.setItem(RETURN_TO_PAGE_KEY, router.query.returnTo);
+      try {
+        localStorage.setItem(RETURN_TO_PAGE_KEY, router.query.returnTo);
+      } catch {
+        // silently fail if persisting the return to URL fails, it sucks but
+        // there isn't really a "good" user experience to have here.
+      }
     }
   }, [router]);
 

--- a/src/authentication/useReturnUrl.test.js
+++ b/src/authentication/useReturnUrl.test.js
@@ -68,6 +68,22 @@ describe("useReturnUrl", () => {
     expect(setItemSpy).not.toHaveBeenCalled();
   });
 
+  it("should not persist if localStorage returns an error", () => {
+    useRouter.mockReturnValue({ query: { returnTo: "/some/path" } });
+    const setItemSpy = jest.spyOn(window.localStorage, "setItem");
+    setItemSpy.mockImplementation(() => {
+      throw new Error("Storage is full");
+    });
+
+    const { result } = renderHook(() => useReturnUrl());
+
+    act(() => {
+      result.current.persist();
+    });
+
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+
   it("restores the route from localstorage", async () => {
     const replaceMock = jest.fn();
     useRouter.mockReturnValue({ replace: replaceMock });


### PR DESCRIPTION
## Description

I didn't realise `localStorage.setItem` could throw, but apparently it can, so this makes that error silent. This fixes POD-BROWSER-2D9 on Sentry.

## Changes

Just adds a try/catch

## Testing

Additional test case has been added.

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [x] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable. — Is this really changelog worthy?

## Interested parties

## Notes

## Screenshots/captures
