### PR TITLE
Add the refresh grant to the client id doc

### DIFF
--- a/constants/app.js
+++ b/constants/app.js
@@ -42,3 +42,5 @@ export const getClientOptions = () => {
     redirectUrl: generateRedirectUrl(""),
   };
 };
+
+export const GRANT_TYPES = ["refresh_token", "authorization_code"];

--- a/pages/api/app.js
+++ b/pages/api/app.js
@@ -27,7 +27,7 @@ function buildAppProfile(hostname, clientId) {
     client_id: clientId,
     redirect_uris: [hostname, hostname.concat("login")],
     client_name: CLIENT_NAME,
-    grant_types: GRANT_TYPES.join(" "),
+    grant_types: GRANT_TYPES,
   };
 }
 

--- a/pages/api/app.js
+++ b/pages/api/app.js
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { CLIENT_NAME } from "../../constants/app";
+import { CLIENT_NAME, GRANT_TYPES } from "../../constants/app";
 
 function buildAppProfile(hostname, clientId) {
   return {
@@ -27,6 +27,7 @@ function buildAppProfile(hostname, clientId) {
     client_id: clientId,
     redirect_uris: [hostname, hostname.concat("login")],
     client_name: CLIENT_NAME,
+    grant_types: GRANT_TYPES.join(" "),
   };
 }
 

--- a/pages/api/app.test.js
+++ b/pages/api/app.test.js
@@ -31,6 +31,7 @@ const PODBROWSER_RESPONSE = {
     "https://podbrowser.inrupt.com/",
     "https://podbrowser.inrupt.com/login",
   ],
+  grant_types: ["refresh_token", "authorization_code"],
 };
 
 describe("/api/app handler tests", () => {
@@ -61,8 +62,6 @@ describe("/api/app handler tests", () => {
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.end).toHaveBeenCalledTimes(1);
     // eslint-disable-next-line no-underscore-dangle
-    expect(JSON.parse(res._getData())).toEqual(
-      expect.objectContaining(PODBROWSER_RESPONSE)
-    );
+    expect(JSON.parse(res._getData())).toStrictEqual(PODBROWSER_RESPONSE);
   });
 });


### PR DESCRIPTION
## Description

For the OIDC issuer to issue a refresh token as well as an access token, the client profile must include "refresh_token" in its "grant_types". If left unspecified, "grant_types" defaults to ["authorization_code"], as per [the OIDC spec](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata), which is what [Solid-OIDC](https://solid.github.io/solid-oidc/#clientids-document) is based on.

## Changes

This adds the missing entry to the client profile.

## Testing

## Commit checklist

- [X] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.