### PR TITLE
changed PT to object and added eslint disable

### DIFF
--- a/__testUtils/testApp.jsx
+++ b/__testUtils/testApp.jsx
@@ -49,5 +49,6 @@ TestApp.defaultProps = {
 
 TestApp.propTypes = {
   children: T.node.isRequired,
-  session: T.oneOfType([Object]),
+  // eslint-disable-next-line react/forbid-prop-types
+  session: T.object,
 };

--- a/__testUtils/withTheme.jsx
+++ b/__testUtils/withTheme.jsx
@@ -36,7 +36,8 @@ export default function WithTheme(props) {
 }
 
 WithTheme.propTypes = {
-  theme: T.oneOfType([Object]),
+  // eslint-disable-next-line react/forbid-prop-types
+  theme: T.object,
   children: T.node.isRequired,
 };
 

--- a/components/consentRequestForm/requestSection/index.jsx
+++ b/components/consentRequestForm/requestSection/index.jsx
@@ -486,5 +486,6 @@ export default function RequestSection(props) {
 RequestSection.propTypes = {
   agentName: T.string.isRequired,
   setSelectedAccess: T.func.isRequired,
-  sectionDetails: T.oneOfType([Object]).isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  sectionDetails: T.object.isRequired,
 };

--- a/constants/propTypes.js
+++ b/constants/propTypes.js
@@ -72,7 +72,8 @@ export const profile = PropTypes.shape({
 export const swrResponse = PropTypes.shape({
   // eslint-disable-next-line react/forbid-prop-types
   data: PropTypes.any,
-  error: PropTypes.oneOfType([Object]),
+  // eslint-disable-next-line react/forbid-prop-types
+  error: PropTypes.object,
   isValidating: PropTypes.bool.isRequired,
   mutate: PropTypes.func.isRequired,
 });

--- a/src/contexts/consentRequestContext/index.jsx
+++ b/src/contexts/consentRequestContext/index.jsx
@@ -44,7 +44,8 @@ function ConsentRequestProvider({
 
 ConsentRequestProvider.propTypes = {
   children: T.node.isRequired,
-  consentRequest: T.oneOfType([Object]),
+  // eslint-disable-next-line react/forbid-prop-types
+  consentRequest: T.object,
   setConsentRequest: T.func,
 };
 


### PR DESCRIPTION
## Description
Prop types that were Object changed back to oneOfType([Object]) because oneOfType([Object]) was breaking unit tests (and is incorrect). Revisit react/forbid-prop-types comments at a later time. 
## Changes

## Testing

## Commit checklist

- [ ] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

## Interested parties

## Notes

## Screenshots/captures
