### PR TITLE
accept a request with no purpose

### DIFF
--- a/components/accessRequestForm/index.jsx
+++ b/components/accessRequestForm/index.jsx
@@ -126,7 +126,10 @@ export default function AccessRequestForm({
   const requestor = getRequestorWebId(accessRequest);
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (selectedAccess.length && selectedPurposes.length) {
+    if (
+      selectedAccess.length &&
+      ((purposes && selectedPurposes.length) || !purposes)
+    ) {
       const date = new Date(selectedDate);
       date.setUTCHours(23, 59, 59, 0);
       const signedVc = await approveAccessRequest(
@@ -151,7 +154,7 @@ export default function AccessRequestForm({
       }
     }
     /* istanbul ignore next */
-    if (!selectedPurposes.length) {
+    if (purposes && !selectedPurposes.length) {
       setOpen(ACCESS_REQUEST_NO_ACCESS_DIALOG);
       setTitle(NO_PURPOSE_TITLE);
       setCancelText("Ok");


### PR DESCRIPTION
## Description

In this PR: accepting an access request without a purpose

## Testing

- Generate a request without a purpose (@matthieubosquet using your demo app or tweaking the existing demo app)
- Use the Vercel deployment for this PR to display the request on PB (replace the corresponding path on the URL)
- verify that you can approve a request without issues and the grant reflects that lack of purpose

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

