### PR TITLE
Fix isAuthCallback check

### DIFF
--- a/src/authentication/AuthenticatedRoute.jsx
+++ b/src/authentication/AuthenticatedRoute.jsx
@@ -30,7 +30,7 @@ const isAuthCallback = (asPath) => {
     const route = new URL(asPath, window.location.href);
     const params = route.searchParams;
 
-    return params.has("error") || (params.has("code") && params.has("code"));
+    return params.has("error") || (params.has("code") && params.has("state"));
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
## Description

Somehow when I added this code I'd meant to check for both `code` and `state` but managed to write code twice. This fixes that, and resolved this bug: https://sonarcloud.io/project/issues?resolved=false&types=BUG&id=inrupt_pod-browser&open=AYWDEcUQGh3M8CzW1zF5

## Changes

Changes the second `"code"` to `"state"` as intended, I'd messed this code up when writing it, and it wasn't caught in review.

## Testing

Open up the development deployment from vercel and test logging in, if you can, then this works, if you can't then we have issues.

## Commit checklist

- [x] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions. (this wasn't originally tested / not spending time to test a workaround)
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

## Interested parties

@chelseapinka @solid-akb @VirginiaBalseiro 
