### PR TITLE
removed webID from accept deny funcs

### DIFF
--- a/components/accessRequestForm/index.jsx
+++ b/components/accessRequestForm/index.jsx
@@ -133,7 +133,6 @@ export default function AccessRequestForm({
       const expirationDate = selectedDate ? new Date(selectedDate) : null;
       expirationDate?.setUTCHours(23, 59, 59, 0);
       const signedVc = await approveAccessRequest(
-        session.info.webId,
         accessRequest,
         {
           requestor,
@@ -180,10 +179,7 @@ export default function AccessRequestForm({
 
   useEffect(() => {
     const handleDenyAccessRequest = async () => {
-      const signedVc = await denyAccessRequest(
-        session.info.webId,
-        accessRequest
-      );
+      const signedVc = await denyAccessRequest(accessRequest);
       if (signedVc) {
         await router.push(
           `${redirectUrl}?${GRANT_VC_URL_PARAM_NAME}=${getVcId(signedVc)}`


### PR DESCRIPTION
## Description
Clean up of code. 
## Changes
The SDK removed the argument of the resourceOwner from their code. This change is now reflected in PodBrowser where we remove the resourceOwner from the argument list when calling `approveAccessRequest` and `denyAccessRequest` 
## Testing
Start the request access flow. 
Get re-routed to PodBrowser (make sure the reroute brings you to localhost PB and not prod PB, you can update the URL to reflect this too)
Accept Request. 
Login to PodBrowser as the requesting user. 
In the upper right corner where it says "change pod", put in the resource URI that you requested access to. 
CHECK IF YOU HAVE ACCESS. If yes it worked.  
Start the request access flow again, use the same resource that you just confirmed you have access to. 
Get re-routed to PB. Again confirm you are in localhost and not podbrowser.inrupt.com
CLick Deny
Login to PodBrowser as the requesting user. 
In the upper right corner where it says "change pod", put in the resource URI that you requested access to. 
CHECK THAT YOU DON"T HAVE ACCESS. If you don't, it worked.  
## Commit checklist

- [ ] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

## Interested parties

## Notes

## Screenshots/captures
