### PR TITLE
handle case where no date is selected

### DIFF
--- a/components/accessRequestForm/index.jsx
+++ b/components/accessRequestForm/index.jsx
@@ -130,8 +130,8 @@ export default function AccessRequestForm({
       selectedAccess.length &&
       ((purposes && selectedPurposes.length) || !purposes)
     ) {
-      const date = new Date(selectedDate);
-      date.setUTCHours(23, 59, 59, 0);
+      const expirationDate = selectedDate ? new Date(selectedDate) : null;
+      expirationDate?.setUTCHours(23, 59, 59, 0);
       const signedVc = await approveAccessRequest(
         session.info.webId,
         accessRequest,
@@ -139,7 +139,7 @@ export default function AccessRequestForm({
           requestor,
           access: selectedAccess.accessModes,
           resources: selectedResources,
-          expirationDate: date || null,
+          expirationDate,
           resourceOwner: session.info.webId,
           purpose: selectedPurposes,
         },


### PR DESCRIPTION
## Description

This PR fixes the issue described in https://github.com/inrupt/pod-browser/pull/491/files#r893842855

However, setting date to "forever" won't change the expiration date on the grant because of a bug on the SDK. Since there is still discussion as to how to handle that, one proposed solution was to distinguish `null` from `undefined` values for expiration date, so I have explicitly set this to null if no date is selected. We can revisit this when that issue is solved.

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

