### PR TITLE
Feat: redirect user to main page if not data subject of access request

### DIFF
--- a/__testUtils/mockConsentRequestDetails.js
+++ b/__testUtils/mockConsentRequestDetails.js
@@ -19,6 +19,39 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+export function getConsentRequestDetailsOneResource() {
+  return {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://w3id.org/security/suites/ed25519-2020/v1",
+      "https://consent.pod.inrupt.com/credentials/v1",
+    ],
+    id: "https://consent.pod.inrupt.com/vc/53973727-f4d0-9e8dbdc041fd",
+    type: ["VerifiableCredential", "SolidCredential", "SolidConsentRequest"],
+    issuer: "https://consent.pod.inrupt.com",
+    issuanceDate: "2021-05-26T16:40:03Z",
+    expirationDate: "2022-06-23T16:40:03Z",
+    credentialSubject: {
+      id: "https://mockappurl.com",
+      inbox: "https://mockappurl.com/inbox/",
+      hasConsent: {
+        mode: ["Read", "Write"],
+        hasStatus: "ConsentStatusRequested",
+        forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
+        forPurpose: "https://example.com/SomeSpecificPurpose",
+        isConsentForDataSubject: "https://id.inrupt.com/someWebId",
+      },
+      proof: {
+        created: "2021-05-26T16:40:03.009Z",
+        proofPurpose: "assertionMethod",
+        proofValue: "eqp8h_kL1DwJCpn65z-d1Arnysx6b11...jb8j0MxUCc1uDQ",
+        type: "Ed25519Signature2020",
+        verificationMethod: "https://consent.pod.inrupt.com/key/396f686b4ec",
+      },
+    },
+  };
+}
+
 export function getConsentRequestDetailsOnePurpose() {
   return {
     "@context": [
@@ -96,24 +129,28 @@ function getConsentRequestDetails() {
             "https://example.com/SomeSpecificPurposeA",
             "https://example.com/SomeSpecificPurposeB",
           ],
+          isConsentForDataSubject: "https://id.inrupt.com/someWebId",
         },
         {
           mode: ["Read"],
           hasStatus: "ConsentStatusRequested",
           forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
+          isConsentForDataSubject: "https://id.inrupt.com/someWebId",
         },
         {
           mode: ["Append"],
           hasStatus: "ConsentStatusRequested",
           forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
+          isConsentForDataSubject: "https://id.inrupt.com/someWebId",
         },
         {
           mode: ["Control"],
           hasStatus: "ConsentStatusRequested",
           forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
           forPurpose: "https://example.com/SomeSpecificPurpose",
+          isConsentForDataSubject: "https://id.inrupt.com/someWebId",
         },
       ],
     },

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -227,7 +227,7 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
   };
 
   if (resourceOwnerWebId !== session.info.webId) {
-    alertError("You don't have access to that.");
+    alertError("You don't have access to that");
     router.push("/");
   }
 

--- a/components/consentRequestForm/index.jsx
+++ b/components/consentRequestForm/index.jsx
@@ -45,6 +45,7 @@ import RequestSection from "./requestSection";
 import DateInput from "./dateInput";
 import styles from "./styles";
 import {
+  getDataSubjectWebId,
   getExpiryDate,
   getPurposeUrls,
   getRequestedAccesses,
@@ -53,6 +54,7 @@ import {
 } from "../../src/models/consent/request";
 import ConfirmationDialogContext from "../../src/contexts/confirmationDialogContext";
 import ConfirmationDialog from "../confirmationDialog";
+import AlertContext from "../../src/contexts/alertContext";
 import PurposeCheckbox from "./purposeCheckBox";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
@@ -78,11 +80,11 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
   const { consentRequest } = useContext(ConsentRequestContext);
   const [selectedAccess, setSelectedAccess] = useState([]);
   const purposes = getPurposeUrls(consentRequest);
+  const resourceOwnerWebId = getDataSubjectWebId(consentRequest);
   const [selectedPurposes, setSelectedPurposes] = useState([]);
   const selectedResources = selectedAccess.map(
     ({ resourceIri }) => resourceIri
   );
-
   const { agentName } = agentDetails || null;
 
   const {
@@ -96,6 +98,8 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
     setOmitCancelButton,
   } = useContext(ConfirmationDialogContext);
   const [confirmationSetup, setConfirmationSetup] = useState(false);
+
+  const { alertError } = useContext(AlertContext);
 
   const requestedAccesses = getRequestedAccesses(consentRequest);
   const expirationDate = getExpiryDate(consentRequest);
@@ -221,6 +225,11 @@ export default function ConsentRequestForm({ agentDetails, agentWebId }) {
       );
     }
   };
+
+  if (resourceOwnerWebId !== session.info.webId) {
+    alertError("You don't have access to that.");
+    router.push("/");
+  }
 
   return (
     <>

--- a/components/consentRequestForm/index.test.jsx
+++ b/components/consentRequestForm/index.test.jsx
@@ -42,7 +42,10 @@ import {
   TESTCAFE_ID_CONFIRM_BUTTON,
 } from "../confirmationDialog";
 import { ConfirmationDialogProvider } from "../../src/contexts/confirmationDialogContext";
+import { AlertProvider } from "../../src/contexts/alertContext";
 import { getConsentRequestDetailsOnePurpose } from "../../__testUtils/mockConsentRequestDetails";
+import mockSessionContextProvider from "../../__testUtils/mockSessionContextProvider";
+import mockSession from "../../__testUtils/mockSession";
 import { TESTCAFE_ID_PURPOSE_CHECKBOX_INPUT } from "./purposeCheckBox";
 import { TESTCAFE_ID_CONSENT_ACCESS_SWITCH } from "./requestSection";
 import useContainer from "../../src/hooks/useContainer";
@@ -61,6 +64,7 @@ const consentRequestWithOnePurpose = getConsentRequestDetailsOnePurpose();
 const ConsentRequestContextProviderOnePurpose = mockConsentRequestContext(
   consentRequestWithOnePurpose
 );
+const SessionProvider = mockSessionContextProvider(mockSession());
 const agentDetails = {
   agentName: "Mock App",
   agentUrl: "http://mockappurl.com",
@@ -90,6 +94,22 @@ describe("Consent Request Form", () => {
         "https://pod.inrupt.com/alice/private/data/data-2",
         "https://pod.inrupt.com/alice/private/data/data-3",
       ]);
+  });
+
+  it("redirects user if not data subject of access request", async () => {
+    const { getByText } = renderWithTheme(
+      <SessionProvider>
+        <ConsentRequestContextProvider>
+          <ConsentRequestForm
+            agentDetails={agentDetails}
+            agentWebId={agentWebId}
+          />
+        </ConsentRequestContextProvider>
+      </SessionProvider>
+    );
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/");
+    });
   });
 
   it("Renders a consent request form with multiple purposes", async () => {

--- a/components/pages/privacy/access/requests/index.test.jsx
+++ b/components/pages/privacy/access/requests/index.test.jsx
@@ -59,7 +59,10 @@ describe("Consent Page", () => {
     });
 
     const fetch = jest.fn();
-    const session = { fetch };
+    const session = {
+      fetch,
+      info: { webId: "https://id.inrupt.com/someWebId" },
+    };
     const SessionProvider = mockSessionContextProvider(session);
 
     jest.spyOn(resourceHelpers, "getProfileResource").mockResolvedValue({

--- a/src/models/consent/request/index.js
+++ b/src/models/consent/request/index.js
@@ -65,6 +65,12 @@ export function getRequestorWebId(consentRequest) {
   return consentRequest?.credentialSubject?.id;
 }
 
+export function getDataSubjectWebId(consentRequest) {
+  return Array.isArray(consentRequest?.credentialSubject?.hasConsent)
+    ? consentRequest?.credentialSubject?.hasConsent[0].isConsentForDataSubject
+    : consentRequest?.credentialSubject?.hasConsent?.isConsentForDataSubject;
+}
+
 export function getVcId(vc) {
   return vc?.id;
 }

--- a/src/models/consent/request/index.test.js
+++ b/src/models/consent/request/index.test.js
@@ -21,8 +21,14 @@
 
 import getConsentRequestDetails, {
   getConsentRequestDetailsOnePurpose,
+  getConsentRequestDetailsOneResource,
 } from "../../../../__testUtils/mockConsentRequestDetails";
-import { getExpiryDate, getPurposeUrls, getRequestedAccesses } from "./index";
+import {
+  getDataSubjectWebId,
+  getExpiryDate,
+  getPurposeUrls,
+  getRequestedAccesses,
+} from "./index";
 
 const consentRequest = getConsentRequestDetails();
 const consentRequestOnePurpose = getConsentRequestDetailsOnePurpose();
@@ -67,25 +73,41 @@ describe("getRequestedAccesses", () => {
           "https://example.com/SomeSpecificPurposeA",
           "https://example.com/SomeSpecificPurposeB",
         ],
+        isConsentForDataSubject: "https://id.inrupt.com/someWebId",
       },
       {
         mode: ["Read"],
         hasStatus: "ConsentStatusRequested",
         forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
         forPurpose: "https://example.com/SomeSpecificPurpose",
+        isConsentForDataSubject: "https://id.inrupt.com/someWebId",
       },
       {
         mode: ["Append"],
         hasStatus: "ConsentStatusRequested",
         forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
         forPurpose: "https://example.com/SomeSpecificPurpose",
+        isConsentForDataSubject: "https://id.inrupt.com/someWebId",
       },
       {
         mode: ["Control"],
         hasStatus: "ConsentStatusRequested",
         forPersonalData: ["https://pod.inrupt.com/alice/private/data"],
         forPurpose: "https://example.com/SomeSpecificPurpose",
+        isConsentForDataSubject: "https://id.inrupt.com/someWebId",
       },
     ]);
+  });
+});
+
+describe("getDataSubjectWebId", () => {
+  it("returns data subject WebId for request with multiple resources", () => {
+    const resourceOwnerWebId = getDataSubjectWebId(consentRequest);
+    expect(resourceOwnerWebId).toEqual("https://id.inrupt.com/someWebId");
+  });
+  it("returns data subject WebId for request with one resource", () => {
+    const oneResourceRequest = getConsentRequestDetailsOneResource();
+    const resourceOwnerWebId = getDataSubjectWebId(oneResourceRequest);
+    expect(resourceOwnerWebId).toEqual("https://id.inrupt.com/someWebId");
   });
 });


### PR DESCRIPTION
## Description

- add check for resource owner WebID and redirect/display alert

- update tests and mock access requests

## Testing
- go to https://test-app-access-grants.vercel.app/
- generate a request
- make sure you are logged in to PB with a WebID that is different from the resource owner you inputted on the demo app to generate the request
- once redirected, grab the section of the URL starting from privacy/...
- go to the Vercel deployment of this PR and append that to the URL
- verify a red toast is displayed and you are redirected to the main PB page
- log out of PB and log in as the resource owner
- navigate to the request page again (use the same one you used before)
- verify you can see the request and everything works as intended

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
