### PR TITLE
Fix/update contacts

### DIFF
--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -33,7 +33,10 @@ import AgentSearchForm from "../agentSearchForm";
 import DetailsMenuContext from "../../src/contexts/detailsMenuContext";
 import AlertContext from "../../src/contexts/alertContext";
 import styles from "./styles";
-import { fetchProfile } from "../../src/solidClientHelpers/profile";
+import {
+  fetchProfile,
+  getFullProfile,
+} from "../../src/solidClientHelpers/profile";
 import { isPodOwner } from "../../src/solidClientHelpers/utils";
 import useContactsOld from "../../src/hooks/useContactsOld";
 import useContactsContainerUrl from "../../src/hooks/useContactsContainerUrl";
@@ -67,7 +70,7 @@ export function handleSubmit({
     setIsLoading(true);
 
     try {
-      const { name, webId, types } = await fetchProfile(iri, fetch);
+      const { names, webId, types } = await getFullProfile(iri, session);
       const existingContact = await findContactInAddressBook(
         people,
         webId,
@@ -80,7 +83,7 @@ export function handleSubmit({
         return;
       }
 
-      const contact = { webId, fn: name || null };
+      const contact = { webId, fn: names[0] || null };
       const { response, error } = await saveContact(
         addressBook,
         addressBookContainerUrl,

--- a/components/addContact/index.jsx
+++ b/components/addContact/index.jsx
@@ -76,14 +76,15 @@ export function handleSubmit({
         webId,
         fetch
       );
-
       if (existingContact) {
         alertError(EXISTING_WEBID_ERROR_MESSAGE);
         setIsLoading(false);
         return;
       }
-
-      const contact = { webId, fn: names[0] || null };
+      const contact = {
+        webId,
+        fn: names[0],
+      };
       const { response, error } = await saveContact(
         addressBook,
         addressBookContainerUrl,
@@ -91,7 +92,6 @@ export function handleSubmit({
         types,
         fetch
       );
-
       if (error) alertError(error);
       if (response) {
         alertSuccess(`${contact.fn || webId} was added to your contacts`);

--- a/components/addContact/index.test.jsx
+++ b/components/addContact/index.test.jsx
@@ -95,7 +95,7 @@ describe("handleSubmit", () => {
       people,
     });
     jest
-      .spyOn(profileHelperFns, "fetchProfile")
+      .spyOn(profileHelperFns, "getFullProfile")
       .mockResolvedValue(personProfile);
     jest
       .spyOn(addressBookFns, "findContactInAddressBook")
@@ -124,7 +124,7 @@ describe("handleSubmit", () => {
       setDirtyForm,
     });
     jest
-      .spyOn(profileHelperFns, "fetchProfile")
+      .spyOn(profileHelperFns, "getFullProfile")
       .mockRejectedValueOnce(mockProfileError);
     await handler("iri");
     expect(setAgentId).toHaveBeenCalledTimes(0);
@@ -135,7 +135,8 @@ describe("handleSubmit", () => {
 
   it("saves a contact without name and alerts the user", async () => {
     const personUri = "http://example.com/marie#me";
-    const mockProfile = { webId: personUri };
+    const mockProfile = { webId: personUri, names: [] };
+    const mockSaveContact = jest.spyOn(addressBookFns, "saveContact");
     const handler = handleSubmit({
       addressBook,
       setAgentId,
@@ -145,15 +146,18 @@ describe("handleSubmit", () => {
       session,
       setDirtyForm,
     });
-    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
+    jest
+      .spyOn(profileHelperFns, "getFullProfile")
+      .mockResolvedValue(mockProfile);
     jest
       .spyOn(addressBookFns, "findContactInAddressBook")
       .mockResolvedValue(undefined);
-    jest.spyOn(addressBookFns, "saveContact").mockResolvedValue({
+    mockSaveContact.mockResolvedValue({
       response: "peopleDataset",
       error: null,
     });
     await handler(personUri);
+    expect(mockSaveContact).toHaveBeenCalledTimes(1);
     expect(setAgentId).toHaveBeenCalledTimes(1);
     expect(setIsLoading).toHaveBeenCalledTimes(2);
     expect(alertSuccess).toHaveBeenCalled();
@@ -170,7 +174,7 @@ describe("handleSubmit", () => {
     const people = mockSolidDatasetFrom(contactsIri);
     const peopleMutate = jest.fn();
     const peopleDatasetWithContact = setThing(people, personDataset);
-    const mockProfile = mockProfileAlice();
+    const mockProfile = { webId: personUri, names: ["Alice"] };
     const handler = handleSubmit({
       addressBook,
       setAgentId,
@@ -185,7 +189,9 @@ describe("handleSubmit", () => {
     jest
       .spyOn(addressBookFns, "findContactInAddressBook")
       .mockResolvedValue(undefined);
-    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
+    jest
+      .spyOn(profileHelperFns, "getFullProfile")
+      .mockResolvedValue(mockProfile);
     jest.spyOn(addressBookFns, "saveContact").mockResolvedValue({
       response: peopleDatasetWithContact,
       error: null,
@@ -201,7 +207,8 @@ describe("handleSubmit", () => {
   });
 
   it("alerts the user if there is an error while creating the contact", async () => {
-    const mockProfile = mockProfileAlice();
+    const personUri = "http://example.com/alice#me";
+    const mockProfile = { webId: personUri, names: [] };
     const handler = handleSubmit({
       addressBook,
       setAgentId,
@@ -211,7 +218,9 @@ describe("handleSubmit", () => {
       session,
       setDirtyForm,
     });
-    jest.spyOn(profileHelperFns, "fetchProfile").mockResolvedValue(mockProfile);
+    jest
+      .spyOn(profileHelperFns, "getFullProfile")
+      .mockResolvedValue(mockProfile);
     jest
       .spyOn(addressBookFns, "findContactInAddressBook")
       .mockResolvedValue(undefined);

--- a/components/contactsList/index.test.jsx
+++ b/components/contactsList/index.test.jsx
@@ -22,11 +22,12 @@
 import React from "react";
 import * as solidClientFns from "@inrupt/solid-client";
 import { useRouter } from "next/router";
-import { foaf } from "rdf-namespaces";
+import { foaf, schema } from "rdf-namespaces";
 import { screen, waitFor } from "@testing-library/react";
 import * as addressBookFns from "../../src/addressBook";
 import useAddressBookOld from "../../src/hooks/useAddressBookOld";
 import useContactsOld from "../../src/hooks/useContactsOld";
+import useFullProfile from "../../src/hooks/useFullProfile";
 import useProfiles from "../../src/hooks/useProfiles";
 import { renderWithTheme } from "../../__testUtils/withTheme";
 import ContactsList, { handleDeleteContact } from "./index";
@@ -44,6 +45,7 @@ import { TESTCAFE_ID_PROFILE_LINK } from "../profileLink";
 jest.mock("../../src/hooks/useAddressBookOld");
 jest.mock("../../src/hooks/useContactsOld");
 jest.mock("../../src/hooks/useProfiles");
+jest.mock("../../src/hooks/useFullProfile");
 jest.mock("next/router");
 
 const mockedUseRouter = useRouter;
@@ -129,6 +131,17 @@ describe("ContactsList", () => {
   });
 
   it("renders page when people is loaded", async () => {
+    useFullProfile
+      .mockReturnValueOnce({
+        webId: aliceWebIdUrl,
+        names: ["Alice"],
+        types: [schema.Person],
+      })
+      .mockReturnValueOnce({
+        webId: bobWebIdUrl,
+        names: ["Bob"],
+        types: [schema.Person],
+      });
     useAddressBookOld.mockReturnValue([42, null]);
     useContactsOld.mockReturnValue({
       data: "peopleData",
@@ -169,6 +182,17 @@ describe("ContactsList", () => {
       mutate: () => {},
     });
     useProfiles.mockReturnValue([mockPersonThingAlice(), contact]);
+    useFullProfile
+      .mockReturnValueOnce({
+        webId: aliceWebIdUrl,
+        names: ["Alice"],
+        types: [schema.Person],
+      })
+      .mockReturnValueOnce({
+        webId,
+        names: [],
+        types: [schema.Person],
+      });
 
     const { asFragment, getAllByTestId } = renderWithTheme(
       <SessionProvider>

--- a/components/profileLink/__snapshots__/index.test.jsx.snap
+++ b/components/profileLink/__snapshots__/index.test.jsx.snap
@@ -11,6 +11,17 @@ exports[`ProfileLink renders correct path for privacy contacts 1`] = `
 </DocumentFragment>
 `;
 
+exports[`ProfileLink renders first name from profile names array 1`] = `
+<DocumentFragment>
+  <a
+    data-testid="profile-link"
+    href="/contacts/https%3A%2F%2Fexample.com%2Falice"
+  >
+    Alice
+  </a>
+</DocumentFragment>
+`;
+
 exports[`ProfileLink renders iri if name is not found 1`] = `
 <DocumentFragment>
   <a
@@ -18,28 +29,6 @@ exports[`ProfileLink renders iri if name is not found 1`] = `
     href="/contacts/https%3A%2F%2Fmockiri.com"
   >
     https://mockiri.com
-  </a>
-</DocumentFragment>
-`;
-
-exports[`ProfileLink supports rendering name from foaf.name 1`] = `
-<DocumentFragment>
-  <a
-    data-testid="profile-link"
-    href="/contacts/https%3A%2F%2Fexample.com%2Fbob"
-  >
-    Bob
-  </a>
-</DocumentFragment>
-`;
-
-exports[`ProfileLink supports rendering name from vcard.fn 1`] = `
-<DocumentFragment>
-  <a
-    data-testid="profile-link"
-    href="/contacts/https%3A%2F%2Fexample.com%2Falice"
-  >
-    Alice
   </a>
 </DocumentFragment>
 `;

--- a/components/profileLink/__snapshots__/index.test.jsx.snap
+++ b/components/profileLink/__snapshots__/index.test.jsx.snap
@@ -32,3 +32,5 @@ exports[`ProfileLink renders iri if name is not found 1`] = `
   </a>
 </DocumentFragment>
 `;
+
+exports[`ProfileLink returns null on first render when profile is still null 1`] = `<DocumentFragment />`;

--- a/components/profileLink/index.jsx
+++ b/components/profileLink/index.jsx
@@ -43,8 +43,7 @@ export default function ProfileLink() {
   const { thing } = useThing();
   const webId = getProfileIriFromContactThing(thing);
   const profile = useFullProfile(webId);
-  const type = getUrl(thing, rdf.type);
-  const path = type === schema.Person ? "person" : "app";
+  const path = profile.types.includes(schema.Person) ? "person" : "app";
   // Pass in an iri, or use the thing from context (such as for the contacts list)
 
   // TODO remove this once react-sdk allows property fallbacks

--- a/components/profileLink/index.jsx
+++ b/components/profileLink/index.jsx
@@ -43,10 +43,10 @@ export default function ProfileLink() {
   const { thing } = useThing();
   const webId = getProfileIriFromContactThing(thing);
   const profile = useFullProfile(webId);
-  const path = profile.types.includes(schema.Person) ? "person" : "app";
-  // Pass in an iri, or use the thing from context (such as for the contacts list)
 
-  // TODO remove this once react-sdk allows property fallbacks
+  if (profile === null) return null;
+
+  const path = profile?.types.includes(schema.Person) ? "person" : "app";
 
   return (
     <Link href={buildProfileLink(webId, route, path)}>

--- a/components/profileLink/index.jsx
+++ b/components/profileLink/index.jsx
@@ -23,10 +23,11 @@ import React from "react";
 import T from "prop-types";
 import Link from "next/link";
 import { useThing } from "@inrupt/solid-ui-react";
-import { getStringNoLocale, getUrl } from "@inrupt/solid-client";
-import { vcard, foaf, rdf, schema } from "rdf-namespaces";
+import { getUrl } from "@inrupt/solid-client";
+import { rdf, schema } from "rdf-namespaces";
 import { useRouter } from "next/router";
 import { getProfileIriFromContactThing } from "../../src/addressBook";
+import useFullProfile from "../../src/hooks/useFullProfile";
 
 export const TESTCAFE_ID_PROFILE_LINK = "profile-link";
 
@@ -37,34 +38,20 @@ export function buildProfileLink(webId, route, path) {
   return `${route}/${path}/${encodeURIComponent(webId)}`;
 }
 
-export default function ProfileLink(props) {
+export default function ProfileLink() {
   const { route } = useRouter();
-  const { webId } = props;
   const { thing } = useThing();
-  const contact = getProfileIriFromContactThing(thing);
-
+  const webId = getProfileIriFromContactThing(thing);
+  const profile = useFullProfile(webId);
   const type = getUrl(thing, rdf.type);
   const path = type === schema.Person ? "person" : "app";
   // Pass in an iri, or use the thing from context (such as for the contacts list)
-  const profileIri = webId || contact;
 
   // TODO remove this once react-sdk allows property fallbacks
-  const name =
-    getStringNoLocale(thing, foaf.name) ||
-    getStringNoLocale(thing, vcard.fn) ||
-    profileIri;
 
   return (
-    <Link href={buildProfileLink(profileIri, route, path)}>
-      <a data-testid={TESTCAFE_ID_PROFILE_LINK}>{name}</a>
+    <Link href={buildProfileLink(webId, route, path)}>
+      <a data-testid={TESTCAFE_ID_PROFILE_LINK}>{profile?.names[0] || webId}</a>
     </Link>
   );
 }
-
-ProfileLink.propTypes = {
-  webId: T.string,
-};
-
-ProfileLink.defaultProps = {
-  webId: null,
-};

--- a/components/profileLink/index.test.jsx
+++ b/components/profileLink/index.test.jsx
@@ -27,10 +27,13 @@ import { ThingProvider } from "@inrupt/solid-ui-react";
 import { foaf, rdf, vcard, schema } from "rdf-namespaces";
 import ProfileLink, { buildProfileLink } from "./index";
 import { chain } from "../../src/solidClientHelpers/utils";
+import useFullProfile from "../../src/hooks/useFullProfile";
 
 jest.mock("next/router");
+jest.mock("../../src/hooks/useFullProfile");
 
 const mockedUseRouter = useRouter;
+const mockedUseFullProfile = useFullProfile;
 
 const alice = chain(mockThingFrom("https://example.com/alice"), (t) =>
   setStringNoLocale(t, vcard.fn, "Alice")
@@ -48,7 +51,12 @@ describe("ProfileLink", () => {
       route: "/contacts",
     });
   });
-  it("supports rendering name from vcard.fn", () => {
+  it("renders first name from profile names array", () => {
+    mockedUseFullProfile.mockReturnValue({
+      webId: "https://example.com/alice",
+      names: ["Alice", "Alice2"],
+      types: [schema.Person],
+    });
     const { asFragment } = render(
       <ThingProvider thing={alice}>
         <ProfileLink iri={iri} />
@@ -57,16 +65,12 @@ describe("ProfileLink", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it("supports rendering name from foaf.name", () => {
-    const { asFragment } = render(
-      <ThingProvider thing={bob}>
-        <ProfileLink />
-      </ThingProvider>
-    );
-    expect(asFragment()).toMatchSnapshot();
-  });
-
   it("renders iri if name is not found", () => {
+    mockedUseFullProfile.mockReturnValue({
+      webId: "https://example.com/alice",
+      names: [],
+      types: [schema.Person],
+    });
     const { asFragment } = render(
       <ThingProvider thing={mockThingFrom("https://mockiri.com")}>
         <ProfileLink />
@@ -76,6 +80,11 @@ describe("ProfileLink", () => {
   });
 
   it("renders correct path for privacy contacts", () => {
+    mockedUseFullProfile.mockReturnValue({
+      webId: "https://example.com/bob",
+      names: ["Bob"],
+      types: [schema.Person],
+    });
     mockedUseRouter.mockReturnValueOnce({
       route: "/privacy",
     });

--- a/components/profileLink/index.test.jsx
+++ b/components/profileLink/index.test.jsx
@@ -51,6 +51,17 @@ describe("ProfileLink", () => {
       route: "/contacts",
     });
   });
+
+  it("returns null on first render when profile is still null", () => {
+    mockedUseFullProfile.mockReturnValue(null);
+    const { asFragment } = render(
+      <ThingProvider thing={alice}>
+        <ProfileLink iri={iri} />
+      </ThingProvider>
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
   it("renders first name from profile names array", () => {
     mockedUseFullProfile.mockReturnValue({
       webId: "https://example.com/alice",

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -234,13 +234,9 @@ export async function getFullProfile(webId, session) {
 
   // find the editable profile datasets
   // check if webid is editable
-  const webIdResourceInfo = await getResourceInfo(
-    getSourceIri(profiles.webIdProfile),
-    {
-      fetch: session.fetch,
-    }
+  const { user: profileEditingAccess } = getEffectiveAccess(
+    profiles.webIdProfile
   );
-  const { user: profileEditingAccess } = getEffectiveAccess(webIdResourceInfo);
   const isProfileEditable =
     profileEditingAccess.write || profileEditingAccess.append;
   if (isProfileEditable) {


### PR DESCRIPTION
This PR addresses a bug where 2.0 account could not be added to contacts, as the old `fetchProfile` function failed to get a profile document. In this PR we use the new `getFullProfile` function to get a full Solid profile and use that instead in the specific places where necessary to fix this bug.

This PR ***does not*** intend to be a deep cleanup of Contacts code, it just addresses the bug, as updating the code in Contacts completely would be a much larger undertaking and it is not worth addressing now considering other priorities.

Essentially this PR updates: 
- AddContact button to use new full profile function
- ContactList (specifically, ProfileLink) to use name from profile returned from new full profile function

## Testing
- try to add a 2.0 WebID to contacts and verify it works as intended

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
