### PR TITLE
set time to just before midnight when selecting expiration date

### DIFF
--- a/components/accessRequestForm/index.jsx
+++ b/components/accessRequestForm/index.jsx
@@ -209,6 +209,7 @@ export default function AccessRequestForm({
   ]);
 
   const handleDateChange = (date) => {
+    date?.setUTCHours(23, 59, 59, 0);
     setSelectedDate(date ? date.toISOString() : null);
   };
 


### PR DESCRIPTION
## Description

In this PR: setting date to just before midnight when selecting a new expiration date using the date picker.

## Testing

Generate a request. Using the vercel deployment for this PR, change the expiration date and verify that the correct date is reflected on the grant once approved and redirected. 

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
