### PR TITLE
pass purpose to aproveAccessRequest

### DIFF
--- a/components/accessRequestForm/index.jsx
+++ b/components/accessRequestForm/index.jsx
@@ -136,6 +136,7 @@ export default function AccessRequestForm({
           resources: selectedResources,
           expirationDate: selectedDate ? new Date(selectedDate) : null,
           resourceOwner: session.info.webId,
+          purpose: selectedPurposes,
         },
         {
           fetch: session.fetch,


### PR DESCRIPTION
## Description

This PR fixes PB not passing the purpose when approving an access request.

## Testing

Generate a request and select only one purpose. Verify the grant reflects this once redirected.

## Commit checklist

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
