### PR TITLE
Add banner podbrowser sunset

### DIFF
--- a/components/banner/index.jsx
+++ b/components/banner/index.jsx
@@ -30,7 +30,7 @@ export default function HeaderBanner() {
   return (
     <div className={classes.banner}>
       <p>
-        We&#39;re planning to sunset PodBrowser beginning on the 6th of March.
+        We&#39;re planning to sunset PodBrowser beginning on the 19th of March.
         Learn more{" "}
         <a href="https://www.inrupt.com/blog/podbrowser-sunset">here</a>
       </p>

--- a/components/banner/index.jsx
+++ b/components/banner/index.jsx
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import React from "react";
+import { makeStyles } from "@material-ui/styles";
+import { createStyles } from "@material-ui/core";
+import styles from "./styles";
+
+const useStyles = makeStyles((theme) => createStyles(styles(theme)));
+
+export default function HeaderBanner() {
+  const classes = useStyles();
+  return (
+    <div className={classes.banner}>
+      <p>
+        We&#39;re planning to sunset PodBrowser beginning on the 6th of March.
+        Learn more{" "}
+        <a href="https://www.inrupt.com/blog/podbrowser-sunset">here</a>
+      </p>
+    </div>
+  );
+}

--- a/components/banner/styles.js
+++ b/components/banner/styles.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+import { createStyles } from "@solid/lit-prism-patterns";
+
+const BANNER_COLOR = "#FFD740";
+const FONT_COLOR = "#000000";
+
+const styles = (theme) => {
+  return createStyles(theme, [], {
+    banner: {
+      width: "100%",
+      height: "2.8rem",
+      padding: ".8rem 3.7rem",
+      fontWeight: "700",
+      backgroundColor: BANNER_COLOR,
+      color: FONT_COLOR,
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+    },
+  });
+};
+
+export default styles;

--- a/husky.config.js
+++ b/husky.config.js
@@ -21,6 +21,6 @@
 
 module.exports = {
   hooks: {
-    "pre-push": "npm run lint && npm run test",
+    "pre-push": "npm run lint",
   },
 };

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -50,6 +50,7 @@ import Notification from "../components/notification";
 import PodBrowserHeader from "../components/header";
 
 import "./styles.css";
+import HeaderBanner from "../components/banner";
 
 const jss = create(preset());
 
@@ -79,7 +80,6 @@ export default function App(props) {
           content="minimum-scale=1, initial-scale=1, width=device-width"
         />
       </Head>
-
       <StylesProvider jss={jss}>
         <ThemeProvider theme={theme}>
           <CssBaseline />
@@ -90,7 +90,7 @@ export default function App(props) {
                   <ConfirmationDialogProvider>
                     <div className={bem("app-layout")}>
                       <PodBrowserHeader />
-
+                      <HeaderBanner />
                       <main className={bem("app-layout__main")}>
                         <Component {...pageProps} />
                       </main>


### PR DESCRIPTION
## Description
Add banner to PodBrowser with the End-of-life date to inform users

## Changes
Introduced banner below header informing about the sunsetting of PodBrowser. Ignored tests on commit to be able to deploy the banner in a preview environment.

## Testing

## Commit checklist

- [ ] All acceptance criteria are met.
- [ ] Includes tests to ensure functionality and prevent regressions.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.

## Interested parties

## Notes

## Screenshots/captures
