### PR TITLE
Use the term folder consistently in UI messaging

### DIFF
--- a/components/containerTable/__snapshots__/index.test.jsx.snap
+++ b/components/containerTable/__snapshots__/index.test.jsx.snap
@@ -59,7 +59,7 @@ exports[`ContainerTable renders a table view without data 1`] = `
           class="PodBrowser-table__body-cell"
           rowspan="3"
         >
-          No resources were found within this container.
+          No resources were found within this folder.
         </td>
       </tr>
     </tbody>

--- a/components/containerTable/index.jsx
+++ b/components/containerTable/index.jsx
@@ -108,7 +108,7 @@ export default function ContainerTable({ containerPath, data, resourcePath }) {
         {!data || !data.length ? (
           <tr key="no-resources-found" className={bem("table__body-row")}>
             <td rowSpan={3} className={bem("table__body-cell")}>
-              No resources were found within this container.
+              No resources were found within this folder.
             </td>
           </tr>
         ) : null}


### PR DESCRIPTION
## Description
Just make 'folder' terminology consistent with the rest of the UI (i.e., 'FOLDER DETAILS', 'CREATE FOLDER' buttons, etc.).

## Changes
Message updated to use the term 'folder' instead of 'container'.

## Testing
All tests pass.

## Commit checklist

- [X] All acceptance criteria are met.
- [X] Includes tests to ensure functionality and prevent regressions.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.

## Interested parties

## Notes

## Screenshots/captures
