### PR TITLE
add new thing with correct subject if not available

### DIFF
--- a/__testUtils/mockPersonResource.js
+++ b/__testUtils/mockPersonResource.js
@@ -27,7 +27,7 @@ import {
   mockThingFrom,
   setThing,
 } from "@inrupt/solid-client";
-import { vcard, foaf, rdf, space, rdfs } from "rdf-namespaces";
+import { vcard, foaf, rdf, space, rdfs, schema } from "rdf-namespaces";
 import { chain } from "../src/solidClientHelpers/utils";
 import { packageProfile } from "../src/solidClientHelpers/profile";
 import { vcardExtras } from "../src/addressBook";
@@ -102,10 +102,35 @@ export function mockPersonDatasetAlice(...operations) {
   );
 }
 
+export function mockEmptyDatasetAlice() {
+  return mockSolidDatasetFrom("http://alice.example.com/seeAlsoEmpty");
+}
+
+export function mockPersonThingAliceWithEmptySeeAlso() {
+  return chain(
+    mockThingFrom(aliceWebIdUrl),
+    (t) => addUrl(t, rdfs.seeAlso, "http://alice.example.com/seeAlsoEmpty"),
+    (t) => addUrl(t, rdf.type, schema.Person)
+  );
+}
+
+export function mockPersonDatasetAliceWithEmptySeeAlso() {
+  return chain(mockSolidDatasetFrom(aliceWebIdUrl), (d) =>
+    setThing(d, mockPersonThingAliceWithEmptySeeAlso())
+  );
+}
+
+export function mockDatasetAliceWithNewThing() {
+  return setThing(
+    mockEmptyDatasetAlice(),
+    addUrl(mockThingFrom(aliceWebIdUrl), rdf.type, schema.Person)
+  );
+}
+
 export function mockPersonDatasetAliceWithContactInfo(...operations) {
   return chain(
     mockSolidDatasetFrom(aliceWebIdUrl),
-    (d) => setThing(d, mockPersonThingAlice(...operations)),
+    (d) => setThing(d, mockPersonThingAliceWithContactInfo(...operations)),
     (d) => setThing(d, mockEmailThing),
     (d) => setThing(d, mockPhoneThing),
     ...operations
@@ -114,7 +139,7 @@ export function mockPersonDatasetAliceWithContactInfo(...operations) {
 
 export function mockSeeAlsoThingAlice() {
   return chain(
-    mockThingFrom("http://alice.example.com/aliceSeeAlso"),
+    mockThingFrom(aliceWebIdUrl),
     (t) => addStringNoLocale(t, foaf.name, "Alternative Alice"),
     (t) =>
       addUrl(t, vcard.hasPhoto, "https://example.com/anotherphotoforalice.jpg")
@@ -124,7 +149,7 @@ export function mockSeeAlsoThingAlice() {
 export function mockSeeAlsoDatasetAlice() {
   return chain(
     mockSolidDatasetFrom("http://alice.example.com/aliceSeeAlso"),
-    (d) => setThing(d, mockSeeAlsoThingAlice(d, mockPhoneThing))
+    (d) => setThing(d, mockSeeAlsoThingAlice())
   );
 }
 

--- a/components/header/__snapshots__/index.test.jsx.snap
+++ b/components/header/__snapshots__/index.test.jsx.snap
@@ -150,15 +150,12 @@ exports[`Header with user logged in renders a header 1`] = `
           type="button"
         >
           <span
-            class="PodBrowser-user-menu__trigger-profile-image"
-            style="background-image: url(http://alice.example.com/alice.jpg);"
-          >
-             
-          </span>
+            class="PodBrowser-icon-user-circle PodBrowser-user-menu__trigger-icon"
+          />
           <span
             class="PodBrowser-user-menu__trigger-label"
           >
-            Alice
+            Account
           </span>
           <span
             class="PodBrowser-icon-caret-down PodBrowser-user-menu__trigger-chevron PodBrowser-user-menu__trigger-chevron--show"

--- a/components/header/index.test.jsx
+++ b/components/header/index.test.jsx
@@ -33,7 +33,10 @@ import { TESTCAFE_ID_USER_MENU } from "./userMenu";
 import { TESTCAFE_ID_MAIN_NAV } from "./mainNav";
 import { TESTCAFE_ID_MENU_DRAWER } from "./menuDrawer";
 import useAuthenticatedProfile from "../../src/hooks/useAuthenticatedProfile";
-import { mockProfileAlice } from "../../__testUtils/mockPersonResource";
+import {
+  alicePodRoot,
+  aliceWebIdUrl,
+} from "../../__testUtils/mockPersonResource";
 
 jest.mock("next/router");
 const mockedRouterHook = useRouter;
@@ -54,7 +57,11 @@ describe("Header", () => {
     it("renders a header", async () => {
       const session = mockAuthenticatedSession();
       const SessionProvider = mockSessionContextProvider(session);
-      mockedAuthenticatedHook.mockReturnValue(mockProfileAlice());
+      mockedAuthenticatedHook.mockReturnValue({
+        names: [],
+        webId: aliceWebIdUrl,
+        pods: [alicePodRoot],
+      });
 
       const { asFragment, queryByTestId } = renderWithTheme(
         <SessionProvider>

--- a/components/header/userMenu/__snapshots__/index.test.jsx.snap
+++ b/components/header/userMenu/__snapshots__/index.test.jsx.snap
@@ -18,15 +18,12 @@ exports[`UserMenu renders a menu 1`] = `
         type="button"
       >
         <span
-          class="PodBrowser-user-menu__trigger-profile-image"
-          style="background-image: url(http://alice.example.com/alice.jpg);"
-        >
-           
-        </span>
+          class="PodBrowser-icon-user-circle PodBrowser-user-menu__trigger-icon"
+        />
         <span
           class="PodBrowser-user-menu__trigger-label"
         >
-          Alice
+          Account
         </span>
         <span
           class="PodBrowser-icon-caret-down PodBrowser-user-menu__trigger-chevron PodBrowser-user-menu__trigger-chevron--show"

--- a/components/header/userMenu/index.jsx
+++ b/components/header/userMenu/index.jsx
@@ -40,14 +40,13 @@ export default function UserMenu() {
   const bem = useBem(useStyles());
   const authenticatedProfile = useAuthenticatedProfile();
   const menu = useUserMenu();
-
   if (!authenticatedProfile) return <Spinner />;
 
   return (
     <div className={bem("userMenu")} data-testid={TESTCAFE_ID_USER_MENU}>
       <PrismUserMenu
         className={bem("userMenu__trigger")}
-        label={authenticatedProfile.name || "Account"}
+        label={authenticatedProfile.names[0] || "Account"}
         imgSrc={authenticatedProfile.avatar}
         menu={menu}
         menuId="UserMenu"

--- a/components/header/userMenu/index.test.jsx
+++ b/components/header/userMenu/index.test.jsx
@@ -35,7 +35,11 @@ const mockedAuthenticatedProfileHook = useAuthenticatedProfile;
 
 describe("UserMenu", () => {
   beforeEach(() => {
-    mockedAuthenticatedProfileHook.mockReturnValue(mockProfileAlice());
+    mockedAuthenticatedProfileHook.mockReturnValue({
+      names: [],
+      webId: aliceWebIdUrl,
+      pods: [alicePodRoot],
+    });
   });
 
   it("renders a menu", () => {
@@ -51,6 +55,7 @@ describe("UserMenu", () => {
 
   it("renders fallback for name and user photo if not available", () => {
     mockedAuthenticatedProfileHook.mockReturnValue({
+      names: [],
       webId: aliceWebIdUrl,
       pods: [alicePodRoot],
     });

--- a/components/pages/profile/index.jsx
+++ b/components/pages/profile/index.jsx
@@ -45,6 +45,7 @@ export default function ProfileShow() {
       <EditableProfile
         profile={agentProfile}
         profileDataset={editableProfile}
+        webId={agentProfile.webId}
       />
     );
   }

--- a/components/profile/contactInfoTable/index.jsx
+++ b/components/profile/contactInfoTable/index.jsx
@@ -210,6 +210,7 @@ export function setupOnChange(setFn) {
 }
 
 export default function ContactTable({
+  webId,
   editing,
   property,
   values,
@@ -224,7 +225,7 @@ export default function ContactTable({
   const { fetch } = useSession();
 
   const { solidDataset: dataset, setDataset } = useContext(DatasetContext);
-  const { thing: profile } = useThing();
+  const profile = dataset && getThing(dataset, webId);
   const contactDetailUrls = profile && getUrlAll(profile, property);
   const contactDetailThings = contactDetailUrls?.map((url) => ({
     dataset,
@@ -371,6 +372,7 @@ ContactTable.propTypes = {
   contactInfoType: T.oneOf([CONTACT_INFO_TYPE_EMAIL, CONTACT_INFO_TYPE_PHONE])
     .isRequired,
   values: T.arrayOf(T.shape({ type: T.string, value: T.string })),
+  webId: T.string.isRequired,
 };
 
 ContactTable.defaultProps = {

--- a/components/profile/contactInfoTable/index.test.jsx
+++ b/components/profile/contactInfoTable/index.test.jsx
@@ -45,6 +45,7 @@ import ContactInfoTable, {
 } from "./index";
 import useDataset from "../../../src/hooks/useDataset";
 import {
+  aliceWebIdUrl,
   mockPersonDatasetAliceWithContactInfo,
   mockPersonThingAliceWithContactInfo,
 } from "../../../__testUtils/mockPersonResource";
@@ -78,6 +79,7 @@ describe("ContactInfoTable", () => {
           property={vcard.hasEmail}
           contactInfoType={CONTACT_INFO_TYPE_EMAIL}
           values={contactInfo}
+          webId={aliceWebIdUrl}
         />
       </SessionProvider>
     );
@@ -98,6 +100,7 @@ describe("ContactInfoTable", () => {
             property={vcard.hasEmail}
             editing
             contactInfoType={CONTACT_INFO_TYPE_EMAIL}
+            webId={aliceWebIdUrl}
           />
         </CombinedDataProvider>
       </SessionProvider>

--- a/components/profile/editableProfile/index.jsx
+++ b/components/profile/editableProfile/index.jsx
@@ -19,15 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useState } from "react";
+import React from "react";
 import T from "prop-types";
 import { Box, Paper } from "@material-ui/core";
-import { Alert } from "@material-ui/lab";
 import { Container } from "@inrupt/prism-react-components";
-import { CombinedDataProvider, useSession } from "@inrupt/solid-ui-react";
-import { getSourceUrl } from "@inrupt/solid-client";
+import { CombinedDataProvider } from "@inrupt/solid-ui-react";
+import { getThing } from "@inrupt/solid-client";
 import { schema } from "rdf-namespaces";
-import { isHTTPError } from "../../../src/error";
 import PersonProfile from "../personProfile";
 import PersonAvatar from "../personAvatar";
 import AppProfile from "../appProfile";
@@ -38,20 +36,16 @@ export const TESTCAFE_ID_NAME_FIELD = "profile-name-field";
 export const TESTCAFE_ID_ROLE_FIELD = "profile-role-field";
 export const TESTCAFE_ID_ORG_FIELD = "profile-org-field";
 
-export default function EditableProfile({ profileDataset, profile }) {
+export default function EditableProfile({ profileDataset, profile, webId }) {
   if (!profileDataset) {
     return <span>No profile document found this this WebID</span>;
   }
-
   if (profile.types.includes(schema.SoftwareApplication)) {
     return <AppProfile />;
   }
 
   return (
-    <CombinedDataProvider
-      solidDataset={profileDataset}
-      thingUrl={getSourceUrl(profileDataset)}
-    >
+    <CombinedDataProvider solidDataset={profileDataset} thingUrl={webId}>
       <Container>
         <Paper style={{ marginTop: "1em" }}>
           <Box p={2}>
@@ -77,6 +71,7 @@ EditableProfile.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   profileDataset: T.object,
   profile: profilePropTypes,
+  webId: T.string.isRequired,
 };
 
 EditableProfile.defaultProps = {

--- a/components/profile/editableProfile/index.test.jsx
+++ b/components/profile/editableProfile/index.test.jsx
@@ -71,6 +71,7 @@ describe("EditableProfile", () => {
           <EditableProfile
             profile={mockProfileAlice}
             profileDataset={profileDataset}
+            webId={aliceWebIdUrl}
           />
         </SessionProvider>
       );
@@ -94,6 +95,7 @@ describe("EditableProfile", () => {
           <EditableProfile
             profileDataset={profileDataset}
             profile={mockAppProfile}
+            webId={aliceWebIdUrl}
           />
         </SessionProvider>
       );

--- a/components/profile/personAvatar/index.jsx
+++ b/components/profile/personAvatar/index.jsx
@@ -19,18 +19,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useContext } from "react";
+import React from "react";
 import T from "prop-types";
-import { foaf, vcard } from "rdf-namespaces";
+import { vcard } from "rdf-namespaces";
 import { Avatar, Box, createStyles, Typography } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
 import { useBem } from "@solid/lit-prism-patterns";
 import { Image } from "@inrupt/solid-ui-react";
-import {
-  getSourceUrl,
-  getStringNoLocale,
-  getThing,
-} from "@inrupt/solid-client";
+import { getSourceUrl, getThing } from "@inrupt/solid-client";
 import styles from "./styles";
 import { profilePropTypes } from "../../../constants/propTypes";
 
@@ -56,10 +52,7 @@ export default function PersonAvatar({
   const errorComponent = setupErrorComponent(bem);
   const thing =
     profileDataset && getThing(profileDataset, getSourceUrl(profileDataset));
-  const name = editing
-    ? (thing && getStringNoLocale(thing, foaf.name)) ||
-      (thing && getStringNoLocale(thing, vcard.fn))
-    : profile?.names[0];
+  const name = profile?.names[0];
 
   if (!profile && !profileDataset) {
     return (

--- a/components/profile/personProfile/index.jsx
+++ b/components/profile/personProfile/index.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import T from "prop-types";
-import { getSourceUrl } from "@inrupt/solid-client";
+import { getSourceUrl, getThing } from "@inrupt/solid-client";
 import { foaf, vcard } from "rdf-namespaces";
 import { Box, InputLabel, createStyles } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";
@@ -98,6 +98,7 @@ export default function PersonProfile({ profile, profileDataset, editing }) {
         <Box mt={4}>
           <InputLabel>Email Addresses</InputLabel>
           <ContactInfoTable
+            webId={profile.webId}
             datasetIri={getSourceUrl(profileDataset)}
             property={vcard.hasEmail}
             editing={editing}
@@ -108,6 +109,7 @@ export default function PersonProfile({ profile, profileDataset, editing }) {
         <Box mt={4}>
           <InputLabel>Phone Numbers</InputLabel>
           <ContactInfoTable
+            webId={profile.webId}
             datasetIri={getSourceUrl(profileDataset)}
             property={vcard.hasTelephone}
             editing={editing}

--- a/components/profile/personProfile/index.jsx
+++ b/components/profile/personProfile/index.jsx
@@ -21,7 +21,7 @@
 
 import React from "react";
 import T from "prop-types";
-import { getSourceUrl, getThing } from "@inrupt/solid-client";
+import { getSourceUrl } from "@inrupt/solid-client";
 import { foaf, vcard } from "rdf-namespaces";
 import { Box, InputLabel, createStyles } from "@material-ui/core";
 import { makeStyles } from "@material-ui/styles";


### PR DESCRIPTION
## Description

This PR: 
- introduces a change in the `getFullProfile` function: when a Thing with WebID as subject cannot be found, one is created and added to the dataset (all of the editable datasets) so that we can use the WebID as Thing URL in the Context wrapping the Profile page.
- simplifies the `getFullProfile` function
- add tests

## To test:
- Create a new account and edit profile on prod PB
- Verify the profile contains wrong triples (profile dataset URL as subject instead of WebID)
- Log in on the deployment of this branch and edit profile
- verify a triple has been added with WebID as subject

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

