### PR TITLE
handle no pod URL and error fetching extended profile properly

### DIFF
--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -20,16 +20,8 @@
  */
 
 import React, { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/router";
 import T from "prop-types";
-import {
-  getEffectiveAccess,
-  getResourceInfo,
-  getSourceUrl,
-  isContainer,
-} from "@inrupt/solid-client";
-import { makeStyles } from "@material-ui/styles";
-import { createStyles } from "@material-ui/core";
+import { getSourceUrl, isContainer } from "@inrupt/solid-client";
 import { useSession } from "@inrupt/solid-ui-react";
 import { renderResourceType } from "../containerTableRow";
 import { getResourceName } from "../../src/solidClientHelpers/resource";
@@ -42,10 +34,7 @@ import ResourceNotFound from "../resourceNotFound";
 import useContainer from "../../src/hooks/useContainer";
 import NotSupported from "../notSupported";
 import { getContainerResourceUrlAll } from "../../src/models/container";
-import {
-  getContainerUrl,
-  getParentContainerUrl,
-} from "../../src/stringHelpers";
+import { getContainerUrl } from "../../src/stringHelpers";
 import ContainerSubHeader from "../containerSubHeader";
 import useAuthenticatedProfile from "../../src/hooks/useAuthenticatedProfile";
 import AuthProfileLoadError from "../authProfileLoadError";
@@ -57,8 +46,7 @@ import ContainerTable from "../containerTable";
 import { isHTTPError } from "../../src/error";
 import { locationIsConnectedToProfile } from "../../src/solidClientHelpers/profile";
 import { isContainerIri } from "../../src/solidClientHelpers/utils";
-import DownloadLink, { downloadResource } from "../downloadLink";
-import styles from "../resourceDetails/styles";
+import { downloadResource } from "../downloadLink";
 import useAccessToResourceAndParentContainer from "../../src/hooks/useAccessToResourceAndParentContainer";
 import DownloadResourceMessage from "../downloadResourceMessage";
 import usePodRootUri from "../../src/hooks/usePodRootUri";
@@ -90,12 +78,8 @@ function maybeRenderWarning(locationIsInUsersPod, noControlError, podRootIri) {
   );
 }
 
-const useStyles = makeStyles((theme) => createStyles(styles(theme)));
-
 export default function Container({ iri }) {
   const [download, setDownload] = useState(false);
-  const classes = useStyles();
-  const router = useRouter();
   const { sessionRequestInProgress, session } = useSession();
   const [resourceUrls, setResourceUrls] = useState(null);
   const authenticatedProfile = useAuthenticatedProfile();

--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -63,6 +63,8 @@ import styles from "../resourceDetails/styles";
 import useAccessToResourceAndParentContainer from "../../src/hooks/useAccessToResourceAndParentContainer";
 import DownloadResourceMessage from "../downloadResourceMessage";
 
+export const NO_POD_URL_ERROR = "We could not find a URL for your Pod.";
+
 function isNotAContainerResource(iri, container) {
   if (!iri) return true;
   return (
@@ -149,6 +151,8 @@ export default function Container({ iri }) {
     }));
   }, [resourceUrls]);
 
+  if (!podRootIri) return <span>{NO_POD_URL_ERROR}</span>;
+
   if (!iri || isValidating || validatingPodRootAccessControl)
     return <Spinner />;
 
@@ -172,7 +176,7 @@ export default function Container({ iri }) {
 
   if (podRootError && locationIsInUsersPod) return <PodRootLoadError />;
 
-  if (!resourceUrls || !container || !podRootIri) return <Spinner />;
+  if (!resourceUrls || !container) return <Spinner />;
 
   const { dataset: containerDataset } = container;
 

--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -62,8 +62,7 @@ import styles from "../resourceDetails/styles";
 import useAccessToResourceAndParentContainer from "../../src/hooks/useAccessToResourceAndParentContainer";
 import DownloadResourceMessage from "../downloadResourceMessage";
 import usePodRootUri from "../../src/hooks/usePodRootUri";
-
-export const NO_POD_URL_ERROR = "We could not find a URL for your Pod.";
+import NoPodFoundError from "../noPodFoundError";
 
 function isNotAContainerResource(iri, container) {
   if (!iri) return true;
@@ -151,8 +150,7 @@ export default function Container({ iri }) {
     }));
   }, [resourceUrls]);
 
-  if (authenticatedProfile && podRootIri === null)
-    return <span>{NO_POD_URL_ERROR}</span>;
+  if (authenticatedProfile && podRootIri === null) return <NoPodFoundError />;
 
   const locationIsInUsersPod = locationIsConnectedToProfile(
     authenticatedProfile,

--- a/components/header/userMenu/index.jsx
+++ b/components/header/userMenu/index.jsx
@@ -40,7 +40,6 @@ export default function UserMenu() {
   const bem = useBem(useStyles());
   const authenticatedProfile = useAuthenticatedProfile();
   const menu = useUserMenu();
-  // if (!authenticatedProfile) return <Spinner />;
 
   return (
     <div className={bem("userMenu")} data-testid={TESTCAFE_ID_USER_MENU}>

--- a/components/header/userMenu/index.jsx
+++ b/components/header/userMenu/index.jsx
@@ -40,14 +40,14 @@ export default function UserMenu() {
   const bem = useBem(useStyles());
   const authenticatedProfile = useAuthenticatedProfile();
   const menu = useUserMenu();
-  if (!authenticatedProfile) return <Spinner />;
+  // if (!authenticatedProfile) return <Spinner />;
 
   return (
     <div className={bem("userMenu")} data-testid={TESTCAFE_ID_USER_MENU}>
       <PrismUserMenu
         className={bem("userMenu__trigger")}
-        label={authenticatedProfile.names[0] || "Account"}
-        imgSrc={authenticatedProfile.avatar}
+        label={authenticatedProfile?.names[0] || "Account"}
+        imgSrc={authenticatedProfile?.avatar}
         menu={menu}
         menuId="UserMenu"
         data-testid={TESTCAFE_ID_USER_MENU_BUTTON}

--- a/components/header/userMenu/index.test.jsx
+++ b/components/header/userMenu/index.test.jsx
@@ -47,12 +47,6 @@ describe("UserMenu", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it("renders a spinner while loading user profile", () => {
-    mockedAuthenticatedProfileHook.mockReturnValue(null);
-    const { getByTestId } = renderWithTheme(<UserMenu />);
-    expect(getByTestId(TESTCAFE_ID_SPINNER)).toBeDefined();
-  });
-
   it("renders fallback for name and user photo if not available", () => {
     mockedAuthenticatedProfileHook.mockReturnValue({
       names: [],

--- a/components/noPodFoundError/__snapshots__/index.test.jsx.snap
+++ b/components/noPodFoundError/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`PodRootLoadError renders 1`] = `
       class="PodBrowser-container"
     >
       <p>
-        PodBrowser could not found a URL fo a Pod linked to your profile.
+        PodBrowser could not find a URL for a Pod linked to your profile.
       </p>
     </div>
   </div>

--- a/components/noPodFoundError/__snapshots__/index.test.jsx.snap
+++ b/components/noPodFoundError/__snapshots__/index.test.jsx.snap
@@ -11,12 +11,15 @@ exports[`PodRootLoadError renders 1`] = `
     </h1>
     <p>
       It appears you do not have a Pod.
-      <a
-        href="https://id.inrupt.com/"
-      >
-        Get a Pod
-      </a>
     </p>
+    <a
+      class="PodBrowser-podLink"
+      href="https://id.inrupt.com/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Get a Pod
+    </a>
   </div>
 </DocumentFragment>
 `;

--- a/components/noPodFoundError/__snapshots__/index.test.jsx.snap
+++ b/components/noPodFoundError/__snapshots__/index.test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Index page Renders an error if there is an empty array of pod iris 1`] = `
+exports[`PodRootLoadError renders 1`] = `
 <DocumentFragment>
   <div
     data-testid="no-pod-found-error"
@@ -24,7 +24,3 @@ exports[`Index page Renders an error if there is an empty array of pod iris 1`] 
   </div>
 </DocumentFragment>
 `;
-
-exports[`Index page Renders null if there is no profile 1`] = `<DocumentFragment />`;
-
-exports[`Index page silently fails on router errors 1`] = `<DocumentFragment />`;

--- a/components/noPodFoundError/__snapshots__/index.test.jsx.snap
+++ b/components/noPodFoundError/__snapshots__/index.test.jsx.snap
@@ -3,24 +3,20 @@
 exports[`PodRootLoadError renders 1`] = `
 <DocumentFragment>
   <div
-    data-testid="no-pod-found-error"
+    class="PodBrowser-container"
+    data-testid="no-pod-message"
   >
-    <div
-      class="PodBrowser-page-header"
-    >
-      <h1
-        class="PodBrowser-page-header__title"
+    <h1>
+      Pod Not Found
+    </h1>
+    <p>
+      It appears you do not have a Pod.
+      <a
+        href="https://id.inrupt.com/"
       >
-        Pod URL Not Found
-      </h1>
-    </div>
-    <div
-      class="PodBrowser-container"
-    >
-      <p>
-        PodBrowser could not find a URL for a Pod linked to your profile.
-      </p>
-    </div>
+        Get a Pod
+      </a>
+    </p>
   </div>
 </DocumentFragment>
 `;

--- a/components/noPodFoundError/index.jsx
+++ b/components/noPodFoundError/index.jsx
@@ -29,7 +29,7 @@ export default function NoPodFoundError() {
     <div data-testid={TESTCAFE_ID_NO_POD_FOUND_ERROR}>
       <PageHeader title="Pod URL Not Found" />
       <Container>
-        <p>PodBrowser could not found a URL fo a Pod linked to your profile.</p>
+        <p>PodBrowser could not find a URL for a Pod linked to your profile.</p>
       </Container>
     </div>
   );

--- a/components/noPodFoundError/index.jsx
+++ b/components/noPodFoundError/index.jsx
@@ -34,10 +34,15 @@ export default function NoPodFoundError() {
   return (
     <div className={classes.container} data-testid={TESTCAFE_ID_NO_POD_MESSAGE}>
       <h1>Pod Not Found</h1>
-      <p>
-        It appears you do not have a Pod.
-        <a href="https://id.inrupt.com/">Get a Pod</a>
-      </p>
+      <p>It appears you do not have a Pod.</p>
+      <a
+        className={classes.podLink}
+        href="https://id.inrupt.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Get a Pod
+      </a>
     </div>
   );
 }

--- a/components/noPodFoundError/index.jsx
+++ b/components/noPodFoundError/index.jsx
@@ -19,34 +19,18 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useEffect } from "react";
-import { useRouter } from "next/router";
+import React from "react";
+import { Container, PageHeader } from "@inrupt/prism-react-components";
 
-import { useSession } from "@inrupt/solid-ui-react";
+export const TESTCAFE_ID_NO_POD_FOUND_ERROR = "no-pod-found-error";
 
-import { resourceHref } from "../../../src/navigator";
-import useFullProfile from "../../../src/hooks/useFullProfile";
-import NoPodFoundError from "../../noPodFoundError";
-
-export default function Home() {
-  const router = useRouter();
-
-  const { session } = useSession();
-  const authenticatedProfile = useFullProfile(session.info.webId);
-
-  useEffect(() => {
-    if (authenticatedProfile?.pods.length > 0) {
-      router
-        .replace("/resource/[iri]", resourceHref(authenticatedProfile?.pods[0]))
-        .catch(() => {
-          /* fire and forget */
-        });
-    }
-  }, [authenticatedProfile, router]);
-
-  if (authenticatedProfile && !authenticatedProfile?.pods.length) {
-    return <NoPodFoundError />;
-  }
-
-  return null;
+export default function NoPodFoundError() {
+  return (
+    <div data-testid={TESTCAFE_ID_NO_POD_FOUND_ERROR}>
+      <PageHeader title="Pod URL Not Found" />
+      <Container>
+        <p>PodBrowser could not found a URL fo a Pod linked to your profile.</p>
+      </Container>
+    </div>
+  );
 }

--- a/components/noPodFoundError/index.test.jsx
+++ b/components/noPodFoundError/index.test.jsx
@@ -19,34 +19,13 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useEffect } from "react";
-import { useRouter } from "next/router";
+import React from "react";
+import { renderWithTheme } from "../../__testUtils/withTheme";
+import PodRootLoadError from "./index";
 
-import { useSession } from "@inrupt/solid-ui-react";
-
-import { resourceHref } from "../../../src/navigator";
-import useFullProfile from "../../../src/hooks/useFullProfile";
-import NoPodFoundError from "../../noPodFoundError";
-
-export default function Home() {
-  const router = useRouter();
-
-  const { session } = useSession();
-  const authenticatedProfile = useFullProfile(session.info.webId);
-
-  useEffect(() => {
-    if (authenticatedProfile?.pods.length > 0) {
-      router
-        .replace("/resource/[iri]", resourceHref(authenticatedProfile?.pods[0]))
-        .catch(() => {
-          /* fire and forget */
-        });
-    }
-  }, [authenticatedProfile, router]);
-
-  if (authenticatedProfile && !authenticatedProfile?.pods.length) {
-    return <NoPodFoundError />;
-  }
-
-  return null;
-}
+describe("PodRootLoadError", () => {
+  it("renders", () => {
+    const { asFragment } = renderWithTheme(<PodRootLoadError />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/noPodFoundError/styles.js
+++ b/components/noPodFoundError/styles.js
@@ -19,21 +19,25 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { content } from "@solid/lit-prism-patterns";
+import { createStyles, button } from "@solid/lit-prism-patterns";
 
-const rules = {
-  container: {
-    display: "flex",
-    flexDirection: "column",
-    textAlign: "center",
-    justifyContent: "center",
-    padding: "15% 2rem 2rem 2rem",
-  },
+const styles = (theme) => {
+  const buttonStyles = button.styles(theme);
+  return createStyles(theme, ["table", "icons"], {
+    container: {
+      display: "flex",
+      flexDirection: "column",
+      textAlign: "center",
+      justifyContent: "center",
+      padding: "15% 2rem 2rem 2rem",
+    },
+    podLink: {
+      ...buttonStyles.button,
+      maxWidth: "fit-content",
+      alignSelf: "center",
+      cursor: "pointer",
+    },
+  });
 };
 
-export default function styles(theme) {
-  return {
-    ...rules,
-    ...content.styles(theme),
-  };
-}
+export default styles;

--- a/components/noPodFoundError/styles.js
+++ b/components/noPodFoundError/styles.js
@@ -19,25 +19,21 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import { makeStyles } from "@material-ui/styles";
-import { createStyles } from "@material-ui/core";
-import styles from "./styles";
+import { content } from "@solid/lit-prism-patterns";
 
-export const TESTCAFE_ID_NO_POD_MESSAGE = "no-pod-message";
+const rules = {
+  container: {
+    display: "flex",
+    flexDirection: "column",
+    textAlign: "center",
+    justifyContent: "center",
+    padding: "15% 2rem 2rem 2rem",
+  },
+};
 
-const useStyles = makeStyles((theme) => createStyles(styles(theme)));
-
-export default function NoPodFoundError() {
-  const classes = useStyles();
-
-  return (
-    <div className={classes.container} data-testid={TESTCAFE_ID_NO_POD_MESSAGE}>
-      <h1>Pod Not Found</h1>
-      <p>
-        It appears you do not have a Pod.
-        <a href="https://id.inrupt.com/">Get a Pod</a>
-      </p>
-    </div>
-  );
+export default function styles(theme) {
+  return {
+    ...rules,
+    ...content.styles(theme),
+  };
 }

--- a/components/pages/index/__snapshots__/index.test.jsx.snap
+++ b/components/pages/index/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`Index page Renders an error if there is an empty array of pod iris 1`] 
       class="PodBrowser-container"
     >
       <p>
-        PodBrowser could not found a URL fo a Pod linked to your profile.
+        PodBrowser could not find a URL for a Pod linked to your profile.
       </p>
     </div>
   </div>

--- a/components/pages/index/__snapshots__/index.test.jsx.snap
+++ b/components/pages/index/__snapshots__/index.test.jsx.snap
@@ -3,24 +3,20 @@
 exports[`Index page Renders an error if there is an empty array of pod iris 1`] = `
 <DocumentFragment>
   <div
-    data-testid="no-pod-found-error"
+    class="PodBrowser-container"
+    data-testid="no-pod-message"
   >
-    <div
-      class="PodBrowser-page-header"
-    >
-      <h1
-        class="PodBrowser-page-header__title"
+    <h1>
+      Pod Not Found
+    </h1>
+    <p>
+      It appears you do not have a Pod.
+      <a
+        href="https://id.inrupt.com/"
       >
-        Pod URL Not Found
-      </h1>
-    </div>
-    <div
-      class="PodBrowser-container"
-    >
-      <p>
-        PodBrowser could not find a URL for a Pod linked to your profile.
-      </p>
-    </div>
+        Get a Pod
+      </a>
+    </p>
   </div>
 </DocumentFragment>
 `;

--- a/components/pages/index/__snapshots__/index.test.jsx.snap
+++ b/components/pages/index/__snapshots__/index.test.jsx.snap
@@ -11,12 +11,15 @@ exports[`Index page Renders an error if there is an empty array of pod iris 1`] 
     </h1>
     <p>
       It appears you do not have a Pod.
-      <a
-        href="https://id.inrupt.com/"
-      >
-        Get a Pod
-      </a>
     </p>
+    <a
+      class="PodBrowser-podLink"
+      href="https://id.inrupt.com/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Get a Pod
+    </a>
   </div>
 </DocumentFragment>
 `;

--- a/components/pages/index/index.test.jsx
+++ b/components/pages/index/index.test.jsx
@@ -25,28 +25,25 @@ import { useRouter } from "next/router";
 import { render } from "@testing-library/react";
 import IndexPage from "./index";
 import { resourceHref } from "../../../src/navigator";
-import usePodIrisFromWebId from "../../../src/hooks/usePodIrisFromWebId";
+import useFullProfile from "../../../src/hooks/useFullProfile";
 import TestApp from "../../../__testUtils/testApp";
 
-jest.mock("../../../src/hooks/usePodIrisFromWebId");
+jest.mock("../../../src/hooks/useFullProfile");
 jest.mock("next/router");
 
 describe("Index page", () => {
   const podIri = "https://mypod.myhost.com";
 
   beforeEach(() => {
-    usePodIrisFromWebId.mockReturnValue({
-      data: [podIri],
+    useFullProfile.mockReturnValue({
+      pods: [podIri],
     });
   });
 
-  it("Renders null if there are no pod iris", () => {
+  it("Renders null if there is no profile", () => {
+    useFullProfile.mockReturnValue(null);
     const replaceMock = jest.fn().mockResolvedValue();
     useRouter.mockReturnValue({ replace: replaceMock });
-
-    usePodIrisFromWebId.mockReturnValue({
-      data: undefined,
-    });
 
     const { asFragment } = render(
       <TestApp>
@@ -56,13 +53,12 @@ describe("Index page", () => {
     expect(asFragment()).toMatchSnapshot();
   });
 
-  it("Renders null if there is an empty array of pod iris", () => {
+  it("Renders an error if there is an empty array of pod iris", () => {
     useRouter.mockReturnValue({
       replace: jest.fn().mockResolvedValue(undefined),
     });
-
-    usePodIrisFromWebId.mockReturnValue({
-      data: [],
+    useFullProfile.mockReturnValue({
+      pods: [],
     });
 
     const { asFragment } = render(

--- a/components/pages/profile/index.jsx
+++ b/components/pages/profile/index.jsx
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 import { SessionContext } from "@inrupt/solid-ui-react";
 import { useRouter } from "next/router";
 import Profile from "../../profile";
@@ -33,6 +33,7 @@ export default function ProfileShow() {
   const decodedIri = router.query.webId
     ? decodeURIComponent(router.query.webId)
     : null;
+
   const agentProfile = useFullProfile(decodedIri ?? session.info.webId);
 
   if (sessionRequestInProgress || !agentProfile) {

--- a/components/pages/resource/__snapshots__/index.test.jsx.snap
+++ b/components/pages/resource/__snapshots__/index.test.jsx.snap
@@ -2,9 +2,26 @@
 
 exports[`Resource page Renders an error if it cannot find a URL for a Pod 1`] = `
 <DocumentFragment>
-  <span>
-    We could not find a URL for your Pod.
-  </span>
+  <div
+    data-testid="no-pod-found-error"
+  >
+    <div
+      class="PodBrowser-page-header"
+    >
+      <h1
+        class="PodBrowser-page-header__title"
+      >
+        Pod URL Not Found
+      </h1>
+    </div>
+    <div
+      class="PodBrowser-container"
+    >
+      <p>
+        PodBrowser could not found a URL fo a Pod linked to your profile.
+      </p>
+    </div>
+  </div>
 </DocumentFragment>
 `;
 

--- a/components/pages/resource/__snapshots__/index.test.jsx.snap
+++ b/components/pages/resource/__snapshots__/index.test.jsx.snap
@@ -18,7 +18,7 @@ exports[`Resource page Renders an error if it cannot find a URL for a Pod 1`] = 
       class="PodBrowser-container"
     >
       <p>
-        PodBrowser could not found a URL fo a Pod linked to your profile.
+        PodBrowser could not find a URL for a Pod linked to your profile.
       </p>
     </div>
   </div>

--- a/components/pages/resource/__snapshots__/index.test.jsx.snap
+++ b/components/pages/resource/__snapshots__/index.test.jsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Resource page Renders an error if it cannot find a URL for a Pod 1`] = `
+<DocumentFragment>
+  <span>
+    We could not find a URL for your Pod.
+  </span>
+</DocumentFragment>
+`;
+
 exports[`Resource page Renders spinner while validating access control 1`] = `
 <DocumentFragment>
   <div

--- a/components/pages/resource/__snapshots__/index.test.jsx.snap
+++ b/components/pages/resource/__snapshots__/index.test.jsx.snap
@@ -11,12 +11,15 @@ exports[`Resource page Renders an error if it cannot find a URL for a Pod 1`] = 
     </h1>
     <p>
       It appears you do not have a Pod.
-      <a
-        href="https://id.inrupt.com/"
-      >
-        Get a Pod
-      </a>
     </p>
+    <a
+      class="PodBrowser-podLink"
+      href="https://id.inrupt.com/"
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Get a Pod
+    </a>
   </div>
 </DocumentFragment>
 `;

--- a/components/pages/resource/__snapshots__/index.test.jsx.snap
+++ b/components/pages/resource/__snapshots__/index.test.jsx.snap
@@ -3,24 +3,20 @@
 exports[`Resource page Renders an error if it cannot find a URL for a Pod 1`] = `
 <DocumentFragment>
   <div
-    data-testid="no-pod-found-error"
+    class="PodBrowser-container"
+    data-testid="no-pod-message"
   >
-    <div
-      class="PodBrowser-page-header"
-    >
-      <h1
-        class="PodBrowser-page-header__title"
+    <h1>
+      Pod Not Found
+    </h1>
+    <p>
+      It appears you do not have a Pod.
+      <a
+        href="https://id.inrupt.com/"
       >
-        Pod URL Not Found
-      </h1>
-    </div>
-    <div
-      class="PodBrowser-container"
-    >
-      <p>
-        PodBrowser could not find a URL for a Pod linked to your profile.
-      </p>
-    </div>
+        Get a Pod
+      </a>
+    </p>
   </div>
 </DocumentFragment>
 `;

--- a/components/pages/resource/index.test.jsx
+++ b/components/pages/resource/index.test.jsx
@@ -28,7 +28,6 @@ import TestApp from "../../../__testUtils/testApp";
 import useAccessControl from "../../../src/hooks/useAccessControl";
 import useAuthenticatedProfile from "../../../src/hooks/useAuthenticatedProfile";
 import useResourceInfo from "../../../src/hooks/useResourceInfo";
-import { NO_POD_URL_ERROR } from "../../container";
 import { aliceWebIdUrl } from "../../../__testUtils/mockPersonResource";
 
 jest.mock("../../../src/hooks/useAccessControl");
@@ -112,7 +111,7 @@ describe("Resource page", () => {
       </TestApp>
     );
     await waitFor(() => {
-      expect(getByText(NO_POD_URL_ERROR)).toBeInTheDocument();
+      expect(getByText("Pod URL Not Found")).toBeInTheDocument();
     });
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/pages/resource/index.test.jsx
+++ b/components/pages/resource/index.test.jsx
@@ -29,6 +29,7 @@ import useAccessControl from "../../../src/hooks/useAccessControl";
 import useAuthenticatedProfile from "../../../src/hooks/useAuthenticatedProfile";
 import useResourceInfo from "../../../src/hooks/useResourceInfo";
 import { aliceWebIdUrl } from "../../../__testUtils/mockPersonResource";
+import { TESTCAFE_ID_NO_POD_MESSAGE } from "../../noPodFoundError";
 
 jest.mock("../../../src/hooks/useAccessControl");
 jest.mock("../../../src/hooks/useResourceInfo");
@@ -105,13 +106,13 @@ describe("Resource page", () => {
       isValidating: false,
     });
 
-    const { asFragment, getByText } = render(
+    const { asFragment, getByTestId } = render(
       <TestApp>
         <IndexPage />
       </TestApp>
     );
     await waitFor(() => {
-      expect(getByText("Pod URL Not Found")).toBeInTheDocument();
+      expect(getByTestId(TESTCAFE_ID_NO_POD_MESSAGE)).toBeInTheDocument();
     });
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/permissionsForm/index.test.jsx
+++ b/components/permissionsForm/index.test.jsx
@@ -41,7 +41,7 @@ const mockedUseFullProfile = useFullProfile;
 
 describe("PermissionsForm", () => {
   const authProfile = mockProfileAlice();
-  const authOwnedIri = joinPath(authProfile.pods[0], "test");
+  const authOwnedIri = authProfile.pods[0];
   const visitorIri = "http://some-random-pod.com/";
   const viewCheckbox = `${TESTCASE_ID_PERMISSION_CHECKBOX}view`;
   const editCheckbox = `${TESTCASE_ID_PERMISSION_CHECKBOX}edit`;

--- a/components/profile/editableProfile/index.jsx
+++ b/components/profile/editableProfile/index.jsx
@@ -24,7 +24,6 @@ import T from "prop-types";
 import { Box, Paper } from "@material-ui/core";
 import { Container } from "@inrupt/prism-react-components";
 import { CombinedDataProvider } from "@inrupt/solid-ui-react";
-import { getThing } from "@inrupt/solid-client";
 import { schema } from "rdf-namespaces";
 import PersonProfile from "../personProfile";
 import PersonAvatar from "../personAvatar";

--- a/components/profile/personAvatar/index.jsx
+++ b/components/profile/personAvatar/index.jsx
@@ -110,11 +110,12 @@ PersonAvatar.propTypes = {
   profileDataset: T.object,
   profile: profilePropTypes,
   editing: T.bool,
-  webId: T.string.isRequired,
+  webId: T.string,
 };
 
 PersonAvatar.defaultProps = {
   profileDataset: null,
   profile: null,
   editing: false,
+  webId: null,
 };

--- a/constants/propTypes.js
+++ b/constants/propTypes.js
@@ -87,7 +87,11 @@ export const profilePropTypes = PropTypes.shape({
   organizations: PropTypes.arrayOf(PropTypes.string),
   editableProfileDatasets: PropTypes.arrayOf(PropTypes.object),
   contactInfo: PropTypes.shape({
-    phones: PropTypes.arrayOf(PropTypes.string),
-    emails: PropTypes.arrayOf(PropTypes.string),
+    phones: PropTypes.arrayOf(
+      PropTypes.shape({ value: PropTypes.string, type: PropTypes.string })
+    ),
+    emails: PropTypes.arrayOf(
+      PropTypes.shape({ value: PropTypes.string, type: PropTypes.string })
+    ),
   }),
 });

--- a/src/hooks/useBookmarks/index.js
+++ b/src/hooks/useBookmarks/index.js
@@ -39,9 +39,8 @@ export default function useBookmarks() {
   const { fetch } = session;
 
   useEffect(() => {
-    if (!session.info.isLoggedIn || !profile) return;
-    const { pods } = profile;
-    const pod = pods[0];
+    const pod = profile?.pods[0];
+    if (!session.info.isLoggedIn || !profile || !pod) return;
 
     const bookmarksIri = joinPath(pod, BOOKMARKS_PATH);
     (async () => {

--- a/src/hooks/usePodRootUri/index.js
+++ b/src/hooks/usePodRootUri/index.js
@@ -20,11 +20,6 @@
  */
 
 import { useEffect, useState } from "react";
-import { getPodOwner } from "@inrupt/solid-client";
-import {
-  getPodConnectedToProfile,
-  packageProfile,
-} from "../../solidClientHelpers/profile";
 import useAuthenticatedProfile from "../useAuthenticatedProfile";
 import useResourceInfo from "../useResourceInfo";
 import useDataset from "../useDataset";
@@ -39,7 +34,7 @@ export default function usePodRootUri(location) {
   const { data: resourceInfo } = useResourceInfo(location, {
     errorRetryCount: 0, // This usually returns a 403 when visiting someone else's Pod, so we don't want to retry that call
   });
-  const [podOwnerUri, setPodOwnerUri] = useState(null);
+  const [podOwnerUri] = useState(null);
   const { data: podOwnerDataset, error: podOwnerError } =
     useDataset(podOwnerUri);
 
@@ -52,19 +47,6 @@ export default function usePodRootUri(location) {
 
     if (profile.pods[0]) {
       setRootUri(normalizeBaseUri(profile.pods[0]));
-      return;
-    }
-    const podOwner = getPodOwner(resourceInfo);
-    setPodOwnerUri(podOwner);
-    if (!podOwner || podOwnerError) {
-      const { origin } = new URL(location);
-      setRootUri(normalizeBaseUri(origin));
-      return;
-    }
-    if (podOwner && podOwnerDataset) {
-      const podOwnerProfile = packageProfile(podOwner, podOwnerDataset);
-      const podOwnerPod = getPodConnectedToProfile(podOwnerProfile, location);
-      setRootUri(podOwnerPod);
     }
   }, [location, podOwnerDataset, podOwnerError, profile, resourceInfo]);
 

--- a/src/hooks/usePodRootUri/index.js
+++ b/src/hooks/usePodRootUri/index.js
@@ -27,7 +27,7 @@ export default function usePodRootUri(location) {
   const profile = useAuthenticatedProfile();
 
   useEffect(() => {
-    if (!location || location === "undefined") {
+    if (!location || location === "undefined" || !profile) {
       return;
     }
 

--- a/src/hooks/usePodRootUri/index.js
+++ b/src/hooks/usePodRootUri/index.js
@@ -21,34 +21,22 @@
 
 import { useEffect, useState } from "react";
 import useAuthenticatedProfile from "../useAuthenticatedProfile";
-import useResourceInfo from "../useResourceInfo";
-import useDataset from "../useDataset";
-
-function normalizeBaseUri(baseUri) {
-  return baseUri[baseUri.length - 1] === "/" ? baseUri : `${baseUri}/`;
-}
 
 export default function usePodRootUri(location) {
-  const [rootUri, setRootUri] = useState(null);
+  const [rootUri, setRootUri] = useState();
   const profile = useAuthenticatedProfile();
-  const { data: resourceInfo } = useResourceInfo(location, {
-    errorRetryCount: 0, // This usually returns a 403 when visiting someone else's Pod, so we don't want to retry that call
-  });
-  const [podOwnerUri] = useState(null);
-  const { data: podOwnerDataset, error: podOwnerError } =
-    useDataset(podOwnerUri);
 
   useEffect(() => {
-    if (!location || location === "undefined" || !profile) {
-      setRootUri(null);
+    if (!location || location === "undefined") {
       return;
     }
-    // defaulting to first pod until we have UI for multiple pods
 
-    if (profile.pods[0]) {
-      setRootUri(normalizeBaseUri(profile.pods[0]));
+    if (profile?.pods?.length) {
+      setRootUri(profile.pods[0]); // defaulting to first pod until we have UI for multiple pods
+    } else {
+      setRootUri(null);
     }
-  }, [location, podOwnerDataset, podOwnerError, profile, resourceInfo]);
+  }, [location, profile]);
 
   return rootUri;
 }

--- a/src/hooks/usePodRootUri/index.test.jsx
+++ b/src/hooks/usePodRootUri/index.test.jsx
@@ -65,28 +65,7 @@ describe("usePodRootUri", () => {
     expect(result.current).toBeNull();
   });
 
-  it("will use getOwnerPod if profile.pods is empty", () => {
-    const profileNoPods = {
-      webId: "webId",
-      pods: [],
-    };
-    mockedAuthenticatedProfileHook.mockReturnValue(profileNoPods);
-    const { result } = renderHook(() => usePodRootUri(location));
-    expect(result.current).toEqual(podRoot);
-  });
-
-  it("will use the domain of the location if getOwnerPod is unable to return info", () => {
-    const profileNoPods = {
-      webId: "webId",
-      pods: [],
-    };
-    mockedAuthenticatedProfileHook.mockReturnValue(profileNoPods);
-    solidClientFns.getPodOwner.mockReturnValue(null);
-    const { result } = renderHook(() => usePodRootUri(location));
-    expect(result.current).toEqual("https://foo.com/");
-  });
-
-  it("will fallback to the domain of the location if owner's profile fails to load", () => {
+  it("will return null owner's full profile fails to load", () => {
     const profileNoPods = {
       webId: "webId",
       pods: [],
@@ -94,7 +73,7 @@ describe("usePodRootUri", () => {
     mockedAuthenticatedProfileHook.mockReturnValue(profileNoPods);
     mockedDatasetHook.mockReturnValue({ error: new Error() });
     const { result } = renderHook(() => usePodRootUri(location));
-    expect(result.current).toEqual("https://foo.com/");
+    expect(result.current).toBeNull();
   });
 
   it("makes sure baseUri ends with slash", () => {

--- a/src/hooks/usePodRootUri/index.test.jsx
+++ b/src/hooks/usePodRootUri/index.test.jsx
@@ -60,9 +60,9 @@ describe("usePodRootUri", () => {
     });
   });
 
-  it("will return null if location is undefined", () => {
+  it("will return undefined if location is undefined", () => {
     const { result } = renderHook(() => usePodRootUri("undefined"));
-    expect(result.current).toBeNull();
+    expect(result.current).toBeUndefined();
   });
 
   it("will return null owner's full profile fails to load", () => {
@@ -74,18 +74,5 @@ describe("usePodRootUri", () => {
     mockedDatasetHook.mockReturnValue({ error: new Error() });
     const { result } = renderHook(() => usePodRootUri(location));
     expect(result.current).toBeNull();
-  });
-
-  it("makes sure baseUri ends with slash", () => {
-    const profilePodWithNoSlash = {
-      webId: "webId",
-      pods: [locationWithNoEndingSlash],
-    };
-    mockedAuthenticatedProfileHook.mockReturnValue(profilePodWithNoSlash);
-
-    const { result } = renderHook(() =>
-      usePodRootUri(locationWithNoEndingSlash)
-    );
-    expect(result.current).toEqual("https://bar.com/");
   });
 });

--- a/src/solidClientHelpers/profile.js
+++ b/src/solidClientHelpers/profile.js
@@ -79,7 +79,7 @@ export function getProfileFromThing(contactThing) {
 
 export function getPodConnectedToProfile(profile, location) {
   const pods = profile ? profile.pods || [] : [];
-  return pods.find((pod) => location.startsWith(pod));
+  return pods.find((pod) => location?.startsWith(pod));
 }
 
 export function locationIsConnectedToProfile(profile, location) {


### PR DESCRIPTION
## Description

Whenever PB cannot find a Pod URL in the profile, it completely hangs. Instead we want to display an error to users. If an extended profile cannot be fetched, we want the function retrieving the profile to ignore this and move on.

This PR introduces a fix to handle the case where a Pod URL cannot be found on a profile, and also fixes a bug where `getFullProfile` was not handling failing to fetch an extended profile dataset properly (ignoring the error and moving on).

I took some design liberties (error messages) so design review is required.

## Testing

Case 1: fail to fetch an extended profile

1. https://id.inrupt.com/ edit your WebID by changing the URLs to the extended profile (highlighted in screenshot below)
<img width="695" alt="image" src="https://user-images.githubusercontent.com/28412960/186151853-e1a5dd6d-8afc-4e11-8a76-cf0ed81dc798.png">
2. Go to the Vercel deployment of this branch (Preview) and verify everything works correctly (main files page, profile).

Case 2: no Pod URL found in profile

1. https://id.inrupt.com/ edit your WebID by deleting the storage triple (highlighted in screenshot below):
<img width="695" alt="image" src="https://user-images.githubusercontent.com/28412960/186152481-71d869dd-0923-4691-af91-e2f04c4b7928.png">

2. Go to the Vercel deployment of this branch (Preview) and verify everything works correctly (main files page, profile).

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
