### PR TITLE
Copy resource link

### DIFF
--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -536,12 +536,13 @@ exports[`Container view renders NoControlError if it fails to get access control
                         <li
                           class="PodBrowser-action-menu__item"
                         >
-                          <p
-                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          <button
+                            class="PodBrowser-action-menu__trigger"
                             data-testid="resource-address-copy-tooltip"
+                            type="button"
                           >
                             COPY LINK
-                          </p>
+                          </button>
                         </li>
                         <li
                           class="PodBrowser-action-menu__item"
@@ -1120,12 +1121,13 @@ exports[`Container view renders a table 1`] = `
                         <li
                           class="PodBrowser-action-menu__item"
                         >
-                          <p
-                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          <button
+                            class="PodBrowser-action-menu__trigger"
                             data-testid="resource-address-copy-tooltip"
+                            type="button"
                           >
                             COPY LINK
-                          </p>
+                          </button>
                         </li>
                         <li
                           class="PodBrowser-action-menu__item"
@@ -1763,12 +1765,13 @@ exports[`Container view renders a table for parent container if iri is a resourc
                         <li
                           class="PodBrowser-action-menu__item"
                         >
-                          <p
-                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          <button
+                            class="PodBrowser-action-menu__trigger"
                             data-testid="resource-address-copy-tooltip"
+                            type="button"
                           >
                             COPY LINK
-                          </p>
+                          </button>
                         </li>
                         <li
                           class="PodBrowser-action-menu__item"

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -538,7 +538,7 @@ exports[`Container view renders NoControlError if it fails to get access control
                         >
                           <p
                             class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                            data-testid="pod-indicator-copy-tooltip"
+                            data-testid="resource-address-copy-tooltip"
                           >
                             COPY LINK
                           </p>
@@ -1122,7 +1122,7 @@ exports[`Container view renders a table 1`] = `
                         >
                           <p
                             class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                            data-testid="pod-indicator-copy-tooltip"
+                            data-testid="resource-address-copy-tooltip"
                           >
                             COPY LINK
                           </p>
@@ -1765,7 +1765,7 @@ exports[`Container view renders a table for parent container if iri is a resourc
                         >
                           <p
                             class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                            data-testid="pod-indicator-copy-tooltip"
+                            data-testid="resource-address-copy-tooltip"
                           >
                             COPY LINK
                           </p>

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -536,6 +536,16 @@ exports[`Container view renders NoControlError if it fails to get access control
                         <li
                           class="PodBrowser-action-menu__item"
                         >
+                          <p
+                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                            data-testid="pod-indicator-copy-tooltip"
+                          >
+                            COPY LINK
+                          </p>
+                        </li>
+                        <li
+                          class="PodBrowser-action-menu__item"
+                        >
                           <button
                             class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                             data-testid="delete-resource-button"
@@ -543,16 +553,6 @@ exports[`Container view renders NoControlError if it fails to get access control
                           >
                             Delete
                           </button>
-                        </li>
-                        <li
-                          class="PodBrowser-action-menu__item"
-                        >
-                          <p
-                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                            data-testid="pod-indicator-copy-tooltip"
-                          >
-                            COPY LINK
-                          </p>
                         </li>
                       </ul>
                     </div>
@@ -1120,6 +1120,16 @@ exports[`Container view renders a table 1`] = `
                         <li
                           class="PodBrowser-action-menu__item"
                         >
+                          <p
+                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                            data-testid="pod-indicator-copy-tooltip"
+                          >
+                            COPY LINK
+                          </p>
+                        </li>
+                        <li
+                          class="PodBrowser-action-menu__item"
+                        >
                           <button
                             class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                             data-testid="delete-resource-button"
@@ -1127,16 +1137,6 @@ exports[`Container view renders a table 1`] = `
                           >
                             Delete
                           </button>
-                        </li>
-                        <li
-                          class="PodBrowser-action-menu__item"
-                        >
-                          <p
-                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                            data-testid="pod-indicator-copy-tooltip"
-                          >
-                            COPY LINK
-                          </p>
                         </li>
                       </ul>
                     </div>
@@ -1763,6 +1763,16 @@ exports[`Container view renders a table for parent container if iri is a resourc
                         <li
                           class="PodBrowser-action-menu__item"
                         >
+                          <p
+                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                            data-testid="pod-indicator-copy-tooltip"
+                          >
+                            COPY LINK
+                          </p>
+                        </li>
+                        <li
+                          class="PodBrowser-action-menu__item"
+                        >
                           <button
                             class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                             data-testid="delete-resource-button"
@@ -1770,16 +1780,6 @@ exports[`Container view renders a table for parent container if iri is a resourc
                           >
                             Delete
                           </button>
-                        </li>
-                        <li
-                          class="PodBrowser-action-menu__item"
-                        >
-                          <p
-                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                            data-testid="pod-indicator-copy-tooltip"
-                          >
-                            COPY LINK
-                          </p>
                         </li>
                       </ul>
                     </div>

--- a/components/container/__snapshots__/index.test.jsx.snap
+++ b/components/container/__snapshots__/index.test.jsx.snap
@@ -544,6 +544,16 @@ exports[`Container view renders NoControlError if it fails to get access control
                             Delete
                           </button>
                         </li>
+                        <li
+                          class="PodBrowser-action-menu__item"
+                        >
+                          <p
+                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                            data-testid="pod-indicator-copy-tooltip"
+                          >
+                            COPY LINK
+                          </p>
+                        </li>
                       </ul>
                     </div>
                   </div>
@@ -1117,6 +1127,16 @@ exports[`Container view renders a table 1`] = `
                           >
                             Delete
                           </button>
+                        </li>
+                        <li
+                          class="PodBrowser-action-menu__item"
+                        >
+                          <p
+                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                            data-testid="pod-indicator-copy-tooltip"
+                          >
+                            COPY LINK
+                          </p>
                         </li>
                       </ul>
                     </div>
@@ -1750,6 +1770,16 @@ exports[`Container view renders a table for parent container if iri is a resourc
                           >
                             Delete
                           </button>
+                        </li>
+                        <li
+                          class="PodBrowser-action-menu__item"
+                        >
+                          <p
+                            class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                            data-testid="pod-indicator-copy-tooltip"
+                          >
+                            COPY LINK
+                          </p>
                         </li>
                       </ul>
                     </div>

--- a/components/podIndicator/index.jsx
+++ b/components/podIndicator/index.jsx
@@ -31,7 +31,6 @@ import {
   ListItemText,
   ListItemIcon,
   Tooltip,
-  createSvgIcon,
 } from "@material-ui/core";
 import Skeleton from "@material-ui/lab/Skeleton";
 import { Icons } from "@inrupt/prism-react-components";

--- a/components/resourceDetails/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.jsx.snap
@@ -81,6 +81,16 @@ exports[`Resource details renders Permissions component for WAC-supporting Solid
                 <li
                   class="PodBrowser-action-menu__item"
                 >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
+                </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
                   <button
                     class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                     data-testid="delete-resource-button"
@@ -88,16 +98,6 @@ exports[`Resource details renders Permissions component for WAC-supporting Solid
                   >
                     Delete
                   </button>
-                </li>
-                <li
-                  class="PodBrowser-action-menu__item"
-                >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
-                  >
-                    COPY LINK
-                  </p>
                 </li>
               </ul>
             </div>
@@ -421,6 +421,16 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                 <li
                   class="PodBrowser-action-menu__item"
                 >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
+                </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
                   <button
                     class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                     data-testid="delete-resource-button"
@@ -428,16 +438,6 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                   >
                     Delete
                   </button>
-                </li>
-                <li
-                  class="PodBrowser-action-menu__item"
-                >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
-                  >
-                    COPY LINK
-                  </p>
                 </li>
               </ul>
             </div>
@@ -873,6 +873,16 @@ exports[`Resource details renders a decoded container name 1`] = `
                 <li
                   class="PodBrowser-action-menu__item"
                 >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
+                </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
                   <button
                     class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                     data-testid="delete-resource-button"
@@ -880,16 +890,6 @@ exports[`Resource details renders a decoded container name 1`] = `
                   >
                     Delete
                   </button>
-                </li>
-                <li
-                  class="PodBrowser-action-menu__item"
-                >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
-                  >
-                    COPY LINK
-                  </p>
                 </li>
               </ul>
             </div>
@@ -1066,6 +1066,16 @@ exports[`Resource details renders container details 1`] = `
                 <li
                   class="PodBrowser-action-menu__item"
                 >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
+                </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
                   <button
                     class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                     data-testid="delete-resource-button"
@@ -1073,16 +1083,6 @@ exports[`Resource details renders container details 1`] = `
                   >
                     Delete
                   </button>
-                </li>
-                <li
-                  class="PodBrowser-action-menu__item"
-                >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
-                  >
-                    COPY LINK
-                  </p>
                 </li>
               </ul>
             </div>

--- a/components/resourceDetails/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.jsx.snap
@@ -83,7 +83,7 @@ exports[`Resource details renders Permissions component for WAC-supporting Solid
                 >
                   <p
                     class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
+                    data-testid="resource-address-copy-tooltip"
                   >
                     COPY LINK
                   </p>
@@ -423,7 +423,7 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                 >
                   <p
                     class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
+                    data-testid="resource-address-copy-tooltip"
                   >
                     COPY LINK
                   </p>
@@ -875,7 +875,7 @@ exports[`Resource details renders a decoded container name 1`] = `
                 >
                   <p
                     class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
+                    data-testid="resource-address-copy-tooltip"
                   >
                     COPY LINK
                   </p>
@@ -1068,7 +1068,7 @@ exports[`Resource details renders container details 1`] = `
                 >
                   <p
                     class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                    data-testid="pod-indicator-copy-tooltip"
+                    data-testid="resource-address-copy-tooltip"
                   >
                     COPY LINK
                   </p>

--- a/components/resourceDetails/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.jsx.snap
@@ -81,12 +81,13 @@ exports[`Resource details renders Permissions component for WAC-supporting Solid
                 <li
                   class="PodBrowser-action-menu__item"
                 >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                  <button
+                    class="PodBrowser-action-menu__trigger"
                     data-testid="resource-address-copy-tooltip"
+                    type="button"
                   >
                     COPY LINK
-                  </p>
+                  </button>
                 </li>
                 <li
                   class="PodBrowser-action-menu__item"
@@ -421,12 +422,13 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                 <li
                   class="PodBrowser-action-menu__item"
                 >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                  <button
+                    class="PodBrowser-action-menu__trigger"
                     data-testid="resource-address-copy-tooltip"
+                    type="button"
                   >
                     COPY LINK
-                  </p>
+                  </button>
                 </li>
                 <li
                   class="PodBrowser-action-menu__item"
@@ -873,12 +875,13 @@ exports[`Resource details renders a decoded container name 1`] = `
                 <li
                   class="PodBrowser-action-menu__item"
                 >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                  <button
+                    class="PodBrowser-action-menu__trigger"
                     data-testid="resource-address-copy-tooltip"
+                    type="button"
                   >
                     COPY LINK
-                  </p>
+                  </button>
                 </li>
                 <li
                   class="PodBrowser-action-menu__item"
@@ -1066,12 +1069,13 @@ exports[`Resource details renders container details 1`] = `
                 <li
                   class="PodBrowser-action-menu__item"
                 >
-                  <p
-                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                  <button
+                    class="PodBrowser-action-menu__trigger"
                     data-testid="resource-address-copy-tooltip"
+                    type="button"
                   >
                     COPY LINK
-                  </p>
+                  </button>
                 </li>
                 <li
                   class="PodBrowser-action-menu__item"

--- a/components/resourceDetails/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDetails/__snapshots__/index.test.jsx.snap
@@ -89,6 +89,16 @@ exports[`Resource details renders Permissions component for WAC-supporting Solid
                     Delete
                   </button>
                 </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
+                </li>
               </ul>
             </div>
           </div>
@@ -418,6 +428,16 @@ exports[`Resource details renders Sharing component for ACP-supporting Solid ser
                   >
                     Delete
                   </button>
+                </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
                 </li>
               </ul>
             </div>
@@ -861,6 +881,16 @@ exports[`Resource details renders a decoded container name 1`] = `
                     Delete
                   </button>
                 </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
+                </li>
               </ul>
             </div>
           </div>
@@ -1043,6 +1073,16 @@ exports[`Resource details renders container details 1`] = `
                   >
                     Delete
                   </button>
+                </li>
+                <li
+                  class="PodBrowser-action-menu__item"
+                >
+                  <p
+                    class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                    data-testid="pod-indicator-copy-tooltip"
+                  >
+                    COPY LINK
+                  </p>
                 </li>
               </ul>
             </div>

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -140,16 +140,6 @@ export default function ResourceDetails({
               </DownloadLink>
             </ActionMenuItem>
             <ActionMenuItem>
-              <DeleteResourceButton
-                className={actionMenuBem("action-menu__trigger", "danger")}
-                resourceIri={datasetUrl}
-                name={displayName}
-                onDelete={onDelete}
-                onDeleteCurrentContainer={onDeleteCurrentContainer}
-                data-testid={TESTCAFE_ID_DELETE_BUTTON}
-              />
-            </ActionMenuItem>
-            <ActionMenuItem>
               <Tooltip
                 PopperProps={{
                   disablePortal: true,
@@ -168,6 +158,16 @@ export default function ResourceDetails({
                   COPY LINK
                 </Typography>
               </Tooltip>
+            </ActionMenuItem>
+            <ActionMenuItem>
+              <DeleteResourceButton
+                className={actionMenuBem("action-menu__trigger", "danger")}
+                resourceIri={datasetUrl}
+                name={displayName}
+                onDelete={onDelete}
+                onDeleteCurrentContainer={onDeleteCurrentContainer}
+                data-testid={TESTCAFE_ID_DELETE_BUTTON}
+              />
             </ActionMenuItem>
           </ActionMenu>
         </AccordionDetails>

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import {
   Accordion,
   AccordionDetails,
@@ -28,6 +28,7 @@ import {
   Divider,
   List,
   ListItem,
+  Tooltip,
   Typography,
 } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
@@ -56,6 +57,7 @@ export const TESTCAFE_ID_ACCORDION_PERMISSIONS =
   "accordion-resource-permissions";
 export const TESTCAFE_ID_ACCORDION_SHARING = "accordion-resource-sharing";
 const TESTCAFE_ID_TITLE = "resource-title";
+export const TESTCAFE_RESOURCE_ADDRESS_TOOLTIP = "pod-indicator-copy-tooltip";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 
@@ -74,6 +76,7 @@ export default function ResourceDetails({
   const displayName = getResourceName(name);
   const type = getContentType(dataset);
   const actionMenuBem = ActionMenu.useBem();
+  const [tooltipOpen, setTooltipOpen] = useState(false);
   const { accessControl, accessControlType } = useContext(AccessControlContext);
 
   const [actionsAccordion, setActionsAccordion] = useLocalStorage(
@@ -92,6 +95,13 @@ export default function ResourceDetails({
     getAccordionKey(dataset, "sharing"),
     false
   );
+  const handleResourceCopyClick = () => {
+    navigator.clipboard.writeText(datasetUrl);
+    setTooltipOpen(true);
+    setTimeout(() => {
+      setTooltipOpen(false);
+    }, 800);
+  };
 
   const expandIcon = <ExpandMoreIcon />;
   return (
@@ -138,6 +148,26 @@ export default function ResourceDetails({
                 onDeleteCurrentContainer={onDeleteCurrentContainer}
                 data-testid={TESTCAFE_ID_DELETE_BUTTON}
               />
+            </ActionMenuItem>
+            <ActionMenuItem>
+              <Tooltip
+                PopperProps={{
+                  disablePortal: true,
+                }}
+                open={tooltipOpen}
+                disableFocusListener
+                disableHoverListener
+                disableTouchListener
+                title="Copied"
+                data-testid={TESTCAFE_RESOURCE_ADDRESS_TOOLTIP}
+              >
+                <Typography
+                  onClick={handleResourceCopyClick}
+                  className={actionMenuBem("action-menu__trigger")}
+                >
+                  COPY LINK
+                </Typography>
+              </Tooltip>
             </ActionMenuItem>
           </ActionMenu>
         </AccordionDetails>

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -57,7 +57,8 @@ export const TESTCAFE_ID_ACCORDION_PERMISSIONS =
   "accordion-resource-permissions";
 export const TESTCAFE_ID_ACCORDION_SHARING = "accordion-resource-sharing";
 const TESTCAFE_ID_TITLE = "resource-title";
-export const TESTCAFE_RESOURCE_ADDRESS_TOOLTIP = "pod-indicator-copy-tooltip";
+export const TESTCAFE_RESOURCE_ADDRESS_TOOLTIP =
+  "resource-address-copy-tooltip";
 
 const useStyles = makeStyles((theme) => createStyles(styles(theme)));
 

--- a/components/resourceDetails/index.jsx
+++ b/components/resourceDetails/index.jsx
@@ -152,12 +152,13 @@ export default function ResourceDetails({
                 title="Copied"
                 data-testid={TESTCAFE_RESOURCE_ADDRESS_TOOLTIP}
               >
-                <Typography
+                <button
+                  type="button"
                   onClick={handleResourceCopyClick}
                   className={actionMenuBem("action-menu__trigger")}
                 >
                   COPY LINK
-                </Typography>
+                </button>
               </Tooltip>
             </ActionMenuItem>
             <ActionMenuItem>

--- a/components/resourceDetails/index.test.jsx
+++ b/components/resourceDetails/index.test.jsx
@@ -20,7 +20,7 @@
  */
 
 import React from "react";
-import { waitFor } from "@testing-library/dom";
+import { waitFor, screen } from "@testing-library/dom";
 import userEvent from "@testing-library/user-event";
 import { mockSolidDatasetFrom } from "@inrupt/solid-client";
 import { DatasetProvider } from "@inrupt/solid-ui-react";
@@ -29,6 +29,7 @@ import { renderWithTheme } from "../../__testUtils/withTheme";
 import ResourceDetails, {
   TESTCAFE_ID_ACCORDION_PERMISSIONS,
   TESTCAFE_ID_ACCORDION_SHARING,
+  TESTCAFE_RESOURCE_ADDRESS_TOOLTIP,
 } from "./index";
 import mockAccessControl from "../../__testUtils/mockAccessControl";
 import { AccessControlProvider } from "../../src/contexts/accessControlContext";
@@ -68,6 +69,27 @@ describe("Resource details", () => {
       expect(getByText("container")).toBeInTheDocument();
     });
     expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("copies resource address to the clipboard when the copy link button is clicked", async () => {
+    const writeText = jest.fn();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText,
+      },
+    });
+
+    const { getByTestId } = renderWithTheme(
+      <DatasetProvider solidDataset={dataset}>
+        <ResourceDetails />
+      </DatasetProvider>
+    );
+    const copyLink = screen.getByTestId(TESTCAFE_RESOURCE_ADDRESS_TOOLTIP);
+    userEvent.click(copyLink);
+    await waitFor(() => {
+      expect(copyLink).toBeInTheDocument();
+      expect(writeText).toHaveBeenCalled();
+    });
   });
 
   it("renders a decoded container name", async () => {

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -108,7 +108,7 @@ exports[`ResourceDrawer view renders a Contents view when the router query has a
                       >
                         <p
                           class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                          data-testid="pod-indicator-copy-tooltip"
+                          data-testid="resource-address-copy-tooltip"
                         >
                           COPY LINK
                         </p>
@@ -749,7 +749,7 @@ exports[`ResourceDrawer view renders without errors when iri contains spaces 1`]
                       >
                         <p
                           class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                          data-testid="pod-indicator-copy-tooltip"
+                          data-testid="resource-address-copy-tooltip"
                         >
                           COPY LINK
                         </p>

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -106,12 +106,13 @@ exports[`ResourceDrawer view renders a Contents view when the router query has a
                       <li
                         class="PodBrowser-action-menu__item"
                       >
-                        <p
-                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                        <button
+                          class="PodBrowser-action-menu__trigger"
                           data-testid="resource-address-copy-tooltip"
+                          type="button"
                         >
                           COPY LINK
-                        </p>
+                        </button>
                       </li>
                       <li
                         class="PodBrowser-action-menu__item"
@@ -747,12 +748,13 @@ exports[`ResourceDrawer view renders without errors when iri contains spaces 1`]
                       <li
                         class="PodBrowser-action-menu__item"
                       >
-                        <p
-                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                        <button
+                          class="PodBrowser-action-menu__trigger"
                           data-testid="resource-address-copy-tooltip"
+                          type="button"
                         >
                           COPY LINK
-                        </p>
+                        </button>
                       </li>
                       <li
                         class="PodBrowser-action-menu__item"

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -114,6 +114,16 @@ exports[`ResourceDrawer view renders a Contents view when the router query has a
                           Delete
                         </button>
                       </li>
+                      <li
+                        class="PodBrowser-action-menu__item"
+                      >
+                        <p
+                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          data-testid="pod-indicator-copy-tooltip"
+                        >
+                          COPY LINK
+                        </p>
+                      </li>
                     </ul>
                   </div>
                 </div>
@@ -744,6 +754,16 @@ exports[`ResourceDrawer view renders without errors when iri contains spaces 1`]
                         >
                           Delete
                         </button>
+                      </li>
+                      <li
+                        class="PodBrowser-action-menu__item"
+                      >
+                        <p
+                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          data-testid="pod-indicator-copy-tooltip"
+                        >
+                          COPY LINK
+                        </p>
                       </li>
                     </ul>
                   </div>

--- a/components/resourceDrawer/__snapshots__/index.test.jsx.snap
+++ b/components/resourceDrawer/__snapshots__/index.test.jsx.snap
@@ -106,6 +106,16 @@ exports[`ResourceDrawer view renders a Contents view when the router query has a
                       <li
                         class="PodBrowser-action-menu__item"
                       >
+                        <p
+                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          data-testid="pod-indicator-copy-tooltip"
+                        >
+                          COPY LINK
+                        </p>
+                      </li>
+                      <li
+                        class="PodBrowser-action-menu__item"
+                      >
                         <button
                           class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                           data-testid="delete-resource-button"
@@ -113,16 +123,6 @@ exports[`ResourceDrawer view renders a Contents view when the router query has a
                         >
                           Delete
                         </button>
-                      </li>
-                      <li
-                        class="PodBrowser-action-menu__item"
-                      >
-                        <p
-                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                          data-testid="pod-indicator-copy-tooltip"
-                        >
-                          COPY LINK
-                        </p>
                       </li>
                     </ul>
                   </div>
@@ -747,6 +747,16 @@ exports[`ResourceDrawer view renders without errors when iri contains spaces 1`]
                       <li
                         class="PodBrowser-action-menu__item"
                       >
+                        <p
+                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
+                          data-testid="pod-indicator-copy-tooltip"
+                        >
+                          COPY LINK
+                        </p>
+                      </li>
+                      <li
+                        class="PodBrowser-action-menu__item"
+                      >
                         <button
                           class="PodBrowser-action-menu__trigger PodBrowser-action-menu__trigger--danger"
                           data-testid="delete-resource-button"
@@ -754,16 +764,6 @@ exports[`ResourceDrawer view renders without errors when iri contains spaces 1`]
                         >
                           Delete
                         </button>
-                      </li>
-                      <li
-                        class="PodBrowser-action-menu__item"
-                      >
-                        <p
-                          class="PodBrowser-root PodBrowser-action-menu__trigger PodBrowser-body1"
-                          data-testid="pod-indicator-copy-tooltip"
-                        >
-                          COPY LINK
-                        </p>
                       </li>
                     </ul>
                   </div>


### PR DESCRIPTION
## Description
Now you can copy your resource address in PB. 
## Changes
New copy link button on Resource Details Drawer
## Testing
Navigate to a container or resource in your pod. Click on the open area next to the name. The details drawer should open to the right. Click on "COPY LINK" and your resource/container address will be saved to your clipboard. 
## Commit checklist

- [ x] All acceptance criteria are met.
- [ x] Includes tests to ensure functionality and prevent regressions.
- [x ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

## Interested parties
@VirginiaBalseiro @KyraAssaad @ThisIsMissEm 
## Notes

## Screenshots/captures

https://user-images.githubusercontent.com/94387648/162857823-a684b1c9-a113-4dd3-9190-ecb906cc58db.mov


