### PR TITLE
download resource

### DIFF
--- a/components/container/index.jsx
+++ b/components/container/index.jsx
@@ -182,7 +182,7 @@ export default function Container({ iri }) {
       <span>
         Downloading resource.{" "}
         <p>
-          If you download down not start, click here:{" "}
+          If you download does not start, click here:{" "}
           <DownloadLink className={classes.downloadLink} iri={iri}>
             {iri}
           </DownloadLink>

--- a/components/downloadLink/index.jsx
+++ b/components/downloadLink/index.jsx
@@ -41,25 +41,25 @@ export function forceDownload(name, file) {
   document.body.removeChild(a);
 }
 
-export function downloadResource(iri, fetch) {
-  return () => {
-    const { pathname } = parseUrl(iri);
-    const name = pathname.replace(/\//g, "");
-
-    fetch(iri)
-      .then((response) => response.blob())
-      .then((file) => forceDownload(name, file))
-      .catch((e) => e);
-  };
+export async function downloadResource(iri, fetch) {
+  const { pathname } = parseUrl(iri);
+  const name = pathname.replace(/\//g, "");
+  await fetch(iri)
+    .then((response) => response.blob())
+    .then((file) => forceDownload(name, file))
+    .catch((e) => e);
 }
 
 export default function DownloadLink({ iri, ...props }) {
   const { fetch } = useSession();
-
   if (isContainerIri(iri)) return null;
 
   return (
-    <button {...props} onClick={downloadResource(iri, fetch)} type="button" />
+    <button
+      {...props}
+      onClick={() => downloadResource(iri, fetch)}
+      type="button"
+    />
   );
 }
 

--- a/components/downloadLink/index.test.jsx
+++ b/components/downloadLink/index.test.jsx
@@ -66,12 +66,11 @@ describe("forceDownload", () => {
 });
 
 describe("downloadResource", () => {
-  it("returns a handler to download the resource", () => {
+  it("downloads the resource", () => {
     const iri = "http://example.com/resource";
     const blobMock = jest.fn();
     const responseMock = { blob: blobMock };
     const fetchMock = jest.fn().mockResolvedValue(responseMock);
-    const handler = downloadResource(iri, fetchMock);
 
     blobMock.mockResolvedValue("file");
 
@@ -79,7 +78,7 @@ describe("downloadResource", () => {
       .spyOn(stringHelpers, "parseUrl")
       .mockReturnValue({ pathname: "/resource" });
 
-    handler();
+    downloadResource(iri, fetchMock);
 
     expect(fetchMock).toHaveBeenCalledWith(iri);
   });

--- a/components/downloadResourceMessage/__snapshots__/index.test.jsx.snap
+++ b/components/downloadResourceMessage/__snapshots__/index.test.jsx.snap
@@ -3,30 +3,21 @@
 exports[`DownloadResourceMessage renders 1`] = `
 <DocumentFragment>
   <div
+    class="PodBrowser-downloadLinkContainer"
     data-testid="download-resource-message"
   >
-    <div
-      class="PodBrowser-page-header"
-    >
-      <h1
-        class="PodBrowser-page-header__title"
+    <h1>
+      Downloading resource...
+    </h1>
+    <p>
+      If you download does not start, click here: 
+      <button
+        class="PodBrowser-downloadLink"
+        type="button"
       >
-        Downloading resource
-      </h1>
-    </div>
-    <div
-      class="PodBrowser-container"
-    >
-      <p>
-        If you download does not start, click here: 
-        <button
-          class="PodBrowser-downloadLink"
-          type="button"
-        >
-          https://example.pod.com/resource.txt
-        </button>
-      </p>
-    </div>
+        https://example.pod.com/resource.txt
+      </button>
+    </p>
   </div>
 </DocumentFragment>
 `;

--- a/components/downloadResourceMessage/__snapshots__/index.test.jsx.snap
+++ b/components/downloadResourceMessage/__snapshots__/index.test.jsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DownloadResourceMessage renders 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="download-resource-message"
+  >
+    <div
+      class="PodBrowser-page-header"
+    >
+      <h1
+        class="PodBrowser-page-header__title"
+      >
+        Downloading resource
+      </h1>
+    </div>
+    <div
+      class="PodBrowser-container"
+    >
+      <p>
+        If you download does not start, click here: 
+        <button
+          class="PodBrowser-downloadLink"
+          type="button"
+        >
+          https://example.pod.com/resource.txt
+        </button>
+      </p>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/components/downloadResourceMessage/index.jsx
+++ b/components/downloadResourceMessage/index.jsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import T from "prop-types";
+import { makeStyles } from "@material-ui/styles";
+import { createStyles } from "@material-ui/core";
+import { Container, PageHeader } from "@inrupt/prism-react-components";
+import styles from "../resourceDetails/styles";
+import DownloadLink from "../downloadLink";
+
+export const TESTCAFE_ID_DOWNLOAD_RESOURCE_MESSAGE =
+  "download-resource-message";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function DownloadResourceMessage({ iri }) {
+  const classes = useStyles();
+
+  return (
+    <div data-testid={TESTCAFE_ID_DOWNLOAD_RESOURCE_MESSAGE}>
+      <PageHeader title="Downloading resource" />
+      <Container>
+        <p>
+          If you download does not start, click here:{" "}
+          <DownloadLink className={classes.downloadLink} iri={iri}>
+            {iri}
+          </DownloadLink>
+        </p>
+      </Container>
+    </div>
+  );
+}
+
+DownloadResourceMessage.propTypes = {
+  iri: T.string.isRequired,
+};

--- a/components/downloadResourceMessage/index.test.jsx
+++ b/components/downloadResourceMessage/index.test.jsx
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import React from "react";
+import { renderWithTheme } from "../../__testUtils/withTheme";
+import DownloadResourceMessage from "./index";
+
+describe("DownloadResourceMessage", () => {
+  const iri = "https://example.pod.com/resource.txt";
+  it("renders", () => {
+    const { asFragment } = renderWithTheme(
+      <DownloadResourceMessage iri={iri} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/components/downloadResourceMessage/styles.js
+++ b/components/downloadResourceMessage/styles.js
@@ -19,38 +19,31 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React from "react";
-import T from "prop-types";
-import { makeStyles } from "@material-ui/styles";
-import { createStyles } from "@material-ui/core";
-import { Container, PageHeader } from "@inrupt/prism-react-components";
-import styles from "./styles";
-import DownloadLink from "../downloadLink";
+import { content } from "@solid/lit-prism-patterns";
 
-export const TESTCAFE_ID_DOWNLOAD_RESOURCE_MESSAGE =
-  "download-resource-message";
-
-const useStyles = makeStyles((theme) => createStyles(styles(theme)));
-
-export default function DownloadResourceMessage({ iri }) {
-  const classes = useStyles();
-
-  return (
-    <div
-      className={classes.downloadLinkContainer}
-      data-testid={TESTCAFE_ID_DOWNLOAD_RESOURCE_MESSAGE}
-    >
-      <h1>Downloading resource...</h1>
-      <p>
-        If you download does not start, click here:{" "}
-        <DownloadLink className={classes.downloadLink} iri={iri}>
-          {iri}
-        </DownloadLink>
-      </p>
-    </div>
-  );
-}
-
-DownloadResourceMessage.propTypes = {
-  iri: T.string.isRequired,
+const rules = {
+  downloadLinkContainer: {
+    display: "flex",
+    flexDirection: "column",
+    textAlign: "center",
+    justifyContent: "center",
+    padding: "20% 2rem 2rem 2rem",
+  },
+  downloadLink: {
+    background: "none",
+    border: "none",
+    color: "revert",
+    cursor: "pointer",
+    textDecoration: "underline",
+    fontFamily: "inherit",
+    fontSize: "inherit",
+    textAlign: "left",
+  },
 };
+
+export default function styles(theme) {
+  return {
+    ...rules,
+    ...content.styles(theme),
+  };
+}

--- a/components/resourceDetails/styles.js
+++ b/components/resourceDetails/styles.js
@@ -19,6 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { blue } from "@material-ui/core/colors";
 import { content } from "@solid/lit-prism-patterns";
 
 const rules = {
@@ -38,6 +39,16 @@ const rules = {
     "& button": {
       marginLeft: "auto",
     },
+  },
+  downloadLink: {
+    background: "none",
+    border: "none",
+    color: blue,
+    cursor: "pointer",
+    textDecoration: "underline",
+    fontFamily: "inherit",
+    fontSize: "inherit",
+    textAlign: "left",
   },
   raw: {
     height: "100%",

--- a/components/resourceDrawer/index.jsx
+++ b/components/resourceDrawer/index.jsx
@@ -98,10 +98,7 @@ export default function ResourceDrawer({ onUpdate, onDeleteCurrentContainer }) {
     );
   }
 
-  const loading =
-    !resourceInfo ||
-    (!accessControlData && !accessControlError) ||
-    isValidating;
+  const loading = !resourceInfo || isValidating;
 
   return (
     <Drawer open={menuOpen} close={closeDrawer}>

--- a/src/hooks/useAccessToResourceAndParentContainer/index.jsx
+++ b/src/hooks/useAccessToResourceAndParentContainer/index.jsx
@@ -31,7 +31,7 @@ export default function useAccessToResourceAndParentContainer(iri) {
   const [accessToResource, setAccessToResource] = useState(null);
 
   useEffect(() => {
-    if (sessionRequestInProgress || isContainerIri(iri)) return;
+    if (sessionRequestInProgress || isContainerIri(iri) || !iri) return;
     (async () => {
       const parentContainerUrl = getParentContainerUrl(iri);
       try {
@@ -53,6 +53,7 @@ export default function useAccessToResourceAndParentContainer(iri) {
         });
 
         const { user } = getEffectiveAccess(resourceInfo);
+
         setAccessToResource(user);
       } catch (e) {
         setAccessToResource(null);

--- a/src/hooks/useAccessToResourceAndParentContainer/index.jsx
+++ b/src/hooks/useAccessToResourceAndParentContainer/index.jsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { getEffectiveAccess, getResourceInfo } from "@inrupt/solid-client";
+import { useSession } from "@inrupt/solid-ui-react";
+import { useEffect, useState } from "react";
+import { isContainerIri } from "../../solidClientHelpers/utils";
+import { getParentContainerUrl } from "../../stringHelpers";
+
+export default function useAccessToResourceAndParentContainer(iri) {
+  const { sessionRequestInProgress, session } = useSession();
+  const [accessToParentContainer, setAccessToParentContainer] = useState(null);
+  const [accessToResource, setAccessToResource] = useState(null);
+
+  useEffect(() => {
+    if (sessionRequestInProgress || isContainerIri(iri)) return;
+    (async () => {
+      const parentContainerUrl = getParentContainerUrl(iri);
+      try {
+        const resourceInfoParentContainer = await getResourceInfo(
+          parentContainerUrl,
+          {
+            fetch: session.fetch,
+          }
+        );
+        const { user } = getEffectiveAccess(resourceInfoParentContainer);
+        setAccessToParentContainer(user);
+      } catch (e) {
+        setAccessToParentContainer(null);
+      }
+
+      try {
+        const resourceInfo = await getResourceInfo(iri, {
+          fetch: session.fetch,
+        });
+
+        const { user } = getEffectiveAccess(resourceInfo);
+        setAccessToResource(user);
+      } catch (e) {
+        setAccessToResource(null);
+      }
+    })();
+  }, [iri, session, sessionRequestInProgress]);
+
+  return { accessToParentContainer, accessToResource };
+}

--- a/src/hooks/useAccessToResourceAndParentContainer/index.test.jsx
+++ b/src/hooks/useAccessToResourceAndParentContainer/index.test.jsx
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { useSession } from "@inrupt/solid-ui-react";
+import { getEffectiveAccess, getResourceInfo } from "@inrupt/solid-client";
+import { renderHook } from "@testing-library/react-hooks";
+import { waitFor } from "@testing-library/dom";
+import mockSessionContextProvider from "../../../__testUtils/mockSessionContextProvider";
+import mockSession from "../../../__testUtils/mockSession";
+import useAccessToResourceAndParentContainer from ".";
+
+jest.mock("@inrupt/solid-ui-react", () => {
+  const uiReactModule = jest.requireActual("@inrupt/solid-ui-react");
+  return {
+    SessionContext: uiReactModule.SessionContext,
+    useSession: jest.fn(),
+  };
+});
+const mockedUseSession = useSession;
+
+jest.mock("@inrupt/solid-client");
+
+describe("useAccessToResourceAndParentContainer", () => {
+  const session = mockSession();
+  const SessionProvider = mockSessionContextProvider(session);
+
+  const readAccess = { read: true, write: false, append: false };
+
+  const noAccess = { read: false, write: false, append: false };
+
+  const wrapper = ({ children }) => (
+    <SessionProvider>{children}</SessionProvider>
+  );
+
+  beforeEach(() => {
+    mockedUseSession.mockReturnValue({ session });
+  });
+
+  it("returns null if given no iri", async () => {
+    const { result } = renderHook(
+      () => useAccessToResourceAndParentContainer(null),
+      {
+        wrapper,
+      }
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        accessToParentContainer: null,
+        accessToResource: null,
+      });
+    });
+  });
+
+  it("returns null if iri is a container iri", async () => {
+    const { result } = renderHook(
+      () =>
+        useAccessToResourceAndParentContainer(
+          "https://example.pod.com/container/"
+        ),
+      {
+        wrapper,
+      }
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        accessToParentContainer: null,
+        accessToResource: null,
+      });
+    });
+  });
+
+  it("returns correct access if user has access to resource and not to parent container", async () => {
+    getResourceInfo
+      .mockRejectedValueOnce("error")
+      .mockResolvedValueOnce("resourceInfo");
+    getEffectiveAccess.mockReturnValueOnce({ user: readAccess });
+    const { result } = renderHook(
+      () =>
+        useAccessToResourceAndParentContainer(
+          "https://example.pod.com/container/resource.txt"
+        ),
+      {
+        wrapper,
+      }
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        accessToParentContainer: null,
+        accessToResource: readAccess,
+      });
+    });
+  });
+
+  it("returns correct access if user has access to both resource and  parent container", async () => {
+    getResourceInfo.mockResolvedValue("resourceInfo");
+    getEffectiveAccess.mockReturnValue({ user: readAccess });
+    const { result } = renderHook(
+      () =>
+        useAccessToResourceAndParentContainer(
+          "https://example.pod.com/container/resource.txt"
+        ),
+      {
+        wrapper,
+      }
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        accessToParentContainer: readAccess,
+        accessToResource: readAccess,
+      });
+    });
+  });
+  it("returns correct access if user has no access to resource or parent container", async () => {
+    getResourceInfo.mockRejectedValue("error");
+    const { result } = renderHook(
+      () =>
+        useAccessToResourceAndParentContainer(
+          "https://example.pod.com/container/resource.txt"
+        ),
+      {
+        wrapper,
+      }
+    );
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        accessToParentContainer: null,
+        accessToResource: null,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

When navigating to a resource to which a user has access (by any means, including authenticated agent) but does not have access to parent container, PodBrowser tried to load the parent container and incorrectly rendered an error saying the user has no access to the resource.

This PR changes that by checking what the user's access is to both resource and parent container, and either triggering a download and isplaying a download message, or rendering an error if user truly does not have access to the resource.

## Testing

1. Log in as User A, share a resource with Anyone
2. Log in as User 2, try to navigate to the resource via the Pod Navigator
3. Verify that a download starts and a download message is displayed
4. Verify that the no access error is displayed by repeating the above steps with a private resource 

## Commit checklist

- [x] All acceptance criteria are met.
- [x] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

