### PR TITLE
fix: present grant_types in client to enable refresh_tokens

### DIFF
--- a/pages/api/app.js
+++ b/pages/api/app.js
@@ -25,8 +25,12 @@ function buildAppProfile(hostname, clientId) {
   return {
     "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
     client_id: clientId,
-    redirect_uris: [hostname, hostname.concat("login")],
     client_name: CLIENT_NAME,
+    // URLs to which the user will be redirected back to upon successful authentication:
+    // FIXME: move towards using a `/authorize` page for receiving the authorization code
+    redirect_uris: [hostname, hostname.concat("login")],
+    // Support refresh_tokens for refreshing the session:
+    grant_types: ["authorization_code", "refresh_token"],
   };
 }
 

--- a/pages/api/app.test.js
+++ b/pages/api/app.test.js
@@ -31,6 +31,7 @@ const PODBROWSER_RESPONSE = {
     "https://podbrowser.inrupt.com/",
     "https://podbrowser.inrupt.com/login",
   ],
+  grant_types: ["authorization_code", "refresh_token"],
 };
 
 describe("/api/app handler tests", () => {


### PR DESCRIPTION
## Description

At some point, ESS made a change that meant it didn't by default issue refresh_tokens to clients that don't ask for them, as such, we need to explicitly ask for them. This only fixes deployments of Pod-Browser, but does not change local development, which needs the published localhost document updated.

## Changes

- Updated the client credential presented by `/api/app`

## Testing

Login, check the console for the `/token` request, and verify that the response body includes a `refresh_token`

## Commit checklist

- [ ] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [x] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

## Interested parties

@VirginiaBalseiro 

## Notes

Requires the public client credential for development on localhost to be updated to match.

## Screenshots/captures
