### PR TITLE
pass fetch fn to deny function

### DIFF
--- a/components/accessRequestForm/index.jsx
+++ b/components/accessRequestForm/index.jsx
@@ -179,7 +179,9 @@ export default function AccessRequestForm({
 
   useEffect(() => {
     const handleDenyAccessRequest = async () => {
-      const signedVc = await denyAccessRequest(accessRequest);
+      const signedVc = await denyAccessRequest(accessRequest, {
+        fetch: session.fetch,
+      });
       if (signedVc) {
         await router.push(
           `${redirectUrl}?${GRANT_VC_URL_PARAM_NAME}=${getVcId(signedVc)}`


### PR DESCRIPTION
## Description

This PR fixes the issue where `denyAccessRequest` was not being called with an options object, causing it to fail. PodBrowser is still at access grants `1.0.1`, so this fixes the issue at the current version and we can look into upgrading separately, as it introduces other challenges.

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

